### PR TITLE
Improve Program Calibration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -594,6 +594,7 @@ dependencies = [
  "proptest",
  "proptest-derive",
  "serde",
+ "thiserror",
 ]
 
 [[package]]
@@ -895,6 +896,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd829fe32373d27f76265620b5309d0340cb8550f523c1dda251d6298069069a"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
+dependencies = [
+ "proc-macro2 1.0.36",
+ "quote 1.0.15",
+ "syn 1.0.86",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ nom = "6.1.0"
 num-complex = "0.4.0"
 petgraph = "0.5.1"
 serde = { version = "1.0.125", features = ["derive"] }
+thiserror = "1.0.30"
 
 [dev-dependencies]
 insta = "1.7.1"

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -236,7 +236,7 @@ impl Expression {
                     std::mem::swap(self, &mut temp);
                 }
             }
-            Variable(_) | Address(_) | PiConstant | Number(_) => {},
+            Variable(_) | Address(_) | PiConstant | Number(_) => {}
         };
 
         if let Ok(number) = self.evaluate(&HashMap::new(), &HashMap::new()) {

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -342,15 +342,15 @@ impl Expression {
                 expression,
             } => FunctionCall {
                 function,
-                expression: expression.substitute_variables(&variable_values).into(),
+                expression: expression.substitute_variables(variable_values).into(),
             },
             Infix {
                 left,
                 operator,
                 right,
             } => {
-                let left = left.substitute_variables(&variable_values).into();
-                let right = right.substitute_variables(&variable_values).into();
+                let left = left.substitute_variables(variable_values).into();
+                let right = right.substitute_variables(variable_values).into();
                 Infix {
                     left,
                     operator,
@@ -362,7 +362,7 @@ impl Expression {
                 expression,
             } => Prefix {
                 operator,
-                expression: expression.substitute_variables(&variable_values).into(),
+                expression: expression.substitute_variables(variable_values).into(),
             },
             Variable(identifier) => match variable_values.get(identifier.as_str()) {
                 Some(value) => value.clone(),

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -244,6 +244,24 @@ impl Expression {
         }
     }
 
+    /// Consume the expression, simplifying it as much as possible.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use quil_rs::expression::Expression;
+    /// use std::str::FromStr;
+    /// use num_complex::Complex64;
+    ///
+    /// let simplified = Expression::from_str("cos(2 * pi) + 2").unwrap().into_simplified();
+    ///
+    /// assert_eq!(simplified, Expression::Number(Complex64::from(3.0)));
+    /// ```
+    pub fn into_simplified(mut self) -> Self {
+        self.simplify();
+        self
+    }
+
     /// Evaluate an expression, expecting that it may be fully reduced to a single complex number.
     /// If it cannot be reduced to a complex number, return an error.
     ///

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -466,7 +466,6 @@ impl From<&Instruction> for InstructionRole {
             | Instruction::Label(_)
             | Instruction::MeasureCalibrationDefinition(_)
             | Instruction::Measurement(_)
-            | Instruction::Pragma(_)
             | Instruction::WaveformDefinition(_) => InstructionRole::ProgramComposition,
             Instruction::Reset(_)
             | Instruction::Capture(_)
@@ -484,6 +483,7 @@ impl From<&Instruction> for InstructionRole {
             | Instruction::Move(_)
             | Instruction::Exchange(_)
             | Instruction::Load(_)
+            | Instruction::Pragma(_)
             | Instruction::Store(_) => InstructionRole::ClassicalCompute,
             Instruction::Halt
             | Instruction::Jump(_)

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -884,13 +884,7 @@ impl Instruction {
     ///
     /// let program = Program::from_str("SHIFT-PHASE 0 \"rf\" 2*2").unwrap();
     /// let mut instructions = program.to_instructions(true);
-    /// instructions.iter_mut().for_each(|inst| inst.apply_to_expressions(|expr| {
-    ///     // Here, `Expression::PiConstant` is used simply as a placeholder value
-    ///     // allowing the closure to take ownership of the subject expression.
-    ///     // Its value is ignored.
-    ///     let previous = replace(expr, Expression::PiConstant);
-    ///     *expr = previous.simplify();
-    /// }));
+    /// instructions.iter_mut().for_each(|inst| inst.apply_to_expressions(Expression::simplify));
     ///
     /// assert_eq!(instructions[0].to_string(), String::from("SHIFT-PHASE 0 \"rf\" 4"))
     ///

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -843,12 +843,14 @@ impl Instruction {
     /// use quil_rs::{expression::Expression, Program};
     ///
     ///
-    /// let program = Program::from_str("SHIFT-PHASE 0 \"rf\" 1*%theta").unwrap();
+    /// let program = Program::from_str("SHIFT-PHASE 0 \"rf\" 2*2").unwrap();
     /// let mut instructions = program.to_instructions(true);
     /// instructions.iter_mut().for_each(|inst| inst.apply_to_expressions(|expr| {
     ///     let previous = replace(expr, Expression::PiConstant);
     ///     *expr = previous.simplify();
     /// }));
+    ///
+    /// assert_eq!(instructions[0].to_string(), String::from("SHIFT-PHASE 0 \"rf\" 4"))
     ///
     /// ```
     pub fn apply_to_expressions(&mut self, mut closure: impl FnMut(&mut Expression)) {

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -742,11 +742,16 @@ impl fmt::Display for Instruction {
                 name,
                 arguments,
                 data,
-            }) => match data {
-                // FIXME: Handle empty argument lists
-                Some(data) => write!(f, "PRAGMA {} {} {}", name, arguments.join(" "), data),
-                None => write!(f, "PRAGMA {} {}", name, arguments.join(" ")),
-            },
+            }) => {
+                write!(f, "PRAGMA {}", name)?;
+                if !arguments.is_empty() {
+                    write!(f, " {}", arguments.join(" "))?;
+                }
+                if let Some(data) = data {
+                    write!(f, "{}", data)?;
+                }
+                Ok(())
+            }
             Instruction::RawCapture(RawCapture {
                 blocking,
                 frame,

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -828,3 +828,113 @@ pub struct Waveform {
     pub parameters: Vec<String>,
     pub sample_rate: f64,
 }
+
+impl Instruction {
+    /// Apply the provided closure to this instruction, mutating any `Expression`s within.
+    /// Does not affect instructions without `Expression`s within.
+    /// Does not traverse or mutate instructions nested within blocks (such as
+    /// within `DEFCAL`).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use std::mem::replace;
+    /// use std::str::FromStr;
+    /// use quil_rs::{expression::Expression, Program};
+    ///
+    ///
+    /// let program = Program::from_str("SHIFT-PHASE 0 \"rf\" 1*%theta").unwrap();
+    /// let mut instructions = program.to_instructions(true);
+    /// instructions.iter_mut().for_each(|inst| inst.apply_to_expressions(|expr| {
+    ///     let previous = replace(expr, Expression::PiConstant);
+    ///     *expr = previous.simplify();
+    /// }));
+    ///
+    /// ```
+    pub fn apply_to_expressions<F>(&mut self, mut closure: F)
+    where
+        F: FnMut(&mut Expression),
+    {
+        match self {
+            Instruction::CalibrationDefinition(Calibration { parameters, .. })
+            | Instruction::Gate(Gate { parameters, .. }) => {
+                parameters.iter_mut().for_each(closure);
+            }
+            Instruction::Capture(Capture { waveform, .. })
+            | Instruction::Pulse(Pulse { waveform, .. }) => {
+                waveform.parameters.values_mut().for_each(closure);
+            }
+            Instruction::Delay(Delay { duration, .. })
+            | Instruction::RawCapture(RawCapture { duration, .. }) => {
+                closure(duration);
+            }
+            Instruction::FrameDefinition(FrameDefinition { attributes, .. }) => {
+                for value in attributes.values_mut() {
+                    if let AttributeValue::Expression(expression) = value {
+                        closure(expression);
+                    }
+                }
+            }
+            Instruction::SetFrequency(SetFrequency {
+                frequency: expression,
+                ..
+            })
+            | Instruction::SetPhase(SetPhase {
+                phase: expression, ..
+            })
+            | Instruction::SetScale(SetScale {
+                scale: expression, ..
+            })
+            | Instruction::ShiftFrequency(ShiftFrequency {
+                frequency: expression,
+                ..
+            })
+            | Instruction::ShiftPhase(ShiftPhase {
+                phase: expression, ..
+            }) => {
+                closure(expression);
+            }
+            Instruction::WaveformDefinition(WaveformDefinition { definition, .. }) => {
+                definition.matrix.iter_mut().for_each(closure);
+            }
+            Instruction::GateDefinition(GateDefinition { matrix, .. }) => {
+                for row in matrix {
+                    for cell in row {
+                        closure(cell);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use crate::{expression::Expression, Program};
+
+    #[test]
+    fn apply_to_expressions() {
+        let mut program = Program::from_str(
+            "DECLARE ro BIT
+SET-PHASE 0 \"rf\" pi/2
+RX(2) 0",
+        )
+        .unwrap();
+        let closure = |expr: &mut Expression| *expr = Expression::Variable(String::from("a"));
+        for instruction in program.instructions.iter_mut() {
+            instruction.apply_to_expressions(closure);
+        }
+
+        let expected_program = Program::from_str(
+            "DECLARE ro BIT
+SET-PHASE 0 \"rf\" %a
+RX(%a) 0",
+        )
+        .unwrap();
+
+        assert_eq!(expected_program, program);
+    }
+}

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -885,6 +885,9 @@ impl Instruction {
     /// let program = Program::from_str("SHIFT-PHASE 0 \"rf\" 2*2").unwrap();
     /// let mut instructions = program.to_instructions(true);
     /// instructions.iter_mut().for_each(|inst| inst.apply_to_expressions(|expr| {
+    ///     // Here, `Expression::PiConstant` is used simply as a placeholder value
+    ///     // allowing the closure to take ownership of the subject expression.
+    ///     // Its value is ignored.
     ///     let previous = replace(expr, Expression::PiConstant);
     ///     *expr = previous.simplify();
     /// }));

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -851,10 +851,7 @@ impl Instruction {
     /// }));
     ///
     /// ```
-    pub fn apply_to_expressions<F>(&mut self, mut closure: F)
-    where
-        F: FnMut(&mut Expression),
-    {
+    pub fn apply_to_expressions(&mut self, mut closure: impl FnMut(&mut Expression)) {
         match self {
             Instruction::CalibrationDefinition(Calibration { parameters, .. })
             | Instruction::Gate(Gate { parameters, .. }) => {

--- a/src/parser/command.rs
+++ b/src/parser/command.rs
@@ -23,8 +23,9 @@ use nom::{
 use crate::instruction::{
     Arithmetic, ArithmeticOperand, ArithmeticOperator, Calibration, Capture, CircuitDefinition,
     Declaration, Delay, Exchange, Fence, FrameDefinition, Instruction, Jump, JumpUnless, JumpWhen,
-    Label, Load, Measurement, Move, Pragma, Pulse, RawCapture, Reset, SetFrequency, SetPhase,
-    SetScale, ShiftFrequency, ShiftPhase, Store, Waveform, WaveformDefinition,
+    Label, Load, MeasureCalibrationDefinition, Measurement, Move, Pragma, Pulse, RawCapture, Reset,
+    SetFrequency, SetPhase, SetScale, ShiftFrequency, ShiftPhase, Store, Waveform,
+    WaveformDefinition,
 };
 use crate::parser::common::parse_variable_qubit;
 use crate::parser::instruction::parse_block;

--- a/src/parser/command.rs
+++ b/src/parser/command.rs
@@ -23,9 +23,9 @@ use nom::{
 use crate::instruction::{
     Arithmetic, ArithmeticOperand, ArithmeticOperator, Calibration, Capture, CircuitDefinition,
     Declaration, Delay, Exchange, Fence, FrameDefinition, Instruction, Jump, JumpUnless, JumpWhen,
-    Label, Load, MeasureCalibrationDefinition, Measurement, Move, Pragma, Pulse, RawCapture, Reset,
-    SetFrequency, SetPhase, SetScale, ShiftFrequency, ShiftPhase, Store, Waveform,
-    WaveformDefinition, Qubit,
+    Label, Load, MeasureCalibrationDefinition, Measurement, Move, Pragma, Pulse, Qubit, RawCapture,
+    Reset, SetFrequency, SetPhase, SetScale, ShiftFrequency, ShiftPhase, Store, Waveform,
+    WaveformDefinition,
 };
 use crate::parser::common::parse_variable_qubit;
 use crate::parser::instruction::parse_block;
@@ -139,7 +139,7 @@ pub fn parse_defcal_gate<'a>(input: ParserInput<'a>) -> ParserResult<'a, Instruc
 /// Parse the contents of a `DEFCAL MEASURE` instruction, following the `MEASURE` token.
 pub fn parse_defcal_measure<'a>(input: ParserInput<'a>) -> ParserResult<'a, Instruction> {
     let (input, qubit_index) = opt(token!(Integer(v)))(input)?;
-    let qubit = qubit_index.map(|q| Qubit::Fixed(q));
+    let qubit = qubit_index.map(Qubit::Fixed);
     let (input, destination) = token!(Identifier(v))(input)?;
     let (input, _) = token!(Colon)(input)?;
     let (input, instructions) = instruction::parse_block(input)?;

--- a/src/parser/command.rs
+++ b/src/parser/command.rs
@@ -99,36 +99,41 @@ pub fn parse_capture(input: ParserInput, blocking: bool) -> ParserResult<Instruc
     ))
 }
 
-/// Parse the contents of a `DEFCAL` instruction.
+/// Parse the contents of a `DEFCAL` instruction (including `DEFCAL MEASURE`),
+/// following the `DEFCAL` token.
 pub fn parse_defcal<'a>(input: ParserInput<'a>) -> ParserResult<'a, Instruction> {
     use crate::parser::lexer::Command::Measure;
     let (input, defcal_measure) = opt(token!(Command(Measure)))(input)?;
     match defcal_measure {
         Some(_) => parse_defcal_measure(input),
-        None => {
-            let (input, modifiers) = many0(parse_gate_modifier)(input)?;
-            let (input, name) = token!(Identifier(v))(input)?;
-            let (input, parameters) = opt(delimited(
-                token!(LParenthesis),
-                separated_list0(token!(Comma), parse_expression),
-                token!(RParenthesis),
-            ))(input)?;
-            let parameters = parameters.unwrap_or_default();
-            let (input, qubits) = many0(parse_qubit)(input)?;
-            let (input, _) = token!(Colon)(input)?;
-            let (input, instructions) = instruction::parse_block(input)?;
-            Ok((
-                input,
-                Instruction::CalibrationDefinition(Calibration {
-                    instructions,
-                    modifiers,
-                    name,
-                    parameters,
-                    qubits,
-                }),
-            ))
-        }
+        None => parse_defcal_gate(input),
     }
+}
+
+/// Parse the contents of a `DEFCAL` instruction (but not `DEFCAL MEASURE`),
+/// following the `DEFCAL` token.
+pub fn parse_defcal_gate<'a>(input: ParserInput<'a>) -> ParserResult<'a, Instruction> {
+    let (input, modifiers) = many0(parse_gate_modifier)(input)?;
+    let (input, name) = token!(Identifier(v))(input)?;
+    let (input, parameters) = opt(delimited(
+        token!(LParenthesis),
+        separated_list0(token!(Comma), parse_expression),
+        token!(RParenthesis),
+    ))(input)?;
+    let parameters = parameters.unwrap_or_default();
+    let (input, qubits) = many0(parse_qubit)(input)?;
+    let (input, _) = token!(Colon)(input)?;
+    let (input, instructions) = instruction::parse_block(input)?;
+    Ok((
+        input,
+        Instruction::CalibrationDefinition(Calibration {
+            instructions,
+            modifiers,
+            name,
+            parameters,
+            qubits,
+        }),
+    ))
 }
 
 /// Parse the contents of a `DEFCAL MEASURE` instruction, following the `MEASURE` token.

--- a/src/parser/command.rs
+++ b/src/parser/command.rs
@@ -25,7 +25,7 @@ use crate::instruction::{
     Declaration, Delay, Exchange, Fence, FrameDefinition, Instruction, Jump, JumpUnless, JumpWhen,
     Label, Load, MeasureCalibrationDefinition, Measurement, Move, Pragma, Pulse, RawCapture, Reset,
     SetFrequency, SetPhase, SetScale, ShiftFrequency, ShiftPhase, Store, Waveform,
-    WaveformDefinition,
+    WaveformDefinition, Qubit,
 };
 use crate::parser::common::parse_variable_qubit;
 use crate::parser::instruction::parse_block;
@@ -138,7 +138,8 @@ pub fn parse_defcal_gate<'a>(input: ParserInput<'a>) -> ParserResult<'a, Instruc
 
 /// Parse the contents of a `DEFCAL MEASURE` instruction, following the `MEASURE` token.
 pub fn parse_defcal_measure<'a>(input: ParserInput<'a>) -> ParserResult<'a, Instruction> {
-    let (input, qubit) = opt(parse_qubit)(input)?;
+    let (input, qubit_index) = opt(token!(Integer(v)))(input)?;
+    let qubit = qubit_index.map(|q| Qubit::Fixed(q));
     let (input, destination) = token!(Identifier(v))(input)?;
     let (input, _) = token!(Colon)(input)?;
     let (input, instructions) = instruction::parse_block(input)?;

--- a/src/parser/command.rs
+++ b/src/parser/command.rs
@@ -100,25 +100,48 @@ pub fn parse_capture(input: ParserInput, blocking: bool) -> ParserResult<Instruc
 
 /// Parse the contents of a `DEFCAL` instruction.
 pub fn parse_defcal<'a>(input: ParserInput<'a>) -> ParserResult<'a, Instruction> {
-    let (input, modifiers) = many0(parse_gate_modifier)(input)?;
-    let (input, name) = token!(Identifier(v))(input)?;
-    let (input, parameters) = opt(delimited(
-        token!(LParenthesis),
-        separated_list0(token!(Comma), parse_expression),
-        token!(RParenthesis),
-    ))(input)?;
-    let parameters = parameters.unwrap_or_default();
-    let (input, qubits) = many0(parse_qubit)(input)?;
+    use crate::parser::lexer::Command::Measure;
+    let (input, defcal_measure) = opt(token!(Command(Measure)))(input)?;
+    match defcal_measure {
+        Some(_) => parse_defcal_measure(input),
+        None => {
+            let (input, modifiers) = many0(parse_gate_modifier)(input)?;
+            let (input, name) = token!(Identifier(v))(input)?;
+            let (input, parameters) = opt(delimited(
+                token!(LParenthesis),
+                separated_list0(token!(Comma), parse_expression),
+                token!(RParenthesis),
+            ))(input)?;
+            let parameters = parameters.unwrap_or_default();
+            let (input, qubits) = many0(parse_qubit)(input)?;
+            let (input, _) = token!(Colon)(input)?;
+            let (input, instructions) = instruction::parse_block(input)?;
+            Ok((
+                input,
+                Instruction::CalibrationDefinition(Calibration {
+                    instructions,
+                    modifiers,
+                    name,
+                    parameters,
+                    qubits,
+                }),
+            ))
+        }
+    }
+}
+
+/// Parse the contents of a `DEFCAL MEASURE` instruction, following the `MEASURE` token.
+pub fn parse_defcal_measure<'a>(input: ParserInput<'a>) -> ParserResult<'a, Instruction> {
+    let (input, qubit) = opt(parse_qubit)(input)?;
+    let (input, destination) = token!(Identifier(v))(input)?;
     let (input, _) = token!(Colon)(input)?;
     let (input, instructions) = instruction::parse_block(input)?;
     Ok((
         input,
-        Instruction::CalibrationDefinition(Calibration {
+        Instruction::MeasureCalibrationDefinition(MeasureCalibrationDefinition {
             instructions,
-            modifiers,
-            name,
-            parameters,
-            qubits,
+            parameter: destination,
+            qubit,
         }),
     ))
 }

--- a/src/program/calibration.rs
+++ b/src/program/calibration.rs
@@ -306,7 +306,8 @@ impl CalibrationSet {
     }
 
     /// Add another gate calibration to the set.
-    #[deprecated]
+    /// Deprecated in favor of [`push_calibration`]
+    #[deprecated = "use ScheduledProgram#push_calibration instead"]
     pub fn push(&mut self, calibration: Calibration) {
         self.push_calibration(calibration)
     }

--- a/src/program/calibration.rs
+++ b/src/program/calibration.rs
@@ -137,7 +137,7 @@ impl CalibrationSet {
                     if let Some(cal_qubit) = &cal.qubit {
                         if cal_qubit == qubit {
                             matching_calibration = Some(cal);
-                            break
+                            break;
                         }
                     } else if !found_matching_calibration_without_qubit {
                         matching_calibration = Some(cal);

--- a/src/program/calibration.rs
+++ b/src/program/calibration.rs
@@ -184,7 +184,7 @@ impl CalibrationSet {
 
         // Add this instruction to the breadcrumb trail before recursion
         let mut downstream_previous_calibrations = vec![instruction.clone()];
-        downstream_previous_calibrations.extend_from_slice(&previous_calibrations);
+        downstream_previous_calibrations.extend_from_slice(previous_calibrations);
 
         Ok(match expanded_once_instructions {
             Some(instructions) => {

--- a/src/program/calibration.rs
+++ b/src/program/calibration.rs
@@ -258,9 +258,16 @@ impl CalibrationSet {
                     .iter()
                     .enumerate()
                     .all(|(calibration_index, _)| {
-                        let calibration_parameters =
-                            calibration.parameters[calibration_index].clone().simplify();
-                        let gate_parameters = gate_parameters[calibration_index].clone().simplify();
+                        let calibration_parameters = {
+                            let mut expr = calibration.parameters[calibration_index].clone();
+                            expr.simplify();
+                            expr
+                        };
+                        let gate_parameters = {
+                            let mut expr = gate_parameters[calibration_index].clone();
+                            expr.simplify();
+                            expr
+                        };
                         match (calibration_parameters, gate_parameters) {
                             // If the calibration is variable, it matches any fixed qubit
                             (Expression::Variable(_), _) => true,

--- a/src/program/calibration.rs
+++ b/src/program/calibration.rs
@@ -17,13 +17,19 @@ use std::collections::HashMap;
 
 use crate::{
     expression::Expression,
-    instruction::{Calibration, Gate, GateModifier, Instruction, Qubit},
+    instruction::{
+        Calibration, Gate, GateModifier, Instruction, MeasureCalibrationDefinition, Measurement,
+        Qubit,
+    },
 };
+
+use super::error::{ProgramError, ProgramResult};
 
 /// A collection of Quil calibrations (`DEFCAL` instructions) with utility methods.
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct CalibrationSet {
     calibrations: Vec<Calibration>,
+    measure_calibrations: Vec<MeasureCalibrationDefinition>,
 }
 
 struct MatchedCalibration<'a> {
@@ -49,14 +55,21 @@ impl<'a> MatchedCalibration<'a> {
 
 impl CalibrationSet {
     pub fn new() -> Self {
-        CalibrationSet {
-            calibrations: vec![],
-        }
+        Self::default()
     }
 
     /// Given an instruction, return the instructions to which it is expanded if there is a match.
-    pub fn expand(&self, instruction: &Instruction) -> Option<Vec<Instruction>> {
-        match instruction {
+    /// Recursively calibrate instructions, returning an error if a calibration directly or indirectly
+    /// expands into itself.
+    pub fn expand(
+        &self,
+        instruction: &Instruction,
+        previous_calibrations: &[Instruction],
+    ) -> ProgramResult<Option<Vec<Instruction>>> {
+        if previous_calibrations.contains(instruction) {
+            return Err(ProgramError::RecursiveCalibration(instruction.clone()));
+        }
+        let expanded_once_instructions = match instruction {
             Instruction::Gate(Gate {
                 name,
                 modifiers,
@@ -75,6 +88,22 @@ impl CalibrationSet {
                             }
                         }
 
+                        // Variables used within the calibration's definition should be replaced with the actual expressions used by the gate.
+                        // That is, `DEFCAL RX(%theta): ...` should have `%theta` replaced by `pi` throughout if it's used to expand `RX(pi)`.
+                        let variable_expansions: HashMap<String, Expression> = calibration
+                            .parameters
+                            .iter()
+                            .zip(parameters.iter())
+                            .filter_map(|(calibration_expression, gate_expression)| {
+                                if let Expression::Variable(variable_name) = calibration_expression
+                                {
+                                    Some((variable_name.clone(), gate_expression.clone()))
+                                } else {
+                                    None
+                                }
+                            })
+                            .collect();
+
                         let mut instructions = calibration.instructions.clone();
 
                         for instruction in instructions.iter_mut() {
@@ -91,6 +120,11 @@ impl CalibrationSet {
                                     }
                                 }
                             }
+
+                            instruction.apply_to_expressions(|expr| {
+                                let previous = std::mem::replace(expr, Expression::PiConstant);
+                                *expr = previous.substitute_variables(&variable_expansions);
+                            })
                         }
 
                         Some(instructions)
@@ -98,8 +132,78 @@ impl CalibrationSet {
                     None => None,
                 }
             }
+            Instruction::Measurement(Measurement { qubit, target }) => {
+                let mut matching_calibrations_with_precedence: Vec<(
+                    u32,
+                    &MeasureCalibrationDefinition,
+                )> = self
+                    .measure_calibrations
+                    .iter()
+                    .filter_map(|cal| match &cal.qubit {
+                        Some(cal_qubit) if qubit == cal_qubit => Some((1, cal)),
+                        None => Some((0, cal)),
+                        _ => None,
+                    })
+                    .collect();
+
+                // The matching calibration is the last-specified one that matched the target qubit (if any),
+                // or otherwise the last-specified one that specified no qubit.
+                matching_calibrations_with_precedence.sort_by_key(|(precedence, _)| *precedence);
+                let matching_calibration = matching_calibrations_with_precedence.last();
+                match matching_calibration {
+                    Some((_, calibration)) => {
+                        let mut instructions = calibration.instructions.clone();
+                        for instruction in instructions.iter_mut() {
+                            match instruction {
+                                // This special-casing is an unfortunate hack to support the current use pattern
+                                // of measurement calibrations.
+                                Instruction::Pragma(pragma) => {
+                                    if pragma.name == "LOAD-MEMORY"
+                                        && pragma.data.as_ref() == Some(&calibration.parameter)
+                                    {
+                                        if let Some(target) = target {
+                                            pragma.data = Some(target.to_string())
+                                        }
+                                    }
+                                }
+                                Instruction::Capture(capture) => {
+                                    if let Some(target) = target {
+                                        capture.memory_reference = target.clone()
+                                    }
+                                }
+                                _ => {}
+                            }
+                        }
+                        Some(instructions)
+                    }
+                    None => None,
+                }
+            }
             _ => None,
-        }
+        };
+
+        // Add this instruction to the breadcrumb trail before recursion
+        let mut downstream_previous_calibrations = vec![instruction.clone()];
+        downstream_previous_calibrations.extend_from_slice(&previous_calibrations);
+
+        Ok(match expanded_once_instructions {
+            Some(instructions) => {
+                let mut recursively_expanded_instructions = vec![];
+
+                for instruction in instructions {
+                    let expanded_instructions =
+                        self.expand(&instruction, &downstream_previous_calibrations)?;
+                    match expanded_instructions {
+                        Some(instructions) => {
+                            recursively_expanded_instructions.extend(instructions)
+                        }
+                        None => recursively_expanded_instructions.push(instruction),
+                    };
+                }
+                Some(recursively_expanded_instructions)
+            }
+            None => None,
+        })
     }
 
     /// Return the final calibration which matches the gate per the QuilT specification:
@@ -201,9 +305,20 @@ impl CalibrationSet {
         self.calibrations.is_empty()
     }
 
-    /// Add another calibration to the set.
+    /// Add another gate calibration to the set.
+    #[deprecated]
     pub fn push(&mut self, calibration: Calibration) {
+        self.push_calibration(calibration)
+    }
+
+    /// Add another gate calibration (`DEFCAL`) to the set.
+    pub fn push_calibration(&mut self, calibration: Calibration) {
         self.calibrations.push(calibration)
+    }
+
+    /// Add another measurement calibration (`DEFCAL MEASURE`) to the set.
+    pub fn push_measurement_calibration(&mut self, calibration: MeasureCalibrationDefinition) {
+        self.measure_calibrations.push(calibration)
     }
 
     /// Return the Quil instructions which describe the contained calibrations.
@@ -256,12 +371,22 @@ mod tests {
                 ),
                 expected: "PULSE 0 \"xy\" gaussian(duration: 1, fwhm: 2, t0: 3)\n",
             },
+            TestCase {
+                input: concat!(
+                    "DEFCAL X 0:\n",
+                    "    Y 0\n",
+                    "DEFCAL Y 0:\n",
+                    "    PULSE 0 \"xy\" gaussian(duration: 1, fwhm: 2, t0: 3)\n",
+                    "X 0\n"
+                ),
+                expected: "PULSE 0 \"xy\" gaussian(duration: 1, fwhm: 2, t0: 3)\n",
+            },
         ];
 
         for case in &cases {
-            let mut program = Program::from_str(case.input).unwrap();
-            program.expand_calibrations();
-            assert_eq!(program.to_string(false).as_str(), case.expected);
+            let program = Program::from_str(case.input).unwrap();
+            let calibrated_program = program.expand_calibrations().unwrap();
+            assert_eq!(calibrated_program.to_string(false).as_str(), case.expected);
         }
     }
 

--- a/src/program/calibration.rs
+++ b/src/program/calibration.rs
@@ -258,16 +258,11 @@ impl CalibrationSet {
                     .iter()
                     .enumerate()
                     .all(|(calibration_index, _)| {
-                        let calibration_parameters = {
-                            let mut expr = calibration.parameters[calibration_index].clone();
-                            expr.simplify();
-                            expr
-                        };
-                        let gate_parameters = {
-                            let mut expr = gate_parameters[calibration_index].clone();
-                            expr.simplify();
-                            expr
-                        };
+                        let calibration_parameters = calibration.parameters[calibration_index]
+                            .clone()
+                            .into_simplified();
+                        let gate_parameters =
+                            gate_parameters[calibration_index].clone().into_simplified();
                         match (calibration_parameters, gate_parameters) {
                             // If the calibration is variable, it matches any fixed qubit
                             (Expression::Variable(_), _) => true,

--- a/src/program/error.rs
+++ b/src/program/error.rs
@@ -1,0 +1,14 @@
+use thiserror::Error;
+
+use crate::instruction::Instruction;
+
+#[derive(Debug, Error)]
+pub enum ProgramError {
+    #[error("invalid calibration `{0}`: {message}")]
+    InvalidCalibration { instruction: Instruction, message: String },
+
+    #[error("instruction {0} expands into itself")]
+    RecursiveCalibration(Instruction)
+}
+
+pub type ProgramResult<T> = Result<T, ProgramError>;

--- a/src/program/error.rs
+++ b/src/program/error.rs
@@ -5,10 +5,13 @@ use crate::instruction::Instruction;
 #[derive(Debug, Error)]
 pub enum ProgramError {
     #[error("invalid calibration `{0}`: {message}")]
-    InvalidCalibration { instruction: Instruction, message: String },
+    InvalidCalibration {
+        instruction: Instruction,
+        message: String,
+    },
 
     #[error("instruction {0} expands into itself")]
-    RecursiveCalibration(Instruction)
+    RecursiveCalibration(Instruction),
 }
 
 pub type ProgramResult<T> = Result<T, ProgramError>;

--- a/src/program/graph.rs
+++ b/src/program/graph.rs
@@ -537,17 +537,11 @@ impl ScheduledProgram {
                 | Instruction::MeasureCalibrationDefinition(MeasureCalibrationDefinition {
                     ..
                 })
-                | Instruction::WaveformDefinition(_) => Err(ScheduleError {
-                    instruction: instruction.clone(),
-                    variant: ScheduleErrorVariant::UnschedulableInstruction,
-                }),
-
+                | Instruction::WaveformDefinition(_) => Ok(()),
                 Instruction::Pragma(_) => {
-                    // TODO: Handle pragmas. Here, we just silently discard them, but certain
-                    // pragmas must be supported.
+                    working_instructions.push(instruction);
                     Ok(())
                 }
-                // _ => Err(()), // Unimplemented
                 Instruction::Label(Label(value)) => {
                     terminate_working_block!(
                         None as Option<BlockTerminator>,

--- a/src/program/mod.rs
+++ b/src/program/mod.rs
@@ -89,7 +89,7 @@ impl Program {
     }
 
     /// Expand any instructions in the program which have a matching calibration, leaving the others
-    /// unchanged. Recurses though each instruction whil ensuring there is no cycle in the expansion
+    /// unchanged. Recurses though each instruction while ensuring there is no cycle in the expansion
     /// graph (i.e. no calibration expands directly or indirectly into itself)
     pub fn expand_calibrations(&self) -> error::ProgramResult<Self> {
         let mut expanded_instructions: Vec<Instruction> = vec![];

--- a/src/program/mod.rs
+++ b/src/program/mod.rs
@@ -28,6 +28,7 @@ pub use self::frame::FrameSet;
 pub use self::memory::MemoryRegion;
 
 mod calibration;
+mod error;
 mod frame;
 pub mod graph;
 mod memory;

--- a/src/program/mod.rs
+++ b/src/program/mod.rs
@@ -50,7 +50,7 @@ pub struct Program {
 impl Program {
     pub fn new() -> Self {
         Program {
-            calibrations: CalibrationSet::new(),
+            calibrations: CalibrationSet::default(),
             frames: FrameSet::new(),
             memory_regions: HashMap::new(),
             waveforms: HashMap::new(),


### PR DESCRIPTION
Significant changes here which are necessary but not sufficient for downstream compilation.

Note that calibration expansion here, while improved from previous, is not at parity with either the spec or pyQuil. That could be finished here or left to a later PR.