### PR TITLE
Fix: DEFCAL MEASURE serialization

### DIFF
--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -806,7 +806,7 @@ impl fmt::Display for Instruction {
 
                 writeln!(
                     f,
-                    " %{}:\n\t{}",
+                    " {}:\n\t{}",
                     parameter,
                     format_instructions(instructions)
                 )

--- a/src/parser/instruction.rs
+++ b/src/parser/instruction.rs
@@ -153,6 +153,7 @@ pub fn parse_block_instruction<'a>(input: ParserInput<'a>) -> ParserResult<'a, I
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
+    use std::str::FromStr;
 
     use crate::expression::Expression;
     use crate::instruction::{
@@ -164,7 +165,7 @@ mod tests {
         WaveformDefinition, WaveformInvocation,
     };
     use crate::parser::lexer::lex;
-    use crate::{make_test, real};
+    use crate::{make_test, real, Program};
 
     use super::parse_instructions;
 
@@ -841,5 +842,22 @@ mod tests {
         ];
         assert_eq!(remainder.len(), 0);
         assert_eq!(parsed, expected);
+    }
+
+    /// Assert that an instruction can be parsed and then identically re-serialized to string.
+    #[test]
+    fn parse_and_serialize() {
+        let inputs = vec![
+            r#"DEFCAL MEASURE 0 dest:
+	DECLARE iq REAL[2]
+	CAPTURE 0 "out" flat(duration: 1.0, iqs: (2.0+3.0i)) iq[0]"#,
+        ];
+
+        for input in inputs {
+            let program = Program::from_str(input).unwrap();
+            let output = program.to_string(true);
+
+            assert_eq!(input.trim(), output.trim());
+        }
     }
 }

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -533,7 +533,7 @@ mod tests {
       DEFCAL RX(%theta) 0:
       \tPULSE 0 \"xy\" my_waveform()
       
-      DEFCAL MEASURE 0 %dest:
+      DEFCAL MEASURE 0 dest:
       \tDECLARE iq REAL[2]
       \tCAPTURE 0 \"out\" flat(duration: 1000000, iqs: (2+3i)) iq[0]
       

--- a/src/program/calibration.rs
+++ b/src/program/calibration.rs
@@ -321,6 +321,11 @@ impl CalibrationSet {
         self.calibrations
             .iter()
             .map(|c| Instruction::CalibrationDefinition(c.clone()))
+            .chain(
+                self.measure_calibrations
+                    .iter()
+                    .map(|c| Instruction::MeasureCalibrationDefinition(c.clone())),
+            )
             .collect()
     }
 }


### PR DESCRIPTION
closes #80 

Simple fix with a test case for regression. See issue for context.