### PR TITLE
Breaking: Hide nom error type from public API

### DIFF
--- a/src/program/mod.rs
+++ b/src/program/mod.rs
@@ -189,13 +189,13 @@ impl Program {
 }
 
 impl FromStr for Program {
-    type Err = nom::Err<String>;
+    type Err = String;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let lexed = lex(s).map_err(nom::Err::Error)?;
+        let lexed = lex(s)?;
         let (_, instructions) = parse_instructions(&lexed).map_err(|err| match err {
-            nom::Err::Incomplete(_) => nom::Err::Error("incomplete".to_owned()),
-            nom::Err::Error(error) => nom::Err::Error(format!("{:?}", error)),
-            nom::Err::Failure(failure) => nom::Err::Error(format!("{:?}", failure)),
+            nom::Err::Incomplete(_) => "incomplete".to_owned(),
+            nom::Err::Error(error) => format!("{:?}", error),
+            nom::Err::Failure(failure) => format!("{:?}", failure),
         })?;
         let mut program = Self::new();
 


### PR DESCRIPTION
In #77, we made a breaking change—but I messed up the commit messages so `semantic-version` didn't catch that, my apologies!—to upgrade the version of `nom` we're using. That change needed to be breaking because we expose a `nom::Err` type in `Program::from_str` in the public API.

This PR makes a small change to remove that type from the public API so that future updates involving `nom` are no longer breaking changes. Instead, the error type of `Program::from_str` is now `String`, which matches `Expression::from_str`.