### PR TITLE
Fix: do not get line/column info for tokens except on error

### DIFF
--- a/src/expression.rs
+++ b/src/expression.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use lexical::{format, to_string_with_options, WriteFloatOptions};
+use nom_locate::LocatedSpan;
 use num_complex::Complex64;
 use std::collections::{hash_map::DefaultHasher, HashMap};
 use std::f64::consts::PI;
@@ -415,7 +416,8 @@ impl FromStr for Expression {
     type Err = ProgramError<Self>;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let tokens = lex(s)?;
+        let input = LocatedSpan::new(s);
+        let tokens = lex(input)?;
         disallow_leftover(parse_expression(&tokens).map_err(ParseError::from_nom_internal_err))
     }
 }

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use nom_locate::LocatedSpan;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 use std::{collections::HashMap, fmt};
@@ -307,7 +308,8 @@ impl FromStr for MemoryReference {
     type Err = SyntaxError<Self>;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let tokens = lex(s)?;
+        let input = LocatedSpan::new(s);
+        let tokens = lex(input)?;
         disallow_leftover(
             parse_memory_reference(&tokens).map_err(ParseError::from_nom_internal_err),
         )
@@ -1208,6 +1210,7 @@ impl Instruction {
     pub(crate) fn parse(input: &str) -> Result<Self, String> {
         use crate::parser::instruction::parse_instruction;
 
+        let input = LocatedSpan::new(input);
         let lexed = lex(input).map_err(|err| err.to_string())?;
         let (_, instruction) =
             nom::combinator::all_consuming(parse_instruction)(&lexed).map_err(|e| e.to_string())?;

--- a/src/parser/common.rs
+++ b/src/parser/common.rs
@@ -330,11 +330,13 @@ pub(crate) fn skip_newlines_and_comments<'a>(
 mod describe_skip_newlines_and_comments {
     use crate::parser::lex;
 
+    use nom_locate::LocatedSpan;
+
     use super::skip_newlines_and_comments;
 
     #[test]
     fn it_skips_indented_comment() {
-        let program = "\t    # this is a comment X 0";
+        let program = LocatedSpan::new("\t    # this is a comment X 0");
         let tokens = lex(program).unwrap();
         let (token_slice, _) = skip_newlines_and_comments(&tokens).unwrap();
         let (_, expected) = tokens.split_at(3);
@@ -343,7 +345,7 @@ mod describe_skip_newlines_and_comments {
 
     #[test]
     fn it_skips_comments() {
-        let program = "# this is a comment \n# and another\nX 0";
+        let program = LocatedSpan::new("# this is a comment \n# and another\nX 0");
         let tokens = lex(program).unwrap();
         let (token_slice, _) = skip_newlines_and_comments(&tokens).unwrap();
         let (_, expected) = tokens.split_at(4);
@@ -352,7 +354,7 @@ mod describe_skip_newlines_and_comments {
 
     #[test]
     fn it_skips_new_lines() {
-        let program = "\nX 0";
+        let program = LocatedSpan::new("\nX 0");
         let tokens = lex(program).unwrap();
         let (token_slice, _) = skip_newlines_and_comments(&tokens).unwrap();
         let (_, expected) = tokens.split_at(1);
@@ -361,7 +363,7 @@ mod describe_skip_newlines_and_comments {
 
     #[test]
     fn it_skips_semicolons() {
-        let program = ";;;;;X 0";
+        let program = LocatedSpan::new(";;;;;X 0");
         let tokens = lex(program).unwrap();
         let (token_slice, _) = skip_newlines_and_comments(&tokens).unwrap();
         let (_, expected) = tokens.split_at(5);
@@ -378,11 +380,13 @@ mod tests {
         real,
     };
 
+    use nom_locate::LocatedSpan;
+
     use super::{parse_matrix, parse_waveform_invocation};
 
     #[test]
     fn waveform_invocation() {
-        let input = "wf(a: 1.0, b: %var, c: ro[0])";
+        let input = LocatedSpan::new("wf(a: 1.0, b: %var, c: ro[0])");
         let lexed = lex(input).unwrap();
         let (remainder, waveform) = parse_waveform_invocation(&lexed).unwrap();
         assert!(
@@ -410,7 +414,7 @@ mod tests {
 
     #[test]
     fn test_parse_matrix() {
-        let input = "\n\t1/sqrt(2), 1/sqrt(2)\n\t1/sqrt(2), -1/sqrt(2)";
+        let input = LocatedSpan::new("\n\t1/sqrt(2), 1/sqrt(2)\n\t1/sqrt(2), -1/sqrt(2)");
         let lexed = lex(input).unwrap();
         let (remainder, matrix) = parse_matrix(&lexed).unwrap();
         assert!(
@@ -423,7 +427,7 @@ mod tests {
 
     #[test]
     fn test_parse_permutation() {
-        let input = "\n\t0, 1, 2, 3, 4, 5, 7, 6";
+        let input = LocatedSpan::new("\n\t0, 1, 2, 3, 4, 5, 7, 6");
         let lexed = lex(input).unwrap();
         let (remainder, permutation) = parse_permutation(&lexed).unwrap();
         assert!(
@@ -433,7 +437,7 @@ mod tests {
         );
         assert_eq!(permutation, vec![0, 1, 2, 3, 4, 5, 7, 6]);
 
-        let input = "\n\t0, 1, 2, 3, 4, 5, 7, 6\n\t0, 1, 2, 3, 4, 5, 6, 7";
+        let input = LocatedSpan::new("\n\t0, 1, 2, 3, 4, 5, 7, 6\n\t0, 1, 2, 3, 4, 5, 6, 7");
         let lexed = lex(input).unwrap();
         let (remainder, permutation) = parse_permutation(&lexed).unwrap();
         assert!(!remainder.is_empty(), "multiline permutations are invalid");

--- a/src/parser/error/input.rs
+++ b/src/parser/error/input.rs
@@ -74,7 +74,7 @@ impl ErrorInput for ParserInput<'_> {
     }
 }
 
-impl ErrorInput for Vec<TokenWithLocation> {
+impl ErrorInput for Vec<TokenWithLocation<'_>> {
     fn line(&self) -> u32 {
         self.as_slice().line()
     }

--- a/src/parser/expression.rs
+++ b/src/parser/expression.rs
@@ -232,13 +232,16 @@ mod tests {
         imag, real,
     };
 
+    use nom_locate::LocatedSpan;
+
     use super::parse_expression;
 
     macro_rules! test {
         ($name: ident, $parser: ident, $input: expr, $expected: expr) => {
             #[test]
             fn $name() {
-                let tokens = lex($input).unwrap();
+                let input = LocatedSpan::new($input);
+                let tokens = lex(input).unwrap();
                 let (remainder, parsed) = $parser(&tokens).unwrap();
                 assert_eq!(remainder.len(), 0);
                 assert_eq!(parsed, $expected);
@@ -250,7 +253,8 @@ mod tests {
     // panic on the first mismatch
     fn compare(cases: Vec<(&str, Expression)>) {
         for case in cases {
-            let tokens = lex(case.0).unwrap();
+            let input = LocatedSpan::new(case.0);
+            let tokens = lex(input).unwrap();
             let (remainder, parsed) = parse_expression(&tokens).unwrap();
             assert_eq!(remainder.len(), 0);
             assert_eq!(case.1, parsed);
@@ -271,7 +275,8 @@ mod tests {
         ];
 
         for case in cases {
-            let tokens = lex(case).unwrap();
+            let input = LocatedSpan::new(case);
+            let tokens = lex(input).unwrap();
             let (remainder, parsed) = parse_expression(&tokens).unwrap();
             assert_eq!(remainder.len(), 0);
             assert_eq!(parsed.to_string(), case);

--- a/src/parser/instruction.rs
+++ b/src/parser/instruction.rs
@@ -158,6 +158,8 @@ mod tests {
     use std::collections::HashMap;
     use std::str::FromStr;
 
+    use nom_locate::LocatedSpan;
+
     use crate::expression::{Expression, InfixOperator, PrefixOperator};
     use crate::instruction::{
         Arithmetic, ArithmeticOperand, ArithmeticOperator, AttributeValue, BinaryLogic,
@@ -341,6 +343,7 @@ mod tests {
         ]
         .iter()
         .for_each(|input| {
+            let input = LocatedSpan::new(*input);
             let tokens = lex(input).unwrap();
             assert!(parse_instructions(&tokens).is_err(), "{}", input);
         })
@@ -403,6 +406,7 @@ mod tests {
     #[test]
     fn test_binary_logic_error() {
         ["AND ro", "XOR 1 1", "IOR 1"].iter().for_each(|input| {
+            let input = LocatedSpan::new(*input);
             let tokens = lex(input).unwrap();
             assert!(parse_instructions(&tokens).is_err(), "{}", input);
         })
@@ -449,6 +453,7 @@ mod tests {
         ["NEG 1", "NOT 1", "NEG 0", "NOT 0"]
             .iter()
             .for_each(|input| {
+                let input = LocatedSpan::new(*input);
                 let tokens = lex(input).unwrap();
                 assert!(parse_instructions(&tokens).is_err(), "{}", input);
             })
@@ -765,7 +770,8 @@ mod tests {
 
     #[test]
     fn parse_set_phase() {
-        let tokens = lex(r#"SET-PHASE 0 "rf" 1.0; SET-PHASE 0 1 "rf" theta"#).unwrap();
+        let input = LocatedSpan::new(r#"SET-PHASE 0 "rf" 1.0; SET-PHASE 0 1 "rf" theta"#);
+        let tokens = lex(input).unwrap();
         let (remainder, parsed) = parse_instructions(&tokens).unwrap();
         let expected = vec![
             Instruction::SetPhase(SetPhase {
@@ -792,7 +798,8 @@ mod tests {
 
     #[test]
     fn parse_set_scale() {
-        let tokens = lex(r#"SET-SCALE 0 "rf" 1.0; SET-SCALE 0 1 "rf" theta"#).unwrap();
+        let input = LocatedSpan::new(r#"SET-SCALE 0 "rf" 1.0; SET-SCALE 0 1 "rf" theta"#);
+        let tokens = lex(input).unwrap();
         let (remainder, parsed) = parse_instructions(&tokens).unwrap();
         let expected = vec![
             Instruction::SetScale(SetScale {
@@ -819,7 +826,8 @@ mod tests {
 
     #[test]
     fn parse_set_frequency() {
-        let tokens = lex(r#"SET-FREQUENCY 0 "rf" 1.0; SET-FREQUENCY 0 1 "rf" theta"#).unwrap();
+        let input = LocatedSpan::new(r#"SET-FREQUENCY 0 "rf" 1.0; SET-FREQUENCY 0 1 "rf" theta"#);
+        let tokens = lex(input).unwrap();
         let (remainder, parsed) = parse_instructions(&tokens).unwrap();
         let expected = vec![
             Instruction::SetFrequency(SetFrequency {
@@ -846,7 +854,9 @@ mod tests {
 
     #[test]
     fn parse_shift_frequency() {
-        let tokens = lex(r#"SHIFT-FREQUENCY 0 "rf" 1.0; SHIFT-FREQUENCY 0 1 "rf" theta"#).unwrap();
+        let input =
+            LocatedSpan::new(r#"SHIFT-FREQUENCY 0 "rf" 1.0; SHIFT-FREQUENCY 0 1 "rf" theta"#);
+        let tokens = lex(input).unwrap();
         let (remainder, parsed) = parse_instructions(&tokens).unwrap();
         let expected = vec![
             Instruction::ShiftFrequency(ShiftFrequency {
@@ -873,7 +883,8 @@ mod tests {
 
     #[test]
     fn parse_shift_phase() {
-        let tokens = lex(r#"SHIFT-PHASE 0 "rf" 1.0; SHIFT-PHASE 0 1 "rf" theta"#).unwrap();
+        let input = LocatedSpan::new(r#"SHIFT-PHASE 0 "rf" 1.0; SHIFT-PHASE 0 1 "rf" theta"#);
+        let tokens = lex(input).unwrap();
         let (remainder, parsed) = parse_instructions(&tokens).unwrap();
         let expected = vec![
             Instruction::ShiftPhase(ShiftPhase {

--- a/src/parser/macros.rs
+++ b/src/parser/macros.rs
@@ -103,7 +103,8 @@ macro_rules! make_test {
     ($name: ident, $parser: ident, $input: expr, $expected: expr) => {
         #[test]
         fn $name() {
-            let tokens = lex($input).unwrap();
+            let input = ::nom_locate::LocatedSpan::new($input);
+            let tokens = lex(input).unwrap();
             let (remainder, parsed) = $parser(&tokens).unwrap();
             assert_eq!(remainder.len(), 0, "tokens left over");
             assert_eq!(parsed, $expected);

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -34,7 +34,7 @@ pub use error::{ParseError, ParserErrorKind};
 pub use lexer::{LexError, LexErrorKind};
 pub use token::{Token, TokenWithLocation};
 
-type ParserInput<'a> = &'a [TokenWithLocation];
+type ParserInput<'a> = &'a [TokenWithLocation<'a>];
 type InternalParserResult<'a, R, E = InternalParseError<'a>> = IResult<ParserInput<'a>, R, E>;
 
 /// Pops the first token off of the `input` and returns it and the remaining input.

--- a/src/parser/token.rs
+++ b/src/parser/token.rs
@@ -4,19 +4,18 @@ use std::fmt::Formatter;
 
 /// Wrapper for [`Token`] that includes file location information.
 #[derive(Debug, Clone, PartialEq)]
-pub struct TokenWithLocation {
+pub struct TokenWithLocation<'a> {
     token: Token,
-    line: u32,
-    column: usize,
+    original_input: LexInput<'a>,
 }
 
-impl PartialEq<Token> for TokenWithLocation {
+impl PartialEq<Token> for TokenWithLocation<'_> {
     fn eq(&self, other: &Token) -> bool {
         &self.token == other
     }
 }
 
-impl TokenWithLocation {
+impl TokenWithLocation<'_> {
     /// Returns a reference to the contained token.
     pub fn as_token(&self) -> &Token {
         &self.token
@@ -29,16 +28,16 @@ impl TokenWithLocation {
 
     /// The line that this token appears on.
     pub fn line(&self) -> u32 {
-        self.line
+        self.original_input.location_line()
     }
 
     /// The column of the line this token appears on.
     pub fn column(&self) -> usize {
-        self.column
+        self.original_input.get_utf8_column()
     }
 }
 
-impl nom::InputLength for TokenWithLocation {
+impl nom::InputLength for TokenWithLocation<'_> {
     fn input_len(&self) -> usize {
         // All tokens take up exactly one place in the input token stream
         self.as_token().input_len()
@@ -56,14 +55,11 @@ where
     move |input| {
         // Using this syntax because map(parser, || ...)(input) has lifetime issues for parser.
         parser.parse(input).map(|(leftover, token)| {
-            let line = input.location_line();
-            let column = input.get_utf8_column();
             (
                 leftover,
                 TokenWithLocation {
                     token,
-                    line,
-                    column,
+                    original_input: input,
                 },
             )
         })

--- a/src/program/mod.rs
+++ b/src/program/mod.rs
@@ -15,6 +15,8 @@
 use std::collections::{BTreeMap, HashSet};
 use std::str::FromStr;
 
+use nom_locate::LocatedSpan;
+
 use crate::instruction::{
     Declaration, FrameDefinition, FrameIdentifier, Instruction, Qubit, Waveform, WaveformDefinition,
 };
@@ -195,7 +197,8 @@ impl Program {
 impl FromStr for Program {
     type Err = ProgramError<Self>;
     fn from_str(s: &str) -> Result<Self> {
-        let lexed = lex(s).map_err(ProgramError::from)?;
+        let input = LocatedSpan::new(s);
+        let lexed = lex(input).map_err(ProgramError::from)?;
         map_parsed(
             disallow_leftover(
                 parse_instructions(&lexed).map_err(ParseError::from_nom_internal_err),


### PR DESCRIPTION
This is another performance improvement. Ish.

When running benchmarks in `dev`/`debug` mode, this showed a 35% decrease in runtime (edit: 26% when I generated HTML reports) on the sample-calibrations file (parse in ~2.33s rather than ~3.6s). It also showed a ~15% improvement on most corpus files, but ~8% regression on three of them.

When running in normal `bench` mode (basically release), the story is a bit different. Before these changes, parsing the sample calibrations file happened in ~223ms on avg, and ~239ms after these changes (~7% regression). Corpus files also showed a single-digit-percent performance regression.

OTOH, the sample calibrations had 15% outliers in the initial run and 5.6% outliers after applying changes. I am not sure whether criterion includes the outliers in average calculations or not.