### PR TITLE
Program.into_simplified

### DIFF
--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -1233,6 +1233,18 @@ impl Instruction {
         }
     }
 
+    /// Return the waveform _directly_ invoked by the instruction, if any.
+    ///
+    /// Note: this does not expand calibrations or other instructions which may
+    /// indirectly cause a waveform to be invoked.
+    pub(crate) fn get_waveform_invocation(&self) -> Option<&WaveformInvocation> {
+        match self {
+            Instruction::Capture(Capture { waveform, .. }) => Some(waveform),
+            Instruction::Pulse(Pulse { waveform, .. }) => Some(waveform),
+            _ => None,
+        }
+    }
+
     #[cfg(test)]
     /// Parse a single instruction from an input string. Returns an error if the input fails to parse,
     /// or if there is input left over after parsing.

--- a/src/program/frame.rs
+++ b/src/program/frame.rs
@@ -87,6 +87,19 @@ impl FrameSet {
         self.frames.insert(identifier, attributes);
     }
 
+    /// Return a new [FrameSet] which describes only the given [FrameIdentifier]s.
+    pub fn intersection(&self, identifiers: &HashSet<&FrameIdentifier>) -> Self {
+        let mut new_frameset = Self::new();
+
+        for (identifier, definition) in &self.frames {
+            if identifiers.contains(&identifier) {
+                new_frameset.insert(identifier.clone(), definition.clone())
+            }
+        }
+
+        new_frameset
+    }
+
     /// Iterate through the contained frames.
     pub fn iter(&self) -> std::collections::hash_map::Iter<'_, FrameIdentifier, FrameAttributes> {
         self.frames.iter()

--- a/src/program/mod.rs
+++ b/src/program/mod.rs
@@ -519,6 +519,12 @@ DEFCAL MEASURE 0 addr:
 DEFCAL MEASURE 1 addr:
     CAPTURE 1 \"ro_rx\" custom addr
 
+DEFFRAME 0 \"ro_rx\":
+    ATTRIBUTE: \"value\"
+
+DEFFRAME 1 \"ro_rx\":
+    ATTRIBUTE: \"other\"
+
 DEFWAVEFORM custom:
     0.0, 1.0
 
@@ -531,6 +537,9 @@ MEASURE 0 ro
 
         let expected = "
 DECLARE ro BIT
+
+DEFFRAME 0 \"ro_rx\":
+    ATTRIBUTE: \"value\"
 
 DEFWAVEFORM custom:
     0.0, 1.0

--- a/src/program/mod.rs
+++ b/src/program/mod.rs
@@ -146,10 +146,8 @@ impl Program {
         instruction: &'a Instruction,
         include_blocked: bool,
     ) -> Option<HashSet<&'a FrameIdentifier>> {
-        let qubits_used_in_program = self.get_used_qubits();
-
         instruction
-            .get_frame_match_condition(include_blocked, qubits_used_in_program)
+            .get_frame_match_condition(include_blocked)
             .map(|condition| self.frames.get_matching_keys(condition))
     }
 

--- a/src/program/mod.rs
+++ b/src/program/mod.rs
@@ -172,7 +172,7 @@ impl Program {
             .collect::<HashSet<_>>()
     }
 
-    /// Simplify this program into a new [Program] which contains only instructions
+    /// Simplify this program into a new [`Program`] which contains only instructions
     /// and definitions which are executed; effectively, perform dead code removal.
     ///
     /// Removes:

--- a/src/program/mod.rs
+++ b/src/program/mod.rs
@@ -183,6 +183,9 @@ impl Program {
     /// When a valid program is simplified, it remains valid.
     pub fn into_simplified(&self) -> Result<Self> {
         let mut expanded_program = self.expand_calibrations()?;
+        // Remove calibrations such that the resulting program contains
+        // only instructions. Calibrations have already been expanded, so
+        // technically there is no need to keep them around anyway.
         expanded_program.calibrations = CalibrationSet::default();
 
         let mut frames_used: HashSet<&FrameIdentifier> = HashSet::new();

--- a/src/program/mod.rs
+++ b/src/program/mod.rs
@@ -190,7 +190,7 @@ impl Program {
 
         for instruction in &expanded_program.instructions {
             if let Some(frames) = expanded_program.get_frames_for_instruction(instruction, false) {
-                frames_used.extend(frames.into_iter())
+                frames_used.extend(frames)
             }
 
             if let Some(waveform) = instruction.get_waveform_invocation() {


### PR DESCRIPTION
Simple approach:

- Expand calibrations
- Remove calibrations
- Scan through instructions and keep only the frames and waveforms used by at least one instruction

Did not address memory references given that a full simplification of those would reduce shrinking them to the minimum size (removing unnecessary capacity), and there's some complexity there. On top of that, too many memory regions is not as common of a problem as is thousands of lines of unused calibrations.