### PR TITLE
Frame calculations for RESET

### DIFF
--- a/src/program/frame.rs
+++ b/src/program/frame.rs
@@ -12,7 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::{HashMap, HashSet};
+use std::{
+    borrow::Cow,
+    collections::{HashMap, HashSet},
+};
 
 use crate::instruction::{FrameAttributes, FrameDefinition, FrameIdentifier, Instruction, Qubit};
 
@@ -137,10 +140,10 @@ pub(crate) enum FrameMatchCondition<'a> {
     AnyOfNames(&'a [String]),
 
     /// Match all frames which contain any of these qubits
-    AnyOfQubits(&'a [Qubit]),
+    AnyOfQubits(Cow<'a, [Qubit]>),
 
     /// Match all frames which contain exactly these qubits
-    ExactQubits(&'a [Qubit]),
+    ExactQubits(Cow<'a, [Qubit]>),
 
     /// Return this specific frame, if present in the set
     Specific(&'a FrameIdentifier),

--- a/src/program/graph.rs
+++ b/src/program/graph.rs
@@ -200,6 +200,16 @@ pub struct InstructionBlock {
     pub terminator: BlockTerminator,
 }
 
+impl Default for InstructionBlock {
+    fn default() -> Self {
+        Self {
+            instructions: Default::default(),
+            graph: Default::default(),
+            terminator: BlockTerminator::Continue,
+        }
+    }
+}
+
 /// PreviousNodes is a structure which helps maintain ordering among instructions which operate on a given frame.
 /// It works similarly to a multiple-reader-single-writer queue, where an instruction which "uses" a frame is like
 /// a writer and an instruction which blocks that frame is like a reader. Multiple instructions may concurrently

--- a/src/program/mod.rs
+++ b/src/program/mod.rs
@@ -146,8 +146,10 @@ impl Program {
         instruction: &'a Instruction,
         include_blocked: bool,
     ) -> Option<HashSet<&'a FrameIdentifier>> {
+        let qubits_used_by_program = self.get_used_qubits();
+
         instruction
-            .get_frame_match_condition(include_blocked)
+            .get_frame_match_condition(include_blocked, qubits_used_by_program)
             .map(|condition| self.frames.get_matching_keys(condition))
     }
 


### PR DESCRIPTION
Simple approach to RESET frame calculation support as described in the issue.

Reviewers:

- Does this approach make sense?
- Are there cases in which "overly greedy" blocking of frames as computed here in `quil-rs` will cause issues in compilation or elsewhere downstream?

Closes #33 

Linked to #128 for use in tandem downstream.