### PR TITLE
fix: Waveforms w/o params need no parens

### DIFF
--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -289,16 +289,36 @@ impl fmt::Display for WaveformInvocation {
 
         key_value_pairs.sort_by(|(k1, _), (k2, _)| k1.cmp(k2));
 
-        write!(
-            f,
-            "{}({})",
-            self.name,
-            key_value_pairs
-                .iter()
-                .map(|(k, v)| format!("{}: {}", k, v))
-                .collect::<Vec<String>>()
-                .join(", ")
-        )
+        if key_value_pairs.is_empty() {
+            write!(f, "{}", self.name,)
+        } else {
+            write!(
+                f,
+                "{}({})",
+                self.name,
+                key_value_pairs
+                    .iter()
+                    .map(|(k, v)| format!("{}: {}", k, v))
+                    .collect::<Vec<String>>()
+                    .join(", ")
+            )
+        }
+    }
+}
+
+#[cfg(test)]
+mod waveform_invocation_tests {
+    use std::collections::HashMap;
+
+    use crate::instruction::WaveformInvocation;
+
+    #[test]
+    fn format_no_parameters() {
+        let wfi = WaveformInvocation {
+            name: "CZ".into(),
+            parameters: HashMap::new(),
+        };
+        assert_eq!(format!("{}", wfi), "CZ".to_string());
     }
 }
 

--- a/src/program/snapshots/quil_rs__program__graphviz_dot__tests__graph__pulse_after_capture.snap
+++ b/src/program/snapshots/quil_rs__program__graphviz_dot__tests__graph__pulse_after_capture.snap
@@ -13,11 +13,11 @@ digraph {
     "block_0_start" -> "block_0_1" [label="frame"];
     "block_0_start" -> "block_0_end" [label="frame
 ordering"];
-    "block_0_0" [shape=rectangle, label="[0] CAPTURE 0 \"ro_rx\" test() ro[0]"];
+    "block_0_0" [shape=rectangle, label="[0] CAPTURE 0 \"ro_rx\" test ro[0]"];
     "block_0_0" -> "block_0_1" [label="frame"];
     "block_0_0" -> "block_0_end" [label="await capture
 frame"];
-    "block_0_1" [shape=rectangle, label="[1] PULSE 0 \"rf\" test()"];
+    "block_0_1" [shape=rectangle, label="[1] PULSE 0 \"rf\" test"];
     "block_0_1" -> "block_0_end" [label="frame"];
     "block_0_end" [shape=circle, label="end"];
   }

--- a/src/program/snapshots/quil_rs__program__graphviz_dot__tests__graph__simple_capture.snap
+++ b/src/program/snapshots/quil_rs__program__graphviz_dot__tests__graph__simple_capture.snap
@@ -12,7 +12,7 @@ digraph {
     "block_0_start" -> "block_0_0" [label="frame"];
     "block_0_start" -> "block_0_end" [label="frame
 ordering"];
-    "block_0_0" [shape=rectangle, label="[0] CAPTURE 0 \"ro_rx\" test() ro[0]"];
+    "block_0_0" [shape=rectangle, label="[0] CAPTURE 0 \"ro_rx\" test ro[0]"];
     "block_0_0" -> "block_0_end" [label="await capture
 frame"];
     "block_0_end" [shape=circle, label="end"];


### PR DESCRIPTION
Closes #137 