### PR TITLE
Fix: correctly expand delays

### DIFF
--- a/src/parser/expression.rs
+++ b/src/parser/expression.rs
@@ -77,8 +77,8 @@ fn parse(input: ParserInput, precedence: Precedence) -> InternalParserResult<Exp
         Some((Token::Float(value), remainder)) => {
             let (remainder, imaginary) = opt(parse_i)(remainder)?;
             match imaginary {
-                None => Ok((remainder, Expression::Number(crate::real!(*value as f64)))),
-                Some(_) => Ok((remainder, Expression::Number(crate::imag!(*value as f64)))),
+                None => Ok((remainder, Expression::Number(crate::real!(*value)))),
+                Some(_) => Ok((remainder, Expression::Number(crate::imag!(*value)))),
             }
         }
         Some((Token::Variable(name), remainder)) => {

--- a/src/parser/lexer/mod.rs
+++ b/src/parser/lexer/mod.rs
@@ -300,7 +300,7 @@ fn lex_number(input: LexInput) -> InternalLexResult {
         input,
         match integer_parse_result {
             Ok(_) => Token::Integer(float_string.parse::<u64>().unwrap()),
-            Err(_) => Token::Float(double(float_string)?.1 as f64),
+            Err(_) => Token::Float(double(float_string)?.1),
         },
     ))
 }

--- a/src/program/calibration.rs
+++ b/src/program/calibration.rs
@@ -102,31 +102,23 @@ impl CalibrationSet {
                         let mut instructions = calibration.instructions.clone();
 
                         for instruction in instructions.iter_mut() {
-                            if let Instruction::Gate(Gate { qubits, .. }) = instruction {
-                                // Swap all qubits for their concrete implementations
-                                for qubit in qubits {
-                                    match qubit {
-                                        Qubit::Variable(name) => {
-                                            if let Some(expansion) = qubit_expansions.get(name) {
-                                                *qubit = expansion.clone();
+                            match instruction {
+                                Instruction::Gate(Gate { qubits, .. })
+                                | Instruction::Delay(Delay { qubits, .. }) => {
+                                    // Swap all qubits for their concrete implementations
+                                    for qubit in qubits {
+                                        match qubit {
+                                            Qubit::Variable(name) => {
+                                                if let Some(expansion) = qubit_expansions.get(name)
+                                                {
+                                                    *qubit = expansion.clone();
+                                                }
                                             }
+                                            Qubit::Fixed(_) => {}
                                         }
-                                        Qubit::Fixed(_) => {}
                                     }
                                 }
-                            }
-                            if let Instruction::Delay(Delay { qubits, .. }) = instruction {
-                                // Swap all qubits for their concrete implementations
-                                for qubit in qubits {
-                                    match qubit {
-                                        Qubit::Variable(name) => {
-                                            if let Some(expansion) = qubit_expansions.get(name) {
-                                                *qubit = expansion.clone();
-                                            }
-                                        }
-                                        Qubit::Fixed(_) => {}
-                                    }
-                                }
+                                _ => {}
                             }
 
                             instruction.apply_to_expressions(|expr| {


### PR DESCRIPTION
Closes #141 

This adds one test case, which currently fails:

```
failures:

---- program::calibration::tests::expansion stdout ----
thread 'program::calibration::tests::expansion' panicked at 'assertion failed: `(left == right)`
  left: `"DELAY q 4e-8\n"`,
 right: `"DELAY 0 4e-8\n"`', src/program/calibration.rs:407:13
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

and subsequently modifies `CalibrationSet.expand` to handle `DELAY` instructions similarly to `GATE` instructions.