### PR TITLE
fix: FENCE blocks qubits, not frames

### DIFF
--- a/src/program/graphviz_dot.rs
+++ b/src/program/graphviz_dot.rs
@@ -306,8 +306,6 @@ NONBLOCKING PULSE 2 \"rf\" test(duration: 1e6)
 PULSE 0 \"rf\" test(duration: 1e6)
 NONBLOCKING PULSE 0 \"ro_tx\" test(duration: 1e6)
 PULSE 0 \"rf\" test(duration: 1e6)
-FENCE 0
-FENCE 0
 "
         );
 
@@ -350,6 +348,18 @@ NONBLOCKING PULSE 0 1 \"cz\" test(duration: 1e-6)
 NONBLOCKING PULSE 1 \"rf\" test(duration: 1e-6)
 FENCE 1
 "
+        );
+
+        build_dot_format_snapshot_test_case!(
+            non_overlapping_fence,
+            r#"
+FENCE 0
+NONBLOCKING PULSE 0 "rf" drag_gaussian(alpha: (-0.95146893464447))
+FENCE 0
+FENCE 1
+NONBLOCKING PULSE 1 "rf" drag_gaussian(alpha: (-1.3853631708424974))
+FENCE 1
+"#
         );
 
         build_dot_format_snapshot_test_case!(

--- a/src/program/snapshots/quil_rs__program__graphviz_dot__tests__graph__active_reset_single_frame.snap
+++ b/src/program/snapshots/quil_rs__program__graphviz_dot__tests__graph__active_reset_single_frame.snap
@@ -13,10 +13,12 @@ digraph {
     "measure_start" -> "measure_1" [label="frame"];
     "measure_start" -> "measure_end" [label="ordering"];
     "measure_0" [shape=rectangle, label="[0] NONBLOCKING PULSE 0 \"ro_tx\" test(duration: 1000000)"];
-    "measure_0" -> "measure_end" [label="frame"];
+    "measure_0" -> "measure_end" [label="frame
+ordering"];
     "measure_1" [shape=rectangle, label="[1] NONBLOCKING CAPTURE 0 \"ro_rx\" test(duration: 1000000) ro[0]"];
     "measure_1" -> "measure_end" [label="await capture
-frame"];
+frame
+ordering"];
     "measure_end" [shape=circle, label="end"];
   }
   "measure_end" -> "end_start" [label="if ro[0] == 0"];
@@ -29,7 +31,8 @@ frame"];
     "feedback_start" -> "feedback_end" [label="frame
 ordering"];
     "feedback_0" [shape=rectangle, label="[0] PULSE 0 \"rf\" test(duration: 1000000)"];
-    "feedback_0" -> "feedback_end" [label="frame"];
+    "feedback_0" -> "feedback_end" [label="frame
+ordering"];
     "feedback_end" [shape=circle, label="end"];
   }
   "feedback_end" -> "measure_start" [label="always"];

--- a/src/program/snapshots/quil_rs__program__graphviz_dot__tests__graph__blocking_2q_pulse.snap
+++ b/src/program/snapshots/quil_rs__program__graphviz_dot__tests__graph__blocking_2q_pulse.snap
@@ -16,12 +16,15 @@ digraph {
 ordering"];
     "block_0_0" [shape=rectangle, label="[0] PULSE 0 \"rf\" test(duration: 1e-6)"];
     "block_0_0" -> "block_0_2" [label="frame"];
-    "block_0_0" -> "block_0_end" [label="frame"];
+    "block_0_0" -> "block_0_end" [label="frame
+ordering"];
     "block_0_1" [shape=rectangle, label="[1] PULSE 1 \"rf\" test(duration: 1e-6)"];
     "block_0_1" -> "block_0_2" [label="frame"];
-    "block_0_1" -> "block_0_end" [label="frame"];
+    "block_0_1" -> "block_0_end" [label="frame
+ordering"];
     "block_0_2" [shape=rectangle, label="[2] PULSE 0 1 \"cz\" test(duration: 1e-6)"];
-    "block_0_2" -> "block_0_end" [label="frame"];
+    "block_0_2" -> "block_0_end" [label="frame
+ordering"];
     "block_0_end" [shape=circle, label="end"];
   }
 }

--- a/src/program/snapshots/quil_rs__program__graphviz_dot__tests__graph__blocking_pulses_after_nonblocking.snap
+++ b/src/program/snapshots/quil_rs__program__graphviz_dot__tests__graph__blocking_pulses_after_nonblocking.snap
@@ -17,12 +17,15 @@ ordering"];
     "block_0_0" [shape=rectangle, label="[0] NONBLOCKING PULSE 0 \"ro_tx\" test(duration: 1000000)"];
     "block_0_0" -> "block_0_1" [label="frame"];
     "block_0_0" -> "block_0_2" [label="frame"];
-    "block_0_0" -> "block_0_end" [label="frame"];
+    "block_0_0" -> "block_0_end" [label="frame
+ordering"];
     "block_0_1" [shape=rectangle, label="[1] PULSE 0 \"rf\" test(duration: 1000000)"];
     "block_0_1" -> "block_0_2" [label="frame"];
-    "block_0_1" -> "block_0_end" [label="frame"];
+    "block_0_1" -> "block_0_end" [label="frame
+ordering"];
     "block_0_2" [shape=rectangle, label="[2] PULSE 0 \"ro_rx\" test(duration: 1000000)"];
-    "block_0_2" -> "block_0_end" [label="frame"];
+    "block_0_2" -> "block_0_end" [label="frame
+ordering"];
     "block_0_end" [shape=circle, label="end"];
   }
 }

--- a/src/program/snapshots/quil_rs__program__graphviz_dot__tests__graph__blocking_pulses_wrap_nonblocking.snap
+++ b/src/program/snapshots/quil_rs__program__graphviz_dot__tests__graph__blocking_pulses_wrap_nonblocking.snap
@@ -11,21 +11,20 @@ digraph {
     "block_0_start" [shape=circle, label="start"];
     "block_0_start" -> "block_0_0" [label="frame"];
     "block_0_start" -> "block_0_1" [label="frame"];
-    "block_0_start" -> "block_0_3" [label="frame"];
-    "block_0_start" -> "block_0_end" [label="ordering"];
+    "block_0_start" -> "block_0_end" [label="frame
+ordering"];
     "block_0_0" [shape=rectangle, label="[0] PULSE 0 \"rf\" test(duration: 1000000)"];
     "block_0_0" -> "block_0_1" [label="frame"];
     "block_0_0" -> "block_0_2" [label="frame"];
-    "block_0_0" -> "block_0_3" [label="frame"];
+    "block_0_0" -> "block_0_end" [label="frame
+ordering"];
     "block_0_1" [shape=rectangle, label="[1] NONBLOCKING PULSE 0 \"ro_tx\" test(duration: 1000000)"];
     "block_0_1" -> "block_0_2" [label="frame"];
-    "block_0_1" -> "block_0_3" [label="frame"];
+    "block_0_1" -> "block_0_end" [label="frame
+ordering"];
     "block_0_2" [shape=rectangle, label="[2] PULSE 0 \"rf\" test(duration: 1000000)"];
-    "block_0_2" -> "block_0_3" [label="frame"];
-    "block_0_3" [shape=rectangle, label="[3] FENCE 0"];
-    "block_0_3" -> "block_0_4" [label="frame"];
-    "block_0_4" [shape=rectangle, label="[4] FENCE 0"];
-    "block_0_4" -> "block_0_end" [label="frame"];
+    "block_0_2" -> "block_0_end" [label="frame
+ordering"];
     "block_0_end" [shape=circle, label="end"];
   }
 }

--- a/src/program/snapshots/quil_rs__program__graphviz_dot__tests__graph__chained_pulses.snap
+++ b/src/program/snapshots/quil_rs__program__graphviz_dot__tests__graph__chained_pulses.snap
@@ -14,18 +14,23 @@ digraph {
 ordering"];
     "block_0_0" [shape=rectangle, label="[0] PULSE 0 \"rf\" test(duration: 1000000)"];
     "block_0_0" -> "block_0_1" [label="frame"];
-    "block_0_0" -> "block_0_end" [label="frame"];
+    "block_0_0" -> "block_0_end" [label="frame
+ordering"];
     "block_0_1" [shape=rectangle, label="[1] PULSE 0 \"rf\" test(duration: 1000000)"];
     "block_0_1" -> "block_0_2" [label="frame"];
-    "block_0_1" -> "block_0_end" [label="frame"];
+    "block_0_1" -> "block_0_end" [label="frame
+ordering"];
     "block_0_2" [shape=rectangle, label="[2] PULSE 0 \"rf\" test(duration: 1000000)"];
     "block_0_2" -> "block_0_3" [label="frame"];
-    "block_0_2" -> "block_0_end" [label="frame"];
+    "block_0_2" -> "block_0_end" [label="frame
+ordering"];
     "block_0_3" [shape=rectangle, label="[3] PULSE 0 \"rf\" test(duration: 1000000)"];
     "block_0_3" -> "block_0_4" [label="frame"];
-    "block_0_3" -> "block_0_end" [label="frame"];
+    "block_0_3" -> "block_0_end" [label="frame
+ordering"];
     "block_0_4" [shape=rectangle, label="[4] PULSE 0 \"rf\" test(duration: 1000000)"];
-    "block_0_4" -> "block_0_end" [label="frame"];
+    "block_0_4" -> "block_0_end" [label="frame
+ordering"];
     "block_0_end" [shape=circle, label="end"];
   }
 }

--- a/src/program/snapshots/quil_rs__program__graphviz_dot__tests__graph__different_frames_blocking.snap
+++ b/src/program/snapshots/quil_rs__program__graphviz_dot__tests__graph__different_frames_blocking.snap
@@ -15,11 +15,14 @@ digraph {
     "block_0_start" -> "block_0_end" [label="frame
 ordering"];
     "block_0_0" [shape=rectangle, label="[0] PULSE 0 \"rf\" test(duration: 1000000)"];
-    "block_0_0" -> "block_0_end" [label="frame"];
+    "block_0_0" -> "block_0_end" [label="frame
+ordering"];
     "block_0_1" [shape=rectangle, label="[1] PULSE 1 \"rf\" test(duration: 1000000)"];
-    "block_0_1" -> "block_0_end" [label="frame"];
+    "block_0_1" -> "block_0_end" [label="frame
+ordering"];
     "block_0_2" [shape=rectangle, label="[2] PULSE 2 \"rf\" test(duration: 1000000)"];
-    "block_0_2" -> "block_0_end" [label="frame"];
+    "block_0_2" -> "block_0_end" [label="frame
+ordering"];
     "block_0_end" [shape=circle, label="end"];
   }
 }

--- a/src/program/snapshots/quil_rs__program__graphviz_dot__tests__graph__different_frames_nonblocking.snap
+++ b/src/program/snapshots/quil_rs__program__graphviz_dot__tests__graph__different_frames_nonblocking.snap
@@ -14,11 +14,14 @@ digraph {
     "block_0_start" -> "block_0_2" [label="frame"];
     "block_0_start" -> "block_0_end" [label="ordering"];
     "block_0_0" [shape=rectangle, label="[0] NONBLOCKING PULSE 0 \"rf\" test(duration: 1000000)"];
-    "block_0_0" -> "block_0_end" [label="frame"];
+    "block_0_0" -> "block_0_end" [label="frame
+ordering"];
     "block_0_1" [shape=rectangle, label="[1] NONBLOCKING PULSE 1 \"rf\" test(duration: 1000000)"];
-    "block_0_1" -> "block_0_end" [label="frame"];
+    "block_0_1" -> "block_0_end" [label="frame
+ordering"];
     "block_0_2" [shape=rectangle, label="[2] NONBLOCKING PULSE 2 \"rf\" test(duration: 1000000)"];
-    "block_0_2" -> "block_0_end" [label="frame"];
+    "block_0_2" -> "block_0_end" [label="frame
+ordering"];
     "block_0_end" [shape=circle, label="end"];
   }
 }

--- a/src/program/snapshots/quil_rs__program__graphviz_dot__tests__graph__fence_all.snap
+++ b/src/program/snapshots/quil_rs__program__graphviz_dot__tests__graph__fence_all.snap
@@ -9,10 +9,8 @@ digraph {
     label="block_0";
     node [style="filled"];
     "block_0_start" [shape=circle, label="start"];
-    "block_0_start" -> "block_0_0" [label="frame"];
     "block_0_start" -> "block_0_end" [label="ordering"];
     "block_0_0" [shape=rectangle, label="[0] FENCE"];
-    "block_0_0" -> "block_0_end" [label="frame"];
     "block_0_end" [shape=circle, label="end"];
   }
 }

--- a/src/program/snapshots/quil_rs__program__graphviz_dot__tests__graph__fence_all_with_nonblocking_pulses.snap
+++ b/src/program/snapshots/quil_rs__program__graphviz_dot__tests__graph__fence_all_with_nonblocking_pulses.snap
@@ -11,20 +11,24 @@ digraph {
     "block_0_start" [shape=circle, label="start"];
     "block_0_start" -> "block_0_0" [label="frame"];
     "block_0_start" -> "block_0_1" [label="frame"];
-    "block_0_start" -> "block_0_2" [label="frame"];
+    "block_0_start" -> "block_0_2" [label="ordering"];
     "block_0_start" -> "block_0_end" [label="ordering"];
     "block_0_0" [shape=rectangle, label="[0] NONBLOCKING PULSE 0 \"rf\" test(duration: 1000000)"];
-    "block_0_0" -> "block_0_2" [label="frame"];
+    "block_0_0" -> "block_0_2" [label="ordering"];
+    "block_0_0" -> "block_0_3" [label="frame"];
     "block_0_1" [shape=rectangle, label="[1] NONBLOCKING PULSE 1 \"rf\" test(duration: 1000000)"];
-    "block_0_1" -> "block_0_2" [label="frame"];
+    "block_0_1" -> "block_0_2" [label="ordering"];
+    "block_0_1" -> "block_0_4" [label="frame"];
     "block_0_2" [shape=rectangle, label="[2] FENCE"];
-    "block_0_2" -> "block_0_3" [label="frame"];
-    "block_0_2" -> "block_0_4" [label="frame"];
-    "block_0_2" -> "block_0_end" [label="frame"];
+    "block_0_2" -> "block_0_3" [label="ordering"];
+    "block_0_2" -> "block_0_4" [label="ordering"];
+    "block_0_2" -> "block_0_end" [label="ordering"];
     "block_0_3" [shape=rectangle, label="[3] NONBLOCKING PULSE 0 \"rf\" test(duration: 1000000)"];
-    "block_0_3" -> "block_0_end" [label="frame"];
+    "block_0_3" -> "block_0_end" [label="frame
+ordering"];
     "block_0_4" [shape=rectangle, label="[4] NONBLOCKING PULSE 1 \"rf\" test(duration: 1000000)"];
-    "block_0_4" -> "block_0_end" [label="frame"];
+    "block_0_4" -> "block_0_end" [label="frame
+ordering"];
     "block_0_end" [shape=circle, label="end"];
   }
 }

--- a/src/program/snapshots/quil_rs__program__graphviz_dot__tests__graph__fence_wrapper.snap
+++ b/src/program/snapshots/quil_rs__program__graphviz_dot__tests__graph__fence_wrapper.snap
@@ -9,18 +9,24 @@ digraph {
     label="block_0";
     node [style="filled"];
     "block_0_start" [shape=circle, label="start"];
-    "block_0_start" -> "block_0_0" [label="frame"];
+    "block_0_start" -> "block_0_0" [label="ordering"];
+    "block_0_start" -> "block_0_1" [label="frame"];
+    "block_0_start" -> "block_0_2" [label="frame"];
     "block_0_start" -> "block_0_end" [label="ordering"];
     "block_0_0" [shape=rectangle, label="[0] FENCE"];
-    "block_0_0" -> "block_0_1" [label="frame"];
-    "block_0_0" -> "block_0_2" [label="frame"];
-    "block_0_0" -> "block_0_end" [label="frame"];
+    "block_0_0" -> "block_0_1" [label="ordering"];
+    "block_0_0" -> "block_0_2" [label="ordering"];
+    "block_0_0" -> "block_0_3" [label="ordering"];
+    "block_0_0" -> "block_0_end" [label="ordering"];
     "block_0_1" [shape=rectangle, label="[1] NONBLOCKING PULSE 0 1 \"cz\" test(duration: 1e-6)"];
-    "block_0_1" -> "block_0_3" [label="frame"];
+    "block_0_1" -> "block_0_3" [label="ordering"];
+    "block_0_1" -> "block_0_end" [label="frame
+ordering"];
     "block_0_2" [shape=rectangle, label="[2] NONBLOCKING PULSE 1 \"rf\" test(duration: 1e-6)"];
-    "block_0_2" -> "block_0_3" [label="frame"];
+    "block_0_2" -> "block_0_3" [label="ordering"];
+    "block_0_2" -> "block_0_end" [label="frame"];
     "block_0_3" [shape=rectangle, label="[3] FENCE 1"];
-    "block_0_3" -> "block_0_end" [label="frame"];
+    "block_0_3" -> "block_0_end" [label="ordering"];
     "block_0_end" [shape=circle, label="end"];
   }
 }

--- a/src/program/snapshots/quil_rs__program__graphviz_dot__tests__graph__jump.snap
+++ b/src/program/snapshots/quil_rs__program__graphviz_dot__tests__graph__jump.snap
@@ -13,7 +13,8 @@ digraph {
     "first-block_start" -> "first-block_end" [label="frame
 ordering"];
     "first-block_0" [shape=rectangle, label="[0] PULSE 0 \"rf\" test(duration: 1000000)"];
-    "first-block_0" -> "first-block_end" [label="frame"];
+    "first-block_0" -> "first-block_end" [label="frame
+ordering"];
     "first-block_end" [shape=circle, label="end"];
   }
   "first-block_end" -> "third-block_start" [label="if ro[0] != 0"];
@@ -26,7 +27,8 @@ ordering"];
     "second-block_start" -> "second-block_end" [label="frame
 ordering"];
     "second-block_0" [shape=rectangle, label="[0] PULSE 0 \"rf\" test(duration: 1000000)"];
-    "second-block_0" -> "second-block_end" [label="frame"];
+    "second-block_0" -> "second-block_end" [label="frame
+ordering"];
     "second-block_end" [shape=circle, label="end"];
   }
   "second-block_end" -> "third-block_start" [label="always"];
@@ -38,7 +40,8 @@ ordering"];
     "third-block_start" -> "third-block_end" [label="frame
 ordering"];
     "third-block_0" [shape=rectangle, label="[0] PULSE 0 \"rf\" test(duration: 1000000)"];
-    "third-block_0" -> "third-block_end" [label="frame"];
+    "third-block_0" -> "third-block_end" [label="frame
+ordering"];
     "third-block_end" [shape=circle, label="end"];
   }
 }

--- a/src/program/snapshots/quil_rs__program__graphviz_dot__tests__graph__non_overlapping_fence.snap
+++ b/src/program/snapshots/quil_rs__program__graphviz_dot__tests__graph__non_overlapping_fence.snap
@@ -1,0 +1,36 @@
+---
+source: src/program/graphviz_dot.rs
+expression: dot_format
+---
+digraph {
+  entry -> "block_0_start";
+  entry [label="Entry Point"];
+  subgraph cluster_0 {
+    label="block_0";
+    node [style="filled"];
+    "block_0_start" [shape=circle, label="start"];
+    "block_0_start" -> "block_0_0" [label="ordering"];
+    "block_0_start" -> "block_0_1" [label="frame"];
+    "block_0_start" -> "block_0_3" [label="ordering"];
+    "block_0_start" -> "block_0_4" [label="frame"];
+    "block_0_start" -> "block_0_end" [label="ordering"];
+    "block_0_0" [shape=rectangle, label="[0] FENCE 0"];
+    "block_0_0" -> "block_0_1" [label="ordering"];
+    "block_0_0" -> "block_0_2" [label="ordering"];
+    "block_0_1" [shape=rectangle, label="[1] NONBLOCKING PULSE 0 \"rf\" drag_gaussian(alpha: (-0.95146893464447))"];
+    "block_0_1" -> "block_0_2" [label="ordering"];
+    "block_0_1" -> "block_0_end" [label="frame"];
+    "block_0_2" [shape=rectangle, label="[2] FENCE 0"];
+    "block_0_2" -> "block_0_end" [label="ordering"];
+    "block_0_3" [shape=rectangle, label="[3] FENCE 1"];
+    "block_0_3" -> "block_0_4" [label="ordering"];
+    "block_0_3" -> "block_0_5" [label="ordering"];
+    "block_0_4" [shape=rectangle, label="[4] NONBLOCKING PULSE 1 \"rf\" drag_gaussian(alpha: (-1.3853631708424974))"];
+    "block_0_4" -> "block_0_5" [label="ordering"];
+    "block_0_4" -> "block_0_end" [label="frame"];
+    "block_0_5" [shape=rectangle, label="[5] FENCE 1"];
+    "block_0_5" -> "block_0_end" [label="ordering"];
+    "block_0_end" [shape=circle, label="end"];
+  }
+}
+

--- a/src/program/snapshots/quil_rs__program__graphviz_dot__tests__graph__parametric_pulse.snap
+++ b/src/program/snapshots/quil_rs__program__graphviz_dot__tests__graph__parametric_pulse.snap
@@ -16,11 +16,13 @@ ordering"];
     "block_0_0" [shape=rectangle, label="[0] PULSE 0 \"rf\" test(a: param[0])"];
     "block_0_0" -> "block_0_1" [label="frame"];
     "block_0_0" -> "block_0_end" [label="await read
-frame"];
+frame
+ordering"];
     "block_0_1" [shape=rectangle, label="[1] CAPTURE 0 \"ro_rx\" test(a: param[0]) ro[0]"];
     "block_0_1" -> "block_0_end" [label="await capture
 await read
-frame"];
+frame
+ordering"];
     "block_0_end" [shape=circle, label="end"];
   }
 }

--- a/src/program/snapshots/quil_rs__program__graphviz_dot__tests__graph__parametric_pulses_using_capture_results.snap
+++ b/src/program/snapshots/quil_rs__program__graphviz_dot__tests__graph__parametric_pulses_using_capture_results.snap
@@ -19,25 +19,31 @@ ordering"];
 frame"];
     "block_0_0" -> "block_0_3" [label="frame"];
     "block_0_0" -> "block_0_end" [label="await read
-frame"];
+frame
+ordering"];
     "block_0_1" [shape=rectangle, label="[1] NONBLOCKING PULSE 0 \"rf\" test(a: ro[0])"];
     "block_0_1" -> "block_0_3" [label="await read
 frame"];
     "block_0_1" -> "block_0_4" [label="frame"];
+    "block_0_1" -> "block_0_end" [label="ordering"];
     "block_0_2" [shape=rectangle, label="[2] NONBLOCKING PULSE 1 \"rf\" test(a: ro[0])"];
     "block_0_2" -> "block_0_3" [label="await read"];
     "block_0_2" -> "block_0_5" [label="frame"];
+    "block_0_2" -> "block_0_end" [label="ordering"];
     "block_0_3" [shape=rectangle, label="[3] CAPTURE 0 \"ro_rx\" test(a: param[0]) ro[0]"];
     "block_0_3" -> "block_0_4" [label="await capture
 frame"];
     "block_0_3" -> "block_0_end" [label="await read
-frame"];
+frame
+ordering"];
     "block_0_4" [shape=rectangle, label="[4] NONBLOCKING PULSE 0 \"rf\" test(a: ro[0])"];
     "block_0_4" -> "block_0_end" [label="await read
-frame"];
+frame
+ordering"];
     "block_0_5" [shape=rectangle, label="[5] NONBLOCKING PULSE 1 \"rf\" test(a: ro[0])"];
     "block_0_5" -> "block_0_end" [label="await read
-frame"];
+frame
+ordering"];
     "block_0_end" [shape=circle, label="end"];
   }
 }

--- a/src/program/snapshots/quil_rs__program__graphviz_dot__tests__graph__pulse_after_capture.snap
+++ b/src/program/snapshots/quil_rs__program__graphviz_dot__tests__graph__pulse_after_capture.snap
@@ -16,9 +16,11 @@ ordering"];
     "block_0_0" [shape=rectangle, label="[0] CAPTURE 0 \"ro_rx\" test ro[0]"];
     "block_0_0" -> "block_0_1" [label="frame"];
     "block_0_0" -> "block_0_end" [label="await capture
-frame"];
+frame
+ordering"];
     "block_0_1" [shape=rectangle, label="[1] PULSE 0 \"rf\" test"];
-    "block_0_1" -> "block_0_end" [label="frame"];
+    "block_0_1" -> "block_0_end" [label="frame
+ordering"];
     "block_0_end" [shape=circle, label="end"];
   }
 }

--- a/src/program/snapshots/quil_rs__program__graphviz_dot__tests__graph__simple_capture.snap
+++ b/src/program/snapshots/quil_rs__program__graphviz_dot__tests__graph__simple_capture.snap
@@ -14,7 +14,8 @@ digraph {
 ordering"];
     "block_0_0" [shape=rectangle, label="[0] CAPTURE 0 \"ro_rx\" test ro[0]"];
     "block_0_0" -> "block_0_end" [label="await capture
-frame"];
+frame
+ordering"];
     "block_0_end" [shape=circle, label="end"];
   }
 }

--- a/src/program/snapshots/quil_rs__program__graphviz_dot__tests__graph__single_dependency.snap
+++ b/src/program/snapshots/quil_rs__program__graphviz_dot__tests__graph__single_dependency.snap
@@ -14,9 +14,11 @@ digraph {
 ordering"];
     "block_0_0" [shape=rectangle, label="[0] PULSE 0 \"rf\" test(duration: 1000000)"];
     "block_0_0" -> "block_0_1" [label="frame"];
-    "block_0_0" -> "block_0_end" [label="frame"];
+    "block_0_0" -> "block_0_end" [label="frame
+ordering"];
     "block_0_1" [shape=rectangle, label="[1] PULSE 0 \"rf\" test(duration: 1000000)"];
-    "block_0_1" -> "block_0_end" [label="frame"];
+    "block_0_1" -> "block_0_end" [label="frame
+ordering"];
     "block_0_end" [shape=circle, label="end"];
   }
 }

--- a/src/program/snapshots/quil_rs__program__graphviz_dot__tests__graph__single_instruction.snap
+++ b/src/program/snapshots/quil_rs__program__graphviz_dot__tests__graph__single_instruction.snap
@@ -13,7 +13,8 @@ digraph {
     "block_0_start" -> "block_0_end" [label="frame
 ordering"];
     "block_0_0" [shape=rectangle, label="[0] PULSE 0 \"rf\" test(duration: 1000000)"];
-    "block_0_0" -> "block_0_end" [label="frame"];
+    "block_0_0" -> "block_0_end" [label="frame
+ordering"];
     "block_0_end" [shape=circle, label="end"];
   }
 }


### PR DESCRIPTION
This takes a simple approach, reusing the `PreviousNodes` mechanism already employed for frame dependencies:

- `FENCE` instructions "use" a qubit, in that they hold exclusive use of that qubit while "executing"
- All RF Control instructions (anything operating on a frame) "blocks" a qubit, in that they must wait for previous "users" to complete but they do not exclude one another. They do this for all qubits named within their frame. This allows, for example, a `NONBLOCKING PULSE 0 "'ro_tx"` to play concurrently with `NONBLOCKING CAPTURE 0 "ro_rx"` as is commonly done.

This does add a couple redundant edges on the timing graph, such as between back-to-back `FENCE` and `FENCE 1`, but I think that price is worth paying for the simplicity of the approach.

I _initially_ added a new variant, `ExecutionDependency::Qubit`, but considered that the effect of a Qubit dependency is itself in nature nothing more than a `StableOrdering`, and so it was not worth the breaking change to distinguish between the two. So, this change as written is just a bugfix and not a breaking change.