### PR TITLE
feat: Implement LaTeX generation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ rstest = "0.15.0"
 
 [features]
 graphviz-dot = ["dot-writer"]
+latex = []
 
 [[bench]]
 name = "parser"

--- a/src/program/latex.rs
+++ b/src/program/latex.rs
@@ -1,0 +1,74 @@
+use crate::Program;
+
+#[derive(Debug)]
+/// Settings to control the layout and rendering of circuits.
+pub struct DiagramSettings {
+    /// Convert numerical constants, such as pi, to LaTeX form.
+    texify_numerical_constants: bool,
+
+    /// Include qubits with indices between those explicitly referenced in the Quil program.
+    /// For example, if true, the diagram for `CNOT 0 2` would have three qubit lines: 0, 1, 2.
+    impute_missing_qubits: bool,
+
+    /// Label qubit lines.
+    label_qubit_lines: bool,
+
+    /// Write controlled rotations in a compact form.
+    /// For example,  `RX(pi)` as `X_{\\pi}`, instead of the longer `R_X(\\pi)`
+    abbreviate_controlled_rotations: bool,
+
+    /// The length by which qubit lines should be extended with open wires at the right of the diagram.
+    /// The default of 1 is the natural choice. The main reason for including this option
+    /// is that it may be appropriate for this to be 0 in subdiagrams.
+    qubit_line_open_wire_length: u32,
+    
+    /// Align measurement operations which appear at the end of the program.
+    right_align_terminal_measurements: bool,
+}
+
+impl Default for DiagramSettings {
+    fn default() -> Self {
+        Self { 
+            texify_numerical_constants: true, 
+            impute_missing_qubits: false, 
+            label_qubit_lines: true, 
+            abbreviate_controlled_rotations: false, 
+            qubit_line_open_wire_length: 1, 
+            right_align_terminal_measurements: true,
+        }
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum LatexGenError {
+    // TODO: Add variants for each error type using `thiserror` crate to return detailed Result::Err.
+    #[error("This is an error on {qubit_index}.")]
+    SomeError{qubit_index: u32},
+}
+
+pub trait ToLatex {
+    fn to_latex(self, diagram_settings: DiagramSettings) -> Result<String, LatexGenError>;
+}
+
+impl ToLatex for Program {
+    fn to_latex(self, diagram_settings: DiagramSettings) -> Result<String, LatexGenError> {
+        // TODO: Generate the Program LaTeX.
+        let latex = "";
+
+        Ok(latex.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+    use crate::Program;
+    use super::{ToLatex, DiagramSettings};
+
+    #[test]
+    fn test_controlled_gate() {
+        let program = Program::from_str("CONTROLLED H 3 2").expect("Program should be returned.");
+        let latex = program.to_latex(DiagramSettings::default()).expect("LaTeX should generate without error.");
+        insta::assert_snapshot!(latex);
+    }
+}

--- a/src/program/mod.rs
+++ b/src/program/mod.rs
@@ -39,6 +39,9 @@ pub type Result<O> = std::result::Result<O, ProgramError<O>>;
 #[cfg(feature = "graphviz-dot")]
 pub mod graphviz_dot;
 
+#[cfg(feature = "latex")]
+pub mod latex;
+
 /// A Quil Program instance describes a quantum program with metadata used in execution.
 ///
 /// This contains not only instructions which are executed in turn on the quantum processor, but

--- a/src/program/snapshots/quil_rs__program__latex__tests__controlled_gate.snap
+++ b/src/program/snapshots/quil_rs__program__latex__tests__controlled_gate.snap
@@ -1,0 +1,15 @@
+---
+source: src/program/latex.rs
+assertion_line: 104
+expression: latex
+---
+\[convert={density=300,outext=.png}]{standalone}
+\usepackage[margin=1in]{geometry}
+\usepackage{tikz}
+\usetikzlibrary{quantikz}
+\begin{document}
+\begin{tikzcd}
+\lstick{\ket{q_{2}}} & \gate{H} & \qw \\
+\lstick{\ket{q_{3}}} & \ctrl{-1} & \qw
+\end{tikzcd}
+\end{document}


### PR DESCRIPTION
This draft PR transfers the pyQuil LaTeX generation feature to quil-rs.

The initial commit,
1. Adds a new `latex.rs` to the `program` crate.
2. Exposes it as a feature to the project in `Cargo.toml` and `mod.rs`.
3. Includes an initial snapshot test for the simple Program `CONTROLLED H 3 2`.
---
program/latex.rs
This file has two sections with some initial code, 
1. LaTeX Implementation 
2. Testing Suite 

LaTeX Implementation
The LaTeX implementation section of `latex.rs` is where the LaTeX generation will occur. The current template was used to generate the first snapshot test. It includes DiagramSettings, directly taken from [pyQuil](https://github.com/rigetti/pyquil/blob/master/pyquil/latex/_diagram.py), that will allow users to customize the LaTeX for their Program following the [Builder](https://rust-unofficial.github.io/patterns/patterns/creational/builder.html) design pattern in Rust. The template also contains an outline for displaying various `Result::Err` using [thiserror](https://docs.rs/thiserror/latest/thiserror/) on a `LatexGenError` enum. 

Testing Suite
The first test in the testing module containing the suite of LaTeX unit tests is a simple snapshot test for `CONTROLLED H 3 2`. The snap file for this test is program/snapshots/quil_rs__program__latex__tests__controlled_gate.snap. It was generated by passing the following expected LaTeX to the unit test `test_controlled_gate` as the initial snapshot assertion.

```latex
\[convert={density=300,outext=.png}]{standalone}
\usepackage[margin=1in]{geometry}
\usepackage{tikz}
\usetikzlibrary{quantikz}
\begin{document}
\begin{tikzcd}
\lstick{\ket{q_{2}}} & \gate{H} & \qw \\
\lstick{\ket{q_{3}}} & \ctrl{-1} & \qw
\end{tikzcd}
\end{document}
```
---
Main Tasks and Sub Tasks lists will be used to help keep track of the work. Once all tasks are marked as complete in the Main Tasks the stage of this PR can be changed from draft to ready for review.

Main Tasks
- [ ] I. Implement all LaTeX generation features currently available in pyQuil.
- [ ] II. Implement new CCNOT and CPHASE features.


Sub Tasks (live list)

I. Implement all LaTeX generation features currently available in pyQuil.
- [ ] Research external LaTeX generation crates.
- [ ] Create simple snapshot tests for single qubit Programs.
- [ ] Implement LaTeX generation for single qubit Programs.
...
- [ ] Pass assertion for multi-qubit `test_controlled_gate` test.
...

II. Implement new CCNOT and CPHASE features
...