### PR TITLE
Refactor `ProgramError`

### DIFF
--- a/quil-rs/src/expression.rs
+++ b/quil-rs/src/expression.rs
@@ -29,7 +29,7 @@ use std::str::FromStr;
 use proptest_derive::Arbitrary;
 
 use crate::parser::{lex, parse_expression, ParseError};
-use crate::program::{disallow_leftover, ProgramError};
+use crate::program::{disallow_leftover, ProgramParsingError};
 use crate::{imag, instruction::MemoryReference, real};
 
 /// The different possible types of errors that could occur during expression evaluation.
@@ -449,7 +449,7 @@ impl Expression {
 }
 
 impl FromStr for Expression {
-    type Err = ProgramError<Self>;
+    type Err = ProgramParsingError<Self>;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let input = LocatedSpan::new(s);

--- a/quil-rs/src/program/calibration.rs
+++ b/quil-rs/src/program/calibration.rs
@@ -22,7 +22,7 @@ use crate::{
     },
 };
 
-use super::error::ProgramError;
+use super::ProgramError;
 
 /// A collection of Quil calibrations (`DEFCAL` instructions) with utility methods.
 #[derive(Clone, Debug, Default, PartialEq)]
@@ -60,7 +60,7 @@ impl CalibrationSet {
         &self,
         instruction: &Instruction,
         previous_calibrations: &[Instruction],
-    ) -> Result<Option<Vec<Instruction>>, ProgramError<super::Program>> {
+    ) -> Result<Option<Vec<Instruction>>, ProgramError> {
         if previous_calibrations.contains(instruction) {
             return Err(ProgramError::RecursiveCalibration(instruction.clone()));
         }

--- a/quil-rs/src/program/error/mod.rs
+++ b/quil-rs/src/program/error/mod.rs
@@ -27,21 +27,16 @@ pub use result::{disallow_leftover, map_parsed, recover};
 pub use syntax::SyntaxError;
 
 /// Errors that may occur while parsing a [`Program`](crate::program::Program).
-// TODO: [`Program`] should have its own error type: https://github.com/rigetti/quil-rs/issues/150
 #[derive(Debug, PartialEq)]
-pub enum ProgramError<T> {
+pub enum ProgramParsingError<T> {
     InvalidCalibration {
         instruction: Instruction,
         message: String,
     },
-    RecursiveCalibration(Instruction),
     Syntax(SyntaxError<T>),
-    InvalidQuiltInstruction(Instruction),
-    InvalidProtoQuilInstruction(Instruction),
-    UnsupportedOperation(Instruction),
 }
 
-impl<T> From<LexError> for ProgramError<T>
+impl<T> From<LexError> for ProgramParsingError<T>
 where
     T: fmt::Debug,
 {
@@ -50,50 +45,44 @@ where
     }
 }
 
-impl<T> From<ParseError> for ProgramError<T> {
+impl<T> From<ParseError> for ProgramParsingError<T> {
     fn from(e: ParseError) -> Self {
         Self::Syntax(SyntaxError::from(e))
     }
 }
 
-impl<T> From<LeftoverError<T>> for ProgramError<T> {
+impl<T> From<LeftoverError<T>> for ProgramParsingError<T> {
     fn from(err: LeftoverError<T>) -> Self {
         Self::Syntax(SyntaxError::from(err))
     }
 }
 
-impl<T> From<SyntaxError<T>> for ProgramError<T> {
+impl<T> From<SyntaxError<T>> for ProgramParsingError<T> {
     fn from(err: SyntaxError<T>) -> Self {
         Self::Syntax(err)
     }
 }
 
-impl<T> ProgramError<T> {
+impl<T> ProgramParsingError<T> {
     /// Convert the parsed output into another type.
     ///
     /// This delegates to [`LeftoverError::map_parsed`] when a [`ProgramError::Leftover`] and does
     /// nothing but change the type signature otherwise.
-    pub fn map_parsed<T2>(self, map: impl Fn(T) -> T2) -> ProgramError<T2> {
+    pub fn map_parsed<T2>(self, map: impl Fn(T) -> T2) -> ProgramParsingError<T2> {
         match self {
             Self::InvalidCalibration {
                 instruction,
                 message,
-            } => ProgramError::InvalidCalibration {
+            } => ProgramParsingError::InvalidCalibration {
                 instruction,
                 message,
             },
-            Self::RecursiveCalibration(inst) => ProgramError::RecursiveCalibration(inst),
-            Self::Syntax(err) => ProgramError::Syntax(err.map_parsed(map)),
-            Self::InvalidQuiltInstruction(inst) => ProgramError::InvalidQuiltInstruction(inst),
-            Self::InvalidProtoQuilInstruction(inst) => {
-                ProgramError::InvalidProtoQuilInstruction(inst)
-            }
-            Self::UnsupportedOperation(inst) => ProgramError::UnsupportedOperation(inst),
+            Self::Syntax(err) => ProgramParsingError::Syntax(err.map_parsed(map)),
         }
     }
 }
 
-impl<T> fmt::Display for ProgramError<T>
+impl<T> fmt::Display for ProgramParsingError<T>
 where
     T: fmt::Debug + 'static,
 {
@@ -103,33 +92,19 @@ where
                 instruction,
                 message,
             } => write!(f, "invalid calibration `{instruction}`: {message}"),
-            Self::RecursiveCalibration(instruction) => {
-                write!(f, "instruction {instruction} expands into itself")
-            }
             Self::Syntax(err) => fmt::Display::fmt(err, f),
-            Self::InvalidQuiltInstruction(inst) => write!(f, "invalid quilt instruction: {inst}"),
-            Self::InvalidProtoQuilInstruction(inst) => {
-                write!(f, "invalid protoquil instruction: {inst}")
-            }
-            Self::UnsupportedOperation(inst) => {
-                write!(f, "operation is not supported on instruction: {inst}")
-            }
         }
     }
 }
 
-impl<T> Error for ProgramError<T>
+impl<T> Error for ProgramParsingError<T>
 where
     T: fmt::Debug + 'static,
 {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
             Self::InvalidCalibration { .. } => None,
-            Self::RecursiveCalibration(_) => None,
             Self::Syntax(err) => Some(err),
-            Self::InvalidQuiltInstruction(_) => None,
-            Self::InvalidProtoQuilInstruction(_) => None,
-            Self::UnsupportedOperation(_) => None,
         }
     }
 }

--- a/quil-rs/src/program/error/result.rs
+++ b/quil-rs/src/program/error/result.rs
@@ -14,7 +14,7 @@
 
 use crate::parser::{ErrorInput, ParseError};
 use crate::program::error::LeftoverError;
-use crate::program::ProgramError;
+use crate::program::ProgramParsingError;
 use nom::Finish;
 
 use super::SyntaxError;
@@ -46,21 +46,21 @@ where
 /// This should be preferred over [`Result::map`], as this will map both the `Ok` case and when
 /// there is a [`LeftoverError`].
 pub fn map_parsed<O, O2>(
-    result: Result<O, ProgramError<O>>,
+    result: Result<O, ProgramParsingError<O>>,
     map: impl Fn(O) -> O2,
-) -> Result<O2, ProgramError<O2>> {
+) -> Result<O2, ProgramParsingError<O2>> {
     match result {
         Ok(parsed) => Ok(map(parsed)),
         Err(err) => Err(err.map_parsed(map)),
     }
 }
 
-/// If this `result` is `Err(ProgramError::Leftover)`, converts it to `Ok(_)` with the parsed
+/// If this `result` is `Err(ProgramParsingError::Leftover)`, converts it to `Ok(_)` with the parsed
 /// output.
-pub fn recover<O>(result: Result<O, ProgramError<O>>) -> Result<O, ProgramError<O>> {
+pub fn recover<O>(result: Result<O, ProgramParsingError<O>>) -> Result<O, ProgramParsingError<O>> {
     match result {
         Ok(parsed) => Ok(parsed),
-        Err(ProgramError::Syntax(err)) => err.recover().map_err(ProgramError::from),
+        Err(ProgramParsingError::Syntax(err)) => err.recover().map_err(ProgramParsingError::from),
         Err(err) => Err(err),
     }
 }


### PR DESCRIPTION
The existing `ProgramError<T>` was created to handle parsing errors but as the Program API expanded, it grew beyond that purpose. 

The existing error type has been renamed to `ProgramParsingError<T>` and any variants that weren't related to parsing have been removed. There is a new `ProgramError` enum that contains a variant for each possible error when working with a program. It also implements `From<ProgramParsingError<T>` so the public API doesn't have to deal with the generics. This makes it possible to use `ProgramError` fairly easily in the python bindings.