### PR TITLE
Support Qubit & Label Placeholders

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -764,6 +764,7 @@ dependencies = [
  "petgraph",
  "proptest",
  "proptest-derive",
+ "rand",
  "rstest",
  "serde",
  "strum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ nom = "7.1.1"
 nom_locate = "4.0.0"
 num-complex = "0.4.0"
 petgraph = "0.6.2"
+rand = "0.8.5"
 serde = { version = "1.0.125", features = ["derive"] }
 strum = { version = "0.24.1", features = ["derive"] }
 thiserror = "1.0.37"

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -1597,6 +1597,7 @@ RX(%a) 0",
 
         use crate::instruction::{Label, LabelPlaceholder, Qubit, QubitPlaceholder};
 
+        #[allow(clippy::redundant_clone)]
         #[test]
         fn label() {
             let placeholder_1 = LabelPlaceholder::new(String::from("label"));
@@ -1627,6 +1628,7 @@ RX(%a) 0",
             assert_eq!(label_2, Label::Placeholder(placeholder_2));
         }
 
+        #[allow(clippy::redundant_clone)]
         #[test]
         fn qubit() {
             let placeholder_1 = QubitPlaceholder::default();

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -16,7 +16,6 @@ use nom_locate::LocatedSpan;
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::collections::HashSet;
-use std::pin::Pin;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::{collections::HashMap, fmt};
@@ -555,7 +554,7 @@ impl Label {
     }
 }
 
-type LabelPlaceholderInner = Arc<Pin<Box<String>>>;
+type LabelPlaceholderInner = Arc<String>;
 
 /// An opaque placeholder for a qubit whose index may be assigned
 /// at a later time.
@@ -564,7 +563,7 @@ pub struct LabelPlaceholder(LabelPlaceholderInner);
 
 impl LabelPlaceholder {
     pub fn new(base_label: String) -> Self {
-        Self(Arc::new(Box::pin(base_label)))
+        Self(Arc::new(base_label))
     }
 
     pub fn as_inner(&self) -> &String {
@@ -1188,7 +1187,7 @@ impl fmt::Display for Qubit {
     }
 }
 
-type QubitPlaceholderInner = Arc<Pin<Box<usize>>>;
+type QubitPlaceholderInner = Arc<()>;
 
 /// An opaque placeholder for a qubit whose index may be assigned
 /// at a later time.
@@ -1197,9 +1196,7 @@ pub struct QubitPlaceholder(QubitPlaceholderInner);
 
 impl Default for QubitPlaceholder {
     fn default() -> Self {
-        use rand::Rng;
-        let value = rand::thread_rng().gen();
-        Self(Arc::new(Box::pin(value)))
+        Self(Arc::new(()))
     }
 }
 
@@ -1480,7 +1477,7 @@ impl Instruction {
             }
         }
     }
-    
+
     /// Per the Quil-T spec, whether this instruction's timing within the pulse
     /// program must be precisely controlled so as to begin exactly on the end of
     /// the latest preceding timed instruction

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,5 +40,6 @@ pub mod instruction;
 mod macros;
 pub(crate) mod parser;
 pub mod program;
+pub mod quil;
 
 pub use program::Program;

--- a/src/parser/command.rs
+++ b/src/parser/command.rs
@@ -23,6 +23,7 @@ use crate::{
     expression::Expression,
     instruction::{Convert, GateSpecification, GateType, Include, PragmaArgument, Qubit},
     parser::common::parse_variable_qubit,
+    quil::Quil,
     real,
 };
 
@@ -210,7 +211,7 @@ pub(crate) fn parse_defcal_measure<'a>(
     let (input, params) = pair(parse_qubit, opt(token!(Identifier(v))))(input)?;
     let (qubit, destination) = match params {
         (qubit, Some(destination)) => (Some(qubit), destination),
-        (destination, None) => (None, destination.to_string()),
+        (destination, None) => (None, destination.to_quil_or_debug()),
     };
     let (input, _) = token!(Colon)(input)?;
     let (input, instructions) = parse_block(input)?;

--- a/src/parser/command.rs
+++ b/src/parser/command.rs
@@ -383,7 +383,7 @@ pub(crate) fn parse_jump_unless<'a>(
 /// Parse the contents of a `DECLARE` instruction.
 pub(crate) fn parse_label<'a>(input: ParserInput<'a>) -> InternalParserResult<'a, Instruction> {
     let (input, name) = token!(Label(v))(input)?;
-    Ok((input, Instruction::Label(Label(name))))
+    Ok((input, Instruction::Label(Label::Fixed(name))))
 }
 
 /// Parse the contents of a `MOVE` instruction.

--- a/src/parser/instruction.rs
+++ b/src/parser/instruction.rs
@@ -609,7 +609,7 @@ mod tests {
         parse_instructions,
         "LABEL @hello\nJUMP @hello\nJUMP-WHEN @hello ro",
         vec![
-            Instruction::Label(Label("hello".to_owned())),
+            Instruction::Label(Label::Fixed("hello".to_owned())),
             Instruction::Jump(Jump {
                 target: "hello".to_owned()
             }),

--- a/src/parser/instruction.rs
+++ b/src/parser/instruction.rs
@@ -164,6 +164,7 @@ mod tests {
     };
     use crate::parser::common::tests::KITCHEN_SINK_QUIL;
     use crate::parser::lexer::lex;
+    use crate::quil::Quil;
     use crate::{make_test, real, Program};
 
     use super::parse_instructions;
@@ -981,7 +982,7 @@ mod tests {
 
         for input in inputs {
             let program = Program::from_str(input).unwrap();
-            let output = program.to_string(true);
+            let output = program.to_quil().unwrap();
             let roundtrip = Program::from_str(&output).unwrap();
 
             assert_eq!(program, roundtrip);

--- a/src/program/calibration.rs
+++ b/src/program/calibration.rs
@@ -45,6 +45,7 @@ impl<'a> MatchedCalibration<'a> {
                 .iter()
                 .filter(|q| match q {
                     Qubit::Fixed(_) => true,
+                    Qubit::Placeholder(_) => false,
                     Qubit::Variable(_) => false,
                 })
                 .count(),
@@ -115,6 +116,7 @@ impl CalibrationSet {
                                                 }
                                             }
                                             Qubit::Fixed(_) => {}
+                                            Qubit::Placeholder(_) => {}
                                         }
                                     }
                                 }
@@ -250,6 +252,7 @@ impl CalibrationSet {
                             (Qubit::Variable(_), _) => true,
                             // If the calibration is fixed, but the gate's qubit is variable, it's not a match
                             (Qubit::Fixed(_), _) => false,
+                            (Qubit::Placeholder(_), _) => false,
                         }
                     });
             if !fixed_qubits_match {

--- a/src/program/calibration.rs
+++ b/src/program/calibration.rs
@@ -342,7 +342,7 @@ impl CalibrationSet {
 mod tests {
     use std::str::FromStr;
 
-    use crate::program::Program;
+    use crate::{program::Program, quil::Quil};
 
     #[test]
     fn expansion() {
@@ -413,8 +413,15 @@ mod tests {
 
         for case in &cases {
             let program = Program::from_str(case.input).unwrap();
-            let calibrated_program = program.expand_calibrations().unwrap();
-            assert_eq!(calibrated_program.to_string(false).as_str(), case.expected);
+            let calibrated_program = program
+                .expand_calibrations()
+                .unwrap()
+                .into_simplified()
+                .unwrap();
+            assert_eq!(
+                calibrated_program.to_quil().unwrap().as_str(),
+                case.expected
+            );
         }
     }
 

--- a/src/program/error/mod.rs
+++ b/src/program/error/mod.rs
@@ -22,6 +22,7 @@ use std::fmt::Formatter;
 
 use crate::instruction::Instruction;
 use crate::parser::{LexError, ParseError};
+use crate::quil::Quil;
 pub use leftover::LeftoverError;
 pub use result::{disallow_leftover, map_parsed, recover};
 pub use syntax::SyntaxError;
@@ -93,9 +94,22 @@ where
             Self::InvalidCalibration {
                 instruction,
                 message,
-            } => write!(f, "invalid calibration `{}`: {}", instruction, message),
+            } => write!(
+                f,
+                "invalid calibration `{}`: {}",
+                instruction
+                    .to_quil()
+                    .unwrap_or_else(|_| format!("{:?}", instruction)),
+                message
+            ),
             Self::RecursiveCalibration(instruction) => {
-                write!(f, "instruction {} expands into itself", instruction)
+                write!(
+                    f,
+                    "instruction {} expands into itself",
+                    instruction
+                        .to_quil()
+                        .unwrap_or_else(|_| format!("{:?}", instruction))
+                )
             }
             Self::Syntax(err) => fmt::Display::fmt(err, f),
         }

--- a/src/program/frame.rs
+++ b/src/program/frame.rs
@@ -40,9 +40,9 @@ impl FrameSet {
     /// Return all frames in the set which match all of these conditions. If a frame _would_ match, but is
     /// not present in this [FrameSet], then it is not returned (notably, the [FrameMatchCondition::Specific]
     /// match condition).
-    pub(crate) fn get_matching_keys<'s, 'a>(
+    pub(crate) fn get_matching_keys<'s>(
         &'s self,
-        condition: FrameMatchCondition<'a>,
+        condition: FrameMatchCondition,
     ) -> HashSet<&'s FrameIdentifier> {
         let keys = self.frames.keys();
 

--- a/src/program/graphviz_dot.rs
+++ b/src/program/graphviz_dot.rs
@@ -16,9 +16,12 @@
 
 use dot_writer::{Attributes, DotWriter, Shape, Style};
 
-use crate::program::graph::{
-    BlockTerminator, ExecutionDependency, InstructionBlock, MemoryAccessType, ScheduledGraphNode,
-    ScheduledProgram,
+use crate::{
+    program::graph::{
+        BlockTerminator, ExecutionDependency, InstructionBlock, MemoryAccessType,
+        ScheduledGraphNode, ScheduledProgram,
+    },
+    quil::Quil,
 };
 
 impl InstructionBlock {
@@ -47,7 +50,7 @@ impl InstructionBlock {
                         .set_label(&escape_label(&format!(
                             "[{}] {}",
                             index,
-                            self.instructions.get(*index).unwrap()
+                            self.instructions.get(*index).unwrap().to_quil_or_debug()
                         )));
                 }
             };

--- a/src/program/memory.rs
+++ b/src/program/memory.rs
@@ -18,9 +18,9 @@ use crate::expression::Expression;
 use crate::instruction::{
     Arithmetic, ArithmeticOperand, BinaryLogic, BinaryOperand, Capture, CircuitDefinition,
     Comparison, ComparisonOperand, Delay, Exchange, Gate, GateDefinition, GateSpecification,
-    Instruction, Jump, JumpUnless, JumpWhen, Label, Load, MeasureCalibrationDefinition,
-    Measurement, MemoryReference, Move, Pulse, RawCapture, SetPhase, SetScale, ShiftPhase, Store,
-    UnaryLogic, Vector, WaveformInvocation,
+    Instruction, Jump, JumpUnless, JumpWhen, Load, MeasureCalibrationDefinition, Measurement,
+    MemoryReference, Move, Pulse, RawCapture, SetPhase, SetScale, ShiftPhase, Store, UnaryLogic,
+    Vector, WaveformInvocation,
 };
 
 #[derive(Clone, Debug, Hash, PartialEq)]
@@ -262,7 +262,7 @@ impl Instruction {
             | Instruction::Halt
             | Instruction::Include(_)
             | Instruction::Jump(Jump { target: _ })
-            | Instruction::Label(Label(_))
+            | Instruction::Label(_)
             | Instruction::Nop
             | Instruction::Pragma(_)
             | Instruction::Reset(_)

--- a/src/program/mod.rs
+++ b/src/program/mod.rs
@@ -238,6 +238,7 @@ impl Program {
     /// If you do not provide a resolver for a placeholder, a default resolver will be used which will generate a unique value
     /// for that placeholder within the scope of the program using an auto-incrementing value (for qubit) or suffix (for label)
     /// while ensuring that unique value is not already in use within the program.
+    #[allow(clippy::type_complexity)]
     pub fn resolve_placeholders(
         &mut self,
         label_resolver: Option<Box<dyn Fn(&LabelPlaceholder) -> Option<String>>>,
@@ -337,13 +338,15 @@ impl Program {
 }
 
 impl Quil for Program {
-    type Display = String;
-
-    fn to_quil(&self) -> std::result::Result<Self::Display, crate::quil::ToQuilError> {
-        self.to_instructions(true)
-            .iter()
-            .map(|inst| inst.to_quil().map(|inst| format!("{}\n", inst)))
-            .collect()
+    fn write(
+        &self,
+        writer: &mut impl std::fmt::Write,
+    ) -> std::result::Result<(), crate::quil::ToQuilError> {
+        for instruction in &self.to_instructions(true) {
+            instruction.write(writer)?;
+            writer.write_char('\n')?;
+        }
+        Ok(())
     }
 }
 

--- a/src/program/type_check.rs
+++ b/src/program/type_check.rs
@@ -10,6 +10,7 @@ use crate::{
         ShiftPhase, Store, UnaryLogic, UnaryOperator,
     },
     program::MemoryRegion,
+    quil::Quil,
     Program,
 };
 use std::collections::BTreeMap;
@@ -19,14 +20,17 @@ use thiserror::Error;
 /// Different types of errors that can occur during type checking.
 #[derive(Debug, Error)]
 pub enum TypeError {
-    #[error("In instruction {instruction}: undefined memory reference {reference}.")]
+    #[error(
+        "In instruction {}: undefined memory reference {reference}.",
+        Quil::to_quil_or_debug(instruction)
+    )]
     UndefinedMemoryReference {
         instruction: Instruction,
         reference: String,
     },
 
     #[error(
-        "In instruction {instruction}: data type mismatch; {dst} is of type {dst_type}, while {src} is of type {src_type}."
+        "In instruction {}: data type mismatch; {dst} is of type {dst_type}, while {src} is of type {src_type}.", Quil::to_quil_or_debug(instruction)
     )]
     DataTypeMismatch {
         instruction: Instruction,
@@ -37,7 +41,8 @@ pub enum TypeError {
     },
 
     #[error(
-        "In instruction {instruction}: required a real value, but {value} has type {data_type}."
+        "In instruction {}: required a real value, but {value} has type {data_type}.",
+        Quil::to_quil_or_debug(instruction)
     )]
     RealValueRequired {
         instruction: Instruction,
@@ -46,7 +51,7 @@ pub enum TypeError {
     },
 
     #[error(
-        "In instruction {instruction}: {operator} can only work with {correct_type} data, but operand {operand} has type {data_type}."
+        "In instruction {}: {operator} can only work with {correct_type} data, but operand {operand} has type {data_type}.", Quil::to_quil_or_debug(instruction)
     )]
     OperatorOperandMismatch {
         instruction: Instruction,

--- a/src/quil.rs
+++ b/src/quil.rs
@@ -1,0 +1,28 @@
+pub trait Quil {
+    type Display: std::fmt::Display;
+
+    /// Return a string in valid Quil syntax or an error if the item cannot be represented with valid Quil.
+    fn to_quil(&self) -> Result<Self::Display, ToQuilError>;
+
+    fn to_quil_or_debug(&self) -> String
+    where
+        Self: std::fmt::Debug,
+    {
+        self.to_quil()
+            .map(|s| s.to_string())
+            .unwrap_or_else(|_| format!("{:#?}", self))
+    }
+}
+
+pub type ToQuilResult<T> = Result<T, ToQuilError>;
+
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum ToQuilError {
+    #[error("Label has not yet been resolved")]
+    UnresolvedLabelPlaceholder,
+    #[error("Qubit has not yet been resolved")]
+    UnresolvedQubitPlaceholder,
+    #[error("Formatter error: {0}")]
+    FormatterError(#[from] std::fmt::Error),
+}

--- a/src/quil.rs
+++ b/src/quil.rs
@@ -23,6 +23,4 @@ pub enum ToQuilError {
     UnresolvedLabelPlaceholder,
     #[error("Qubit has not yet been resolved")]
     UnresolvedQubitPlaceholder,
-    #[error("Formatter error: {0}")]
-    FormatterError(#[from] std::fmt::Error),
 }

--- a/src/quil.rs
+++ b/src/quil.rs
@@ -1,9 +1,11 @@
+/// A trait to wrap items which represent some construct within the Quil language.
 pub trait Quil {
     type Display: std::fmt::Display;
 
     /// Return a string in valid Quil syntax or an error if the item cannot be represented with valid Quil.
     fn to_quil(&self) -> Result<Self::Display, ToQuilError>;
 
+    /// Return a string in valid Quil syntax if possible or otherwise the debug representation of the item.
     fn to_quil_or_debug(&self) -> String
     where
         Self: std::fmt::Debug,
@@ -16,6 +18,7 @@ pub trait Quil {
 
 pub type ToQuilResult<T> = Result<T, ToQuilError>;
 
+/// Errors which can occur when converting a Quil item to a string.
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum ToQuilError {


### PR DESCRIPTION
What is a placeholder for?

It's when a program author wants to say something like "I want _this_ instruction and _that_ instruction to use the same qubit, but I don't want to decide _which precise_ qubit that is yet." This is valuable for composition of a complex program from reusable pieces. Placeholders get created at a sub-program scope, and resolved to concrete values at a whole-program scope.

This PR supports placeholders in the following ways:

* Alongside `Fixed` and `Variable` (both of which are defined in Quil syntax), a Qubit may also now be a `Placeholder`. To the user, this is an opaque reference, subject only to the constraint that two copies of the same placeholder (two cloned from the same original) are considered _equal_, and all other pairs are considered _inequal_.
* Labels are now not just wrappers for fixed strings - they also now have placeholders as well. Here, a `Placeholder` is initialized with a string as a "base label" - this is the label that will be modified in some way, if needed, to be resolved to a fixed string label unique within the program.

## Implementation

Both of these are implemented as an `Arc<Pin<Box<T>`:

* `Arc` to allow sharing of a placeholder among many locations within the program. Without that feature, placeholders would be mostly pointless.
* `Pin` to ensure that the address of the `Box` stays the same. We use pointer (address) equality to compare equality between two placeholders, so we need to make sure that that address stays the same. _Note: I think this might be overly cautious, given the wrapping `Arc`. The user cannot perform pointer equality testing themselves because the field is private, so there's no case in which the pointer would be stored and then later checked for equality._
* `Box` just because that's what the `Pin` needs - a heap allocation for an address. Stack pinning doesn't make sense here.
* Then, as the inner type `T`:
  * `T = usize` for `QubitPlaceholder` with a thought to make serialization work pseudo-correctly; I started with `()` and may return to that. Serialization is not implemented here.
  * `T = String` for `LabelPlaceholder`, because that's the `base_label` to be suffixed until a unique label is found.


## The Problem

`Program` is now being pulled in two different ways for two different use cases, and as of this PR (and feature) those are apparently incompatible:

* Up the stack: `pyQuil` already has the concept of placeholders, and as its functionality is brought down into `quil-rs` that needs to be ported as well. Placeholders are an application development convenience and are not a part of Quil itself.
* Down the stack: `quil-rs` was written _first_ to parse and write Quil programs as text. `Program` represents a parsed program as a Rust struct.

## Questions

* How should `Display` be implemented for `Label`, `Qubit`, and (transitively) `Instruction` and `Program`?
  * Currently, this outputs syntactically correct Quil in a way that can be round-tripped. However, there is no way to do so with placeholders - these are not valid Quil.
    * Option 1: Break the expectation that `Display` outputs Quil
    * Option 2: Resolve placeholders at display time
    * Option 3: Convert fallibly from these structures to those which do map directly to Quil. See the next point: 
* Should we split `Program` into `Program` for application users and `ParserProgram` to faithfully represent a Quil program?
  * This would let the `Program` include higher-level conveniences like placeholders, while allowing `ParserProgram` to infallibly output Quil. `Program` -> `ParserProgram` would either coerce (resolve) "extra" functions to basic Quil, or would fail.

TODO:

- [x] Display implementation
- [x] Label placeholders
- [ ] Program::get_used_qubits refactor

Closes #147 