### PR TITLE
174 fix expression defgate parsing

### DIFF
--- a/quil-rs/src/instruction/mod.rs
+++ b/quil-rs/src/instruction/mod.rs
@@ -413,7 +413,7 @@ pub fn get_expression_parameter_string(parameters: &[Expression]) -> String {
         return String::from("");
     }
 
-    let parameter_str: String = parameters.iter().map(|e| format!("{e}")).collect();
+    let parameter_str: String = parameters.iter().map(|e| format!(r"{e}")).collect();
     format!("({parameter_str})")
 }
 
@@ -422,7 +422,11 @@ pub fn get_string_parameter_string(parameters: &[String]) -> String {
         return String::from("");
     }
 
-    let parameter_str: String = parameters.join(",");
+    let parameter_str: String = parameters
+        .iter()
+        .map(|param| format!(r"%{param}"))
+        .collect::<Vec<_>>()
+        .join(",");
     format!("({parameter_str})")
 }
 

--- a/quil-rs/src/instruction/snapshots/quil_rs__instruction__gate__test_gate_definition__display-2.snap
+++ b/quil-rs/src/instruction/snapshots/quil_rs__instruction__gate__test_gate_definition__display-2.snap
@@ -1,0 +1,9 @@
+---
+source: quil-rs/src/instruction/gate.rs
+description: Parameterized GateDefinition
+expression: gate_def.to_string()
+---
+DEFGATE ParamGate(%theta) AS MATRIX:
+	cos((%theta/2)), ((-1i)*sin((%theta/2)))
+	((-1i)*sin((%theta/2))), cos((%theta/2))
+

--- a/quil-rs/src/instruction/snapshots/quil_rs__instruction__gate__test_gate_definition__display.snap
+++ b/quil-rs/src/instruction/snapshots/quil_rs__instruction__gate__test_gate_definition__display.snap
@@ -1,0 +1,8 @@
+---
+source: quil-rs/src/instruction/gate.rs
+description: Permutation GateDefinition
+expression: gate_def.to_string()
+---
+DEFGATE PermGate AS PERMUTATION:
+	0, 1, 2, 3, 4, 5, 7, 6
+

--- a/quil-rs/src/parser/expression.rs
+++ b/quil-rs/src/parser/expression.rs
@@ -155,7 +155,7 @@ fn parse_expression_identifier(input: ParserInput) -> InternalParserResult<Expre
 
     match super::split_first_token(input) {
         None => unexpected_eof!(input),
-        Some((Token::Identifier(ident), remainder)) => match ident.as_str() {
+        Some((Token::Identifier(ident), remainder)) => match ident.to_lowercase().as_str() {
             "cis" => parse_function_call(remainder, ExpressionFunction::Cis),
             "cos" => parse_function_call(remainder, ExpressionFunction::Cosine),
             "exp" => parse_function_call(remainder, ExpressionFunction::Exponent),

--- a/quil-rs/src/parser/instruction.rs
+++ b/quil-rs/src/parser/instruction.rs
@@ -767,10 +767,10 @@ mod tests {
     make_test!(
         gate_definition_with_params,
         parse_instructions,
-        "DEFGATE RX:\n\tCOS(%theta/2), -i*SIN(%theta/2)\n\t-i*SIN(%theta/2), COS(%theta/2)\n",
+        "DEFGATE RX(%theta):\n\tCOS(%theta/2), -i*SIN(%theta/2)\n\t-i*SIN(%theta/2), COS(%theta/2)\n",
         vec![Instruction::GateDefinition(GateDefinition {
             name: "RX".to_string(),
-            parameters: vec!["%theta".to_string()],
+            parameters: vec!["theta".to_string()],
             specification: GateSpecification::Matrix(vec![
                 vec![
                     Expression::FunctionCall(FunctionCallExpression {

--- a/quil-rs/src/parser/instruction.rs
+++ b/quil-rs/src/parser/instruction.rs
@@ -151,10 +151,11 @@ mod tests {
     use std::str::FromStr;
 
     use nom_locate::LocatedSpan;
+    use num_complex::Complex;
 
     use crate::expression::{
-        Expression, FunctionCallExpression, InfixExpression, InfixOperator, PrefixExpression,
-        PrefixOperator,
+        Expression, ExpressionFunction, FunctionCallExpression, InfixExpression, InfixOperator,
+        PrefixExpression, PrefixOperator,
     };
     use crate::instruction::{
         Arithmetic, ArithmeticOperand, ArithmeticOperator, AttributeValue, BinaryLogic,
@@ -757,6 +758,68 @@ mod tests {
                             function: crate::expression::ExpressionFunction::SquareRoot,
                             expression: Box::new(Expression::Number(real!(2.0))),
                         })),
+                    }),
+                ],
+            ]),
+        })]
+    );
+
+    make_test!(
+        gate_definition_with_params,
+        parse_instructions,
+        "DEFGATE RX:\n\tCOS(%theta/2), -i*SIN(%theta/2)\n\t-i*SIN(%theta/2), COS(%theta/2)\n",
+        vec![Instruction::GateDefinition(GateDefinition {
+            name: "RX".to_string(),
+            parameters: vec!["%theta".to_string()],
+            specification: GateSpecification::Matrix(vec![
+                vec![
+                    Expression::FunctionCall(FunctionCallExpression {
+                        function: ExpressionFunction::Cosine,
+                        expression: Box::new(Expression::Infix(InfixExpression {
+                            left: Box::new(Expression::Variable("theta".to_string())),
+                            operator: InfixOperator::Slash,
+                            right: Box::new(Expression::Number(Complex { re: 2.0, im: 0.0 })),
+                        }))
+                    }),
+                    Expression::Infix(InfixExpression {
+                        left: Box::new(Expression::Prefix(PrefixExpression {
+                            operator: PrefixOperator::Minus,
+                            expression: Box::new(Expression::Number(Complex { re: 0.0, im: 1.0 })),
+                        })),
+                        operator: InfixOperator::Star,
+                        right: Box::new(Expression::FunctionCall(FunctionCallExpression {
+                            function: ExpressionFunction::Sine,
+                            expression: Box::new(Expression::Infix(InfixExpression {
+                                left: Box::new(Expression::Variable("theta".to_string())),
+                                operator: InfixOperator::Slash,
+                                right: Box::new(Expression::Number(Complex { re: 2.0, im: 0.0 })),
+                            }))
+                        }))
+                    }),
+                ],
+                vec![
+                    Expression::Infix(InfixExpression {
+                        left: Box::new(Expression::Prefix(PrefixExpression {
+                            operator: PrefixOperator::Minus,
+                            expression: Box::new(Expression::Number(Complex { re: 0.0, im: 1.0 }))
+                        })),
+                        operator: InfixOperator::Star,
+                        right: Box::new(Expression::FunctionCall(FunctionCallExpression {
+                            function: ExpressionFunction::Sine,
+                            expression: Box::new(Expression::Infix(InfixExpression {
+                                left: Box::new(Expression::Variable("theta".to_string())),
+                                operator: InfixOperator::Slash,
+                                right: Box::new(Expression::Number(Complex { re: 2.0, im: 0.0 }))
+                            }))
+                        }))
+                    }),
+                    Expression::FunctionCall(FunctionCallExpression {
+                        function: ExpressionFunction::Cosine,
+                        expression: Box::new(Expression::Infix(InfixExpression {
+                            left: Box::new(Expression::Variable("theta".to_string())),
+                            operator: InfixOperator::Slash,
+                            right: Box::new(Expression::Number(Complex { re: 2.0, im: 0.0 })),
+                        }))
                     }),
                 ],
             ]),


### PR DESCRIPTION
There were two issues to solve here:

1. Ignore casing for function calls

This may be controversial. The Quil spec only ever refers to these functions in their lowercase form, but `pyQuil` and its parser accepts any casing.

2. Fix parameter output

Parameters for `GateDefintion` and `WaveDefinition` are stored in a `Vec<String>`. These parameters are Quil identifiers prefixed with a `%` (aka "formal parameters). The parser recognizes these as formal parameters, but stores them on the instruction without the `%`. This meant they were getting printed back out as `Quil` without the `%`, which is incorrect. This fix restores the `%` on output, though it may make more sense to keep it in the parser.