### PR TITLE
fix: parse SWAP-PHASES

### DIFF
--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -1244,7 +1244,7 @@ impl Instruction {
                 Some(FrameMatchCondition::Specific(frame))
             }
             Instruction::SwapPhases(SwapPhases { frame_1, frame_2 }) => {
-                Some(FrameMatchCondition::And(vec![
+                Some(FrameMatchCondition::Or(vec![
                     FrameMatchCondition::Specific(frame_1),
                     FrameMatchCondition::Specific(frame_2),
                 ]))

--- a/src/parser/command.rs
+++ b/src/parser/command.rs
@@ -29,8 +29,8 @@ use crate::instruction::{
     Capture, CircuitDefinition, Comparison, ComparisonOperator, Declaration, Delay, Exchange,
     Fence, FrameDefinition, GateDefinition, Instruction, Jump, JumpUnless, JumpWhen, Label, Load,
     MeasureCalibrationDefinition, Measurement, Move, Pragma, Pulse, RawCapture, Reset,
-    SetFrequency, SetPhase, SetScale, ShiftFrequency, ShiftPhase, Store, UnaryLogic, UnaryOperator,
-    Waveform, WaveformDefinition,
+    SetFrequency, SetPhase, SetScale, ShiftFrequency, ShiftPhase, Store, SwapPhases, UnaryLogic,
+    UnaryOperator, Waveform, WaveformDefinition,
 };
 use crate::parser::instruction::parse_block;
 use crate::parser::InternalParserResult;
@@ -537,6 +537,17 @@ pub(crate) fn parse_shift_phase(input: ParserInput) -> InternalParserResult<Inst
     let (input, phase) = parse_expression(input)?;
 
     Ok((input, Instruction::ShiftPhase(ShiftPhase { frame, phase })))
+}
+
+/// Parse the contents of a `SWAP-PHASES` instruction.
+pub(crate) fn parse_swap_phases(input: ParserInput) -> InternalParserResult<Instruction> {
+    let (input, frame_1) = parse_frame_identifier(input)?;
+    let (input, frame_2) = parse_frame_identifier(input)?;
+
+    Ok((
+        input,
+        Instruction::SwapPhases(SwapPhases { frame_1, frame_2 }),
+    ))
 }
 
 /// Parse the contents of a `MEASURE` instruction.

--- a/src/parser/command.rs
+++ b/src/parser/command.rs
@@ -14,14 +14,16 @@
 
 use nom::{
     branch::alt,
-    combinator::{map, opt},
+    combinator::{map, opt, value},
     multi::{many0, many1, separated_list0, separated_list1},
     sequence::{delimited, pair, preceded, tuple},
 };
 
 use crate::{
-    instruction::{Convert, GateSpecification, GateType, Include, PragmaArgument},
+    expression::Expression,
+    instruction::{Convert, GateSpecification, GateType, Include, PragmaArgument, Qubit},
     parser::common::parse_variable_qubit,
+    real,
 };
 
 use crate::instruction::{
@@ -249,8 +251,8 @@ pub(crate) fn parse_defgate<'a>(input: ParserInput<'a>) -> InternalParserResult<
     let (input, gate_type) = opt(preceded(
         token!(As),
         alt((
-            map(token!(Matrix), |()| GateType::Matrix),
-            map(token!(Permutation), |()| GateType::Permutation),
+            value(GateType::Matrix, token!(Matrix)),
+            value(GateType::Permutation, token!(Permutation)),
         )),
     ))(input)?;
     let (input, _) = token!(Colon)(input)?;
@@ -322,9 +324,19 @@ pub(crate) fn parse_defcircuit<'a>(
 
 /// Parse the contents of a `DELAY` instruction.
 pub(crate) fn parse_delay<'a>(input: ParserInput<'a>) -> InternalParserResult<'a, Instruction> {
-    let (input, qubits) = many0(parse_qubit)(input)?;
+    let (input, mut qubits) = many0(parse_qubit)(input)?;
     let (input, frame_names) = many0(token!(String(v)))(input)?;
-    let (input, duration) = parse_expression(input)?;
+    // If there is no intervening frame name and the delay is an integer, it will have been parsed
+    // as a qubit. We check for and correct that condition here.
+    let (input, duration) = parse_expression(input).or_else(|e| {
+        if let Some(Qubit::Fixed(index)) = qubits.last() {
+            let duration = *index as f64;
+            qubits.pop();
+            Ok((input, Expression::Number(real!(duration))))
+        } else {
+            Err(e)
+        }
+    })?;
 
     Ok((
         input,

--- a/src/parser/common.rs
+++ b/src/parser/common.rs
@@ -372,7 +372,7 @@ mod describe_skip_newlines_and_comments {
 }
 
 #[cfg(test)]
-mod tests {
+pub mod tests {
     use crate::{
         expression::Expression,
         instruction::MemoryReference,
@@ -383,6 +383,64 @@ mod tests {
     use nom_locate::LocatedSpan;
 
     use super::{parse_matrix, parse_waveform_invocation};
+
+    /// A Quil program which uses all available instructions.
+    pub const KITCHEN_SINK_QUIL: &str = "DECLARE ro BIT[1]
+DEFGATE HADAMARD AS MATRIX:
+\t(1/sqrt(2)),(1/sqrt(2))
+\t(1/sqrt(2)),((-1)/sqrt(2))
+
+DEFGATE RX(%theta) AS MATRIX:
+\tcos((%theta/2)),((-1i)*sin((%theta/2)))
+\t((-1i)*sin((%theta/2))),cos((%theta/2))
+
+DEFGATE Name AS PERMUTATION:
+\t1, 0
+
+DEFCIRCUIT SIMPLE:
+\tX 0
+\tX 1
+
+RX 0
+CZ 0 1
+MEASURE 0 ro[0]
+RESET 0
+RESET
+CAPTURE 0 \"out\" my_waveform() iq[0]
+DEFCAL X 0:
+\tPULSE 0 \"xy\" my_waveform()
+
+DEFCAL RX(%theta) 0:
+\tPULSE 0 \"xy\" my_waveform()
+
+DEFCAL MEASURE 0 dest:
+\tDECLARE iq REAL[2]
+\tCAPTURE 0 \"out\" flat(duration: 1000000, iqs: (2+3i)) iq[0]
+
+DEFFRAME 0 \"xy\":
+\tSAMPLE-RATE: 3000
+
+DEFFRAME 0 \"xy\":
+\tDIRECTION: \"rx\"
+\tCENTER-FREQUENCY: 1000
+\tHARDWARE-OBJECT: \"some object\"
+\tINITIAL-FREQUENCY: 2000
+\tSAMPLE-RATE: 3000
+
+DELAY 0 100
+DELAY 0 \"xy\" 100000000
+FENCE 0
+FENCE 0 1
+PULSE 0 \"xy\" my_waveform()
+PULSE 0 1 \"cz\" my_parametrized_waveform(a: 1)
+RAW-CAPTURE 0 \"out\" 200000000 iqs[0]
+SET-FREQUENCY 0 \"xy\" 5400000000
+SET-PHASE 0 \"xy\" pi
+SET-SCALE 0 \"xy\" pi
+SHIFT-FREQUENCY 0 \"ro\" 6100000000
+SHIFT-PHASE 0 \"xy\" (-pi)
+SHIFT-PHASE 0 \"xy\" (%theta*(2/pi))
+SWAP-PHASES 2 3 \"xy\" 3 4 \"xy\"";
 
     #[test]
     fn waveform_invocation() {

--- a/src/parser/instruction.rs
+++ b/src/parser/instruction.rs
@@ -162,6 +162,7 @@ mod tests {
         ShiftPhase, SwapPhases, UnaryLogic, UnaryOperator, Waveform, WaveformDefinition,
         WaveformInvocation,
     };
+    use crate::parser::common::tests::KITCHEN_SINK_QUIL;
     use crate::parser::lexer::lex;
     use crate::{make_test, real, Program};
 
@@ -959,6 +960,12 @@ mod tests {
         ];
         assert_eq!(remainder.len(), 0);
         assert_eq!(parsed, expected);
+    }
+
+    /// Test that an entire sample program can be parsed without failure.
+    #[test]
+    fn kitchen_sink() {
+        Program::from_str(KITCHEN_SINK_QUIL).unwrap();
     }
 
     /// Assert that when a program is converted to a string, the conversion of

--- a/src/parser/instruction.rs
+++ b/src/parser/instruction.rs
@@ -813,8 +813,8 @@ mod tests {
                 }),
             }),
         ];
-        assert_eq!(remainder.len(), 0);
         assert_eq!(parsed, expected);
+        assert_eq!(remainder.len(), 0);
     }
 
     #[test]
@@ -845,8 +845,8 @@ mod tests {
                 },
             }),
         ];
-        assert_eq!(remainder.len(), 0);
         assert_eq!(parsed, expected);
+        assert_eq!(remainder.len(), 0);
     }
 
     #[test]
@@ -873,8 +873,8 @@ mod tests {
                 }),
             }),
         ];
-        assert_eq!(remainder.len(), 0);
         assert_eq!(parsed, expected);
+        assert_eq!(remainder.len(), 0);
     }
 
     #[test]
@@ -901,8 +901,8 @@ mod tests {
                 }),
             }),
         ];
-        assert_eq!(remainder.len(), 0);
         assert_eq!(parsed, expected);
+        assert_eq!(remainder.len(), 0);
     }
 
     #[test]
@@ -930,8 +930,8 @@ mod tests {
                 }),
             }),
         ];
-        assert_eq!(remainder.len(), 0);
         assert_eq!(parsed, expected);
+        assert_eq!(remainder.len(), 0);
     }
 
     #[test]
@@ -958,8 +958,8 @@ mod tests {
                 }),
             }),
         ];
-        assert_eq!(remainder.len(), 0);
         assert_eq!(parsed, expected);
+        assert_eq!(remainder.len(), 0);
     }
 
     /// Test that an entire sample program can be parsed without failure.

--- a/src/parser/instruction.rs
+++ b/src/parser/instruction.rs
@@ -89,6 +89,7 @@ pub(crate) fn parse_instruction(input: ParserInput) -> InternalParserResult<Inst
             Command::SetScale => command::parse_set_scale(remainder),
             Command::ShiftFrequency => command::parse_shift_frequency(remainder),
             Command::ShiftPhase => command::parse_shift_phase(remainder),
+            Command::SwapPhases => command::parse_swap_phases(remainder),
             Command::Store => command::parse_store(remainder),
             Command::Sub => command::parse_arithmetic(ArithmeticOperator::Subtract, remainder),
             Command::Xor => command::parse_logical_binary(BinaryOperator::Xor, remainder),
@@ -158,7 +159,8 @@ mod tests {
         ComparisonOperator, Convert, FrameDefinition, FrameIdentifier, Gate, GateDefinition,
         GateSpecification, Include, Instruction, Jump, JumpWhen, Label, MemoryReference, Move,
         Pulse, Qubit, RawCapture, Reset, SetFrequency, SetPhase, SetScale, ShiftFrequency,
-        ShiftPhase, UnaryLogic, UnaryOperator, Waveform, WaveformDefinition, WaveformInvocation,
+        ShiftPhase, SwapPhases, UnaryLogic, UnaryOperator, Waveform, WaveformDefinition,
+        WaveformInvocation,
     };
     use crate::parser::lexer::lex;
     use crate::{make_test, real, Program};
@@ -808,6 +810,38 @@ mod tests {
                     name: String::from("theta"),
                     index: 0,
                 }),
+            }),
+        ];
+        assert_eq!(remainder.len(), 0);
+        assert_eq!(parsed, expected);
+    }
+
+    #[test]
+    fn parse_swap_phases() {
+        let input =
+            LocatedSpan::new(r#"SWAP-PHASES 0 "rf" 1 "rf"; SWAP-PHASES 1 2 3 "rf" 4 5 6 "rf""#);
+        let tokens = lex(input).unwrap();
+        let (remainder, parsed) = parse_instructions(&tokens).unwrap();
+        let expected = vec![
+            Instruction::SwapPhases(SwapPhases {
+                frame_1: FrameIdentifier {
+                    name: String::from("rf"),
+                    qubits: vec![Qubit::Fixed(0)],
+                },
+                frame_2: FrameIdentifier {
+                    name: String::from("rf"),
+                    qubits: vec![Qubit::Fixed(1)],
+                },
+            }),
+            Instruction::SwapPhases(SwapPhases {
+                frame_1: FrameIdentifier {
+                    name: String::from("rf"),
+                    qubits: vec![Qubit::Fixed(1), Qubit::Fixed(2), Qubit::Fixed(3)],
+                },
+                frame_2: FrameIdentifier {
+                    name: String::from("rf"),
+                    qubits: vec![Qubit::Fixed(4), Qubit::Fixed(5), Qubit::Fixed(6)],
+                },
             }),
         ];
         assert_eq!(remainder.len(), 0);

--- a/src/parser/lexer/mod.rs
+++ b/src/parser/lexer/mod.rs
@@ -86,7 +86,6 @@ pub enum Command {
     SetScale,
     ShiftFrequency,
     ShiftPhase,
-    #[strum(to_string = "SWAP-PHASES")]
     SwapPhases,
     Store,
     Sub,

--- a/src/parser/lexer/mod.rs
+++ b/src/parser/lexer/mod.rs
@@ -86,6 +86,8 @@ pub enum Command {
     SetScale,
     ShiftFrequency,
     ShiftPhase,
+    #[strum(to_string = "SWAP-PHASES")]
+    SwapPhases,
     Store,
     Sub,
     Xor,
@@ -235,6 +237,7 @@ fn recognize_command_or_identifier(identifier: String) -> Token {
         "SET-FREQUENCY" => Token::Command(SetFrequency),
         "SET-PHASE" => Token::Command(SetPhase),
         "SET-SCALE" => Token::Command(SetScale),
+        "SWAP-PHASES" => Token::Command(SwapPhases),
         "SHIFT-FREQUENCY" => Token::Command(ShiftFrequency),
         "SHIFT-PHASE" => Token::Command(ShiftPhase),
         "LABEL" => Token::Command(Label),

--- a/src/parser/lexer/mod.rs
+++ b/src/parser/lexer/mod.rs
@@ -386,6 +386,8 @@ mod tests {
     use nom_locate::LocatedSpan;
     use rstest::*;
 
+    use crate::parser::common::tests::KITCHEN_SINK_QUIL;
+
     use super::{lex, Command, Operator, Token};
 
     #[test]
@@ -566,66 +568,8 @@ mod tests {
 
     /// Test that an entire sample program can be lexed without failure.
     #[test]
-    fn whole_program() {
-        let input = "DECLARE ro BIT[1]
-      DEFGATE HADAMARD AS MATRIX:
-      \t(1/sqrt(2)),(1/sqrt(2))
-      \t(1/sqrt(2)),((-1)/sqrt(2))
-
-      DEFGATE RX(%theta) AS MATRIX:
-      \tcos((%theta/2)),((-1i)*sin((%theta/2)))
-      \t((-1i)*sin((%theta/2))),cos((%theta/2))
-
-      DEFGATE Name AS PERMUTATION:
-      \t1,0
-      \t0,1
-
-      DEFCIRCUIT SIMPLE:
-      \tX 0
-      \tX 1
-
-      RX 0
-      CZ 0 1
-      MEASURE 0 ro[0]
-      RESET 0
-      RESET
-      CAPTURE 0 \"out\" my_waveform() iq[0]
-      DEFCAL X 0:
-      \tPULSE 0 \"xy\" my_waveform()
-
-      DEFCAL RX(%theta) 0:
-      \tPULSE 0 \"xy\" my_waveform()
-
-      DEFCAL MEASURE 0 dest:
-      \tDECLARE iq REAL[2]
-      \tCAPTURE 0 \"out\" flat(duration: 1000000, iqs: (2+3i)) iq[0]
-
-      DEFFRAME 0 \"xy\":
-      \tSAMPLE-RATE: 3000
-
-      DEFFRAME 0 \"xy\":
-      \tDIRECTION: \"rx\"
-      \tCENTER-FREQUENCY: 1000
-      \tHARDWARE-OBJECT: \"some object\"
-      \tINITIAL-FREQUENCY: 2000
-      \tSAMPLE-RATE: 3000
-
-      DELAY 0 100
-      DELAY 0 \"xy\" 100000000
-      FENCE 0
-      FENCE 0 1
-      PULSE 0 \"xy\" my_waveform()
-      PULSE 0 1 \"cz\" my_parametrized_waveform(a: 1)
-      RAW-CAPTURE 0 \"out\" 200000000 iqs[0]
-      SET-FREQUENCY 0 \"xy\" 5400000000
-      SET-PHASE 0 \"xy\" pi
-      SET-SCALE 0 \"xy\" pi
-      SHIFT-FREQUENCY 0 \"ro\" 6100000000
-      SHIFT-PHASE 0 \"xy\" (-pi)
-      SHIFT-PHASE 0 \"xy\" (%theta*(2/pi))
-      SWAP-PHASES 2 3 \"xy\" 3 4 \"xy\"";
-
-        let input = LocatedSpan::new(input);
+    fn kitchen_sink() {
+        let input = LocatedSpan::new(KITCHEN_SINK_QUIL);
 
         lex(input).unwrap();
     }

--- a/src/program/frame.rs
+++ b/src/program/frame.rs
@@ -77,6 +77,14 @@ impl FrameSet {
                 .map(|c| self.get_matching_keys(c))
                 .reduce(|acc, el| acc.into_iter().filter(|&v| el.contains(v)).collect())
                 .unwrap_or_default(),
+            FrameMatchCondition::Or(conditions) => conditions
+                .into_iter()
+                .map(|c| self.get_matching_keys(c))
+                .reduce(|mut acc, el| {
+                    acc.extend(el);
+                    acc
+                })
+                .unwrap_or_default(),
         }
     }
 
@@ -150,4 +158,7 @@ pub(crate) enum FrameMatchCondition<'a> {
 
     /// Return all frames which match all of these conditions
     And(Vec<FrameMatchCondition<'a>>),
+
+    /// Return all frames which match any of these conditions
+    Or(Vec<FrameMatchCondition<'a>>),
 }

--- a/src/program/frame.rs
+++ b/src/program/frame.rs
@@ -79,12 +79,8 @@ impl FrameSet {
                 .unwrap_or_default(),
             FrameMatchCondition::Or(conditions) => conditions
                 .into_iter()
-                .map(|c| self.get_matching_keys(c))
-                .reduce(|mut acc, el| {
-                    acc.extend(el);
-                    acc
-                })
-                .unwrap_or_default(),
+                .flat_map(|c| self.get_matching_keys(c))
+                .collect(),
         }
     }
 

--- a/src/program/mod.rs
+++ b/src/program/mod.rs
@@ -487,6 +487,11 @@ DEFFRAME 0 1 \"2q\":
             (r#"DELAY 1 1.0"#, vec![r#"1 "c""#], vec![r#"1 "c""#]),
             (r#"DELAY 1 "c" 1.0"#, vec![r#"1 "c""#], vec![r#"1 "c""#]),
             (r#"DELAY 0 1 1.0"#, vec![r#"0 1 "2q""#], vec![r#"0 1 "2q""#]),
+            (
+                r#"SWAP-PHASES 0 "a" 0 "b""#,
+                vec![r#"0 "a""#, r#"0 "b""#],
+                vec![r#"0 "a""#, r#"0 "b""#],
+            ),
         ] {
             let instruction = Instruction::parse(instruction_string).unwrap();
             let used_frames: HashSet<String> = program


### PR DESCRIPTION
- Adds a parser for SWAP-PHASES with a test
- Covers the parser with a test case previously limited to the lexer - a "kitchen sink" program. That had a SWAP-PHASES instruction all along, which lexed fine ... as a gate.
- This exposed two failures in parsing that program:
  - `DEFGATE Name as PERMUTATION` incorrectly had a second line. Permutation-type gate definitions have a single-line block. Fixed the test case.
  - `DELAY 0 1` exposed an edge case in parsing delays which is now handled - the `1` should be interpreted as the duration rather than a qubit index, even though the two parsers overlap on integers.
- Fixes `SWAP-PHASES` frame matching by adding `FrameMatchCondition::Or`

Closes https://github.com/rigetti/quil-rs/issues/199