### PR TITLE
fix: mark additional instructions as scheduled

### DIFF
--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -1312,7 +1312,13 @@ impl Instruction {
             | Instruction::Delay(_)
             | Instruction::Fence(_)
             | Instruction::Pulse(_)
-            | Instruction::RawCapture(_) => true,
+            | Instruction::RawCapture(_)
+            | Instruction::SetFrequency(_)
+            | Instruction::SetPhase(_)
+            | Instruction::SetScale(_)
+            | Instruction::ShiftFrequency(_)
+            | Instruction::ShiftPhase(_)
+            | Instruction::SwapPhases(_) => true,
             Instruction::Arithmetic(_)
             | Instruction::BinaryLogic(_)
             | Instruction::CalibrationDefinition(_)
@@ -1337,13 +1343,7 @@ impl Instruction {
             | Instruction::Nop
             | Instruction::Pragma(_)
             | Instruction::Reset(_)
-            | Instruction::SetFrequency(_)
-            | Instruction::SetPhase(_)
-            | Instruction::SetScale(_)
-            | Instruction::ShiftFrequency(_)
-            | Instruction::ShiftPhase(_)
             | Instruction::Store(_)
-            | Instruction::SwapPhases(_)
             | Instruction::UnaryLogic(_)
             | Instruction::WaveformDefinition(_) => false,
         }

--- a/src/program/snapshots/quil_rs__program__graphviz_dot__tests__graph__pulse_after_set_frequency.snap
+++ b/src/program/snapshots/quil_rs__program__graphviz_dot__tests__graph__pulse_after_set_frequency.snap
@@ -9,13 +9,15 @@ digraph {
     label="block_0";
     node [style="filled"];
     "block_0_start" [shape=circle, label="start"];
-    "block_0_start" -> "block_0_0" [label="ordering"];
+    "block_0_start" -> "block_0_0" [label="ordering
+timing"];
     "block_0_start" -> "block_0_1" [label="ordering
 timing"];
     "block_0_start" -> "block_0_end" [label="ordering
 timing"];
     "block_0_0" [shape=rectangle, label="[0] SET-FREQUENCY 0 \"rf\" 3000000000"];
-    "block_0_0" -> "block_0_1" [label="ordering"];
+    "block_0_0" -> "block_0_1" [label="ordering
+timing"];
     "block_0_1" [shape=rectangle, label="[1] PULSE 0 \"rf\" test"];
     "block_0_1" -> "block_0_end" [label="ordering
 timing"];


### PR DESCRIPTION
Closes #202 

Several instructions don't participate directly in the pulse program, but should still be scheduled relative to instructions which do. This is important for FREQUENCY and PHASE operations especially, because their effects vary depending on when they are executed. It is not enough to ensure correct ordering, as `main` does today.