### PR TITLE
fix: The imaginary part of a complex number will now always be formatted as a floating point number.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -616,9 +616,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.15.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "oorandom"
@@ -761,6 +761,7 @@ dependencies = [
  "nom",
  "nom_locate",
  "num-complex",
+ "once_cell",
  "petgraph",
  "proptest",
  "proptest-derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ lexical = "6.1.1"
 nom = "7.1.1"
 nom_locate = "4.0.0"
 num-complex = "0.4.0"
+once_cell = "1.17.1"
 petgraph = "0.6.2"
 serde = { version = "1.0.125", features = ["derive"] }
 strum = { version = "0.24.1", features = ["derive"] }

--- a/deny.toml
+++ b/deny.toml
@@ -19,7 +19,7 @@ vulnerability = "deny"
 # The lint level for unmaintained crates
 unmaintained = "deny"
 # The lint level for crates that have been yanked from their source registry
-yanked = "deny"
+yanked = "warn"
 # The lint level for crates with security notices.
 notice = "deny"
 # A list of advisory IDs to ignore. Note that ignored advisories will still
@@ -77,6 +77,7 @@ skip-tree = [
     { name = "hermit-abi", version = "*" },           # various dependencies rely on two versions of this
     { name = "memoffset", version = "*" },           # various dependencies rely on two versions of this
     { name = "windows-sys", version = "*" },           # various dependencies rely on two versions of this
+    { name = "crossbeam-channel", version = "*" },           # various dependencies rely on two versions of this
 ]
 
 # This section is considered when running `cargo deny check sources`.

--- a/deny.toml
+++ b/deny.toml
@@ -77,7 +77,6 @@ skip-tree = [
     { name = "hermit-abi", version = "*" },           # various dependencies rely on two versions of this
     { name = "memoffset", version = "*" },           # various dependencies rely on two versions of this
     { name = "windows-sys", version = "*" },           # various dependencies rely on two versions of this
-    { name = "crossbeam-channel", version = "*" },           # various dependencies rely on two versions of this
 ]
 
 # This section is considered when running `cargo deny check sources`.

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -15,6 +15,7 @@
 use lexical::{format, to_string_with_options, WriteFloatOptions};
 use nom_locate::LocatedSpan;
 use num_complex::Complex64;
+use once_cell::sync::Lazy;
 use std::collections::{hash_map::DefaultHasher, HashMap};
 use std::f64::consts::PI;
 use std::fmt;
@@ -452,6 +453,24 @@ impl FromStr for Expression {
     }
 }
 
+static FORMAT_REAL_OPTIONS: Lazy<WriteFloatOptions> = Lazy::new(|| {
+    WriteFloatOptions::builder()
+        .negative_exponent_break(NonZeroI32::new(-5))
+        .positive_exponent_break(NonZeroI32::new(15))
+        .trim_floats(true)
+        .build()
+        .expect("options are valid")
+});
+
+static FORMAT_COMPLEX_OPTIONS: Lazy<WriteFloatOptions> = Lazy::new(|| {
+    WriteFloatOptions::builder()
+        .negative_exponent_break(NonZeroI32::new(-5))
+        .positive_exponent_break(NonZeroI32::new(15))
+        .trim_floats(false)
+        .build()
+        .expect("options are valid")
+});
+
 /// Format a num_complex::Complex64 value in a way that omits the real or imaginary part when
 /// reasonable. That is:
 ///
@@ -475,27 +494,21 @@ fn format_complex(value: &Complex64) -> String {
     //   - and trim floats can only take a bool and both branches are safe.
     // As of version 6.1.1 of lexical, this means `OPTIONS.is_valid()` must be true. However, we
     // still `assert!` it just to be "safe."
-    const OPTIONS: WriteFloatOptions = unsafe {
-        let options = WriteFloatOptions::builder()
-            .negative_exponent_break(NonZeroI32::new(-5))
-            .positive_exponent_break(NonZeroI32::new(15))
-            .trim_floats(true)
-            .build_unchecked();
-        assert!(options.is_valid());
-        options
-    };
     if value.re == 0f64 && value.im == 0f64 {
         "0".to_owned()
     } else if value.im == 0f64 {
-        to_string_with_options::<_, FORMAT>(value.re, &OPTIONS)
+        to_string_with_options::<_, FORMAT>(value.re, &FORMAT_REAL_OPTIONS)
     } else if value.re == 0f64 {
-        to_string_with_options::<_, FORMAT>(value.im, &OPTIONS) + "i"
+        to_string_with_options::<_, FORMAT>(value.im, &FORMAT_COMPLEX_OPTIONS) + "i"
     } else {
-        let mut out = to_string_with_options::<_, FORMAT>(value.re, &OPTIONS);
+        let mut out = to_string_with_options::<_, FORMAT>(value.re, &FORMAT_REAL_OPTIONS);
         if value.im > 0f64 {
             out.push('+')
         }
-        out.push_str(&to_string_with_options::<_, FORMAT>(value.im, &OPTIONS));
+        out.push_str(&to_string_with_options::<_, FORMAT>(
+            value.im,
+            &FORMAT_COMPLEX_OPTIONS,
+        ));
         out.push('i');
         out
     }
@@ -922,6 +935,8 @@ mod tests {
             (Complex64::new(0.0, 0.0), "0"),
             (Complex64::new(-0.0, 0.0), "0"),
             (Complex64::new(-0.0, -0.0), "0"),
+            (Complex64::new(0.0, 1.0), "1.0i"),
+            (Complex64::new(1.0, -1.0), "1-1.0i"),
             (Complex64::new(1.234, 0.0), "1.234"),
             (Complex64::new(0.0, 1.234), "1.234i"),
             (Complex64::new(-1.234, 0.0), "-1.234"),
@@ -930,7 +945,7 @@ mod tests {
             (Complex64::new(-1.234, 5.678), "-1.234+5.678i"),
             (Complex64::new(1.234, -5.678), "1.234-5.678i"),
             (Complex64::new(-1.234, -5.678), "-1.234-5.678i"),
-            (Complex64::new(1e100, 2e-100), "1e100+2e-100i"),
+            (Complex64::new(1e100, 2e-100), "1e100+2.0e-100i"),
         ] {
             assert_eq!(format_complex(x), *s);
         }


### PR DESCRIPTION
closes #204