### PR TITLE
fix: The parser now follows the correct precedence rules for ungrouped infix expressions

### DIFF
--- a/src/expression.rs
+++ b/src/expression.rs
@@ -545,6 +545,32 @@ fn format_inner_expression(f: &mut fmt::Formatter, expression: &Expression) -> f
     }
 }
 
+#[cfg(test)]
+mod test {
+    use crate::{
+        expression::{Expression, InfixOperator, PrefixOperator},
+        real,
+    };
+
+    #[test]
+    fn formats_nested_expression() {
+        let expression = Expression::Infix {
+            left: Box::new(Expression::Prefix {
+                operator: PrefixOperator::Minus,
+                expression: Box::new(Expression::Number(real!(3f64))),
+            }),
+            operator: InfixOperator::Star,
+            right: Box::new(Expression::Infix {
+                left: Box::new(Expression::PiConstant),
+                operator: InfixOperator::Slash,
+                right: Box::new(Expression::Number(real!(2f64))),
+            }),
+        };
+
+        assert_eq!(expression.to_string(), "-3*(pi/2)");
+    }
+}
+
 /// A function defined within Quil syntax.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(test, derive(Arbitrary))]

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -513,15 +513,35 @@ impl fmt::Display for Expression {
                 left,
                 operator,
                 right,
-            } => write!(f, "({}{}{})", left, operator, right),
+            } => {
+                format_inner_expression(f, left)?;
+                write!(f, "{}", operator)?;
+                format_inner_expression(f, right)
+            }
             Number(value) => write!(f, "{}", format_complex(value)),
             PiConstant => write!(f, "pi"),
             Prefix {
                 operator,
                 expression,
-            } => write!(f, "({}{})", operator, expression),
+            } => {
+                write!(f, "{}", operator)?;
+                format_inner_expression(f, expression)
+            }
             Variable(identifier) => write!(f, "%{}", identifier),
         }
+    }
+}
+
+/// Utility function to wrap infix expressions that are part of an expression in parentheses, so
+/// that correct precedence rules are enforced.
+fn format_inner_expression(f: &mut fmt::Formatter, expression: &Expression) -> fmt::Result {
+    match expression {
+        Expression::Infix {
+            left,
+            operator,
+            right,
+        } => write!(f, "({left}{operator}{right})"),
+        _ => write!(f, "{expression}"),
     }
 }
 

--- a/src/parser/expression.rs
+++ b/src/parser/expression.rs
@@ -281,6 +281,7 @@ mod tests {
             "cis(%theta)",
             "%a+%b",
             "(pi/2)+(1*theta[0])",
+            "3--2",
         ];
 
         for case in cases {
@@ -381,6 +382,23 @@ mod tests {
                     index: 0,
                 })),
             }),
+        }
+    );
+
+    test!(
+        infix_minus_negative,
+        parse_expression,
+        "-3 - -2",
+        Expression::Infix {
+            left: Box::new(Expression::Prefix {
+                operator: PrefixOperator::Minus,
+                expression: Box::new(Expression::Number(real!(3f64))),
+            }),
+            operator: InfixOperator::Minus,
+            right: Box::new(Expression::Prefix {
+                operator: PrefixOperator::Minus,
+                expression: Box::new(Expression::Number(real!(2.0)))
+            })
         }
     );
 

--- a/src/parser/expression.rs
+++ b/src/parser/expression.rs
@@ -267,11 +267,11 @@ mod tests {
         let cases = vec![
             "pi",
             "sin(pi)",
-            "(1+(2*3))",
-            "((1+2)*3)",
+            "1+(2*3)",
+            "(1+2)*3",
             "%theta",
             "cis(%theta)",
-            "(%a+%b)",
+            "%a+%b",
         ];
 
         for case in cases {


### PR DESCRIPTION
closes #206