### PR TITLE
fix!: Expression parameter strings are now delimited by a comma. `get_expression_parameter_string` and `get_string_parameter_string` have been removed from the instruction module.

### DIFF
--- a/quil-rs/src/instruction/calibration.rs
+++ b/quil-rs/src/instruction/calibration.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use crate::{
     instruction::{
-        format_instructions, get_expression_parameter_string, Expression, GateModifier,
+        format_instructions, write_expression_parameter_string, Expression, GateModifier,
         Instruction, Qubit,
     },
     validation::identifier::{validate_identifier, IdentifierValidationError},
@@ -45,8 +45,8 @@ impl Calibration {
 
 impl fmt::Display for Calibration {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let parameter_str = get_expression_parameter_string(&self.parameters);
-        write!(f, "DEFCAL {}{}", self.name, parameter_str)?;
+        write!(f, "DEFCAL {}", self.name)?;
+        write_expression_parameter_string(f, &self.parameters)?;
         write_qubit_parameters(f, &self.qubits)?;
         write!(f, ":")?;
         for instruction in &self.instructions {

--- a/quil-rs/src/instruction/circuit.rs
+++ b/quil-rs/src/instruction/circuit.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use super::{get_string_parameter_string, Instruction};
+use super::{write_parameter_string, Instruction};
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct CircuitDefinition {
@@ -30,10 +30,7 @@ impl CircuitDefinition {
 impl fmt::Display for CircuitDefinition {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "DEFCIRCUIT {}", self.name)?;
-        if !self.parameters.is_empty() {
-            let parameter_str = get_string_parameter_string(&self.parameters);
-            write!(f, "{parameter_str}")?;
-        }
+        write_parameter_string(f, &self.parameters)?;
         for qubit_variable in &self.qubit_variables {
             write!(f, " {qubit_variable}")?;
         }

--- a/quil-rs/src/instruction/gate.rs
+++ b/quil-rs/src/instruction/gate.rs
@@ -2,13 +2,13 @@ use std::{collections::HashSet, fmt};
 
 use crate::{
     expression::Expression,
-    instruction::get_string_parameter_string,
+    instruction::write_parameter_string,
     validation::identifier::{
         validate_identifier, validate_user_identifier, IdentifierValidationError,
     },
 };
 
-use super::{format_qubits, get_expression_parameter_string, Qubit};
+use super::{write_expression_parameter_string, write_qubits, Qubit};
 
 /// A struct encapsulating all the properties of a Quil Quantum Gate.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -118,14 +118,13 @@ impl Gate {
 
 impl fmt::Display for Gate {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let parameter_str = get_expression_parameter_string(&self.parameters);
-
-        let qubit_str = format_qubits(&self.qubits);
         for modifier in &self.modifiers {
             write!(f, "{modifier} ")?;
         }
 
-        write!(f, "{}{} {}", self.name, parameter_str, qubit_str)
+        write!(f, "{}", self.name)?;
+        write_expression_parameter_string(f, &self.parameters)?;
+        write_qubits(f, &self.qubits)
     }
 }
 
@@ -278,12 +277,8 @@ impl GateDefinition {
 
 impl fmt::Display for GateDefinition {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "DEFGATE {}{}",
-            self.name,
-            get_string_parameter_string(&self.parameters)
-        )?;
+        write!(f, "DEFGATE {}", self.name,)?;
+        write_parameter_string(f, &self.parameters)?;
         match &self.specification {
             GateSpecification::Matrix(_) => writeln!(f, " AS MATRIX:")?,
             GateSpecification::Permutation(_) => writeln!(f, " AS PERMUTATION:")?,

--- a/quil-rs/src/instruction/mod.rs
+++ b/quil-rs/src/instruction/mod.rs
@@ -244,14 +244,16 @@ pub fn write_comma_separated_list(
     f: &mut fmt::Formatter,
     values: &[impl fmt::Display],
 ) -> fmt::Result {
-    if values.is_empty() {
-        return Ok(());
+    let mut iter = values.iter();
+    
+    if let Some(value) = iter.next() {
+        write!(f, "{value}")?;
     }
-
-    write!(f, "{}", values[0])?;
-    for value in values[1..].iter() {
+    
+    for value in iter {
         write!(f, ", {value}")?;
     }
+    
     Ok(())
 }
 

--- a/quil-rs/src/instruction/mod.rs
+++ b/quil-rs/src/instruction/mod.rs
@@ -222,6 +222,13 @@ pub fn format_qubits(qubits: &[Qubit]) -> String {
         .join(" ")
 }
 
+fn write_qubits(f: &mut fmt::Formatter, qubits: &[Qubit]) -> fmt::Result {
+    for qubit in qubits {
+        write!(f, " {qubit}")?;
+    }
+    Ok(())
+}
+
 /// Format qubits as a Quil parameter list, where each variable qubit must be prefixed with a `%`.
 fn write_qubit_parameters(f: &mut fmt::Formatter, qubits: &[Qubit]) -> fmt::Result {
     for qubit in qubits.iter() {
@@ -234,26 +241,48 @@ fn write_qubit_parameters(f: &mut fmt::Formatter, qubits: &[Qubit]) -> fmt::Resu
     Ok(())
 }
 
-pub fn get_expression_parameter_string(parameters: &[Expression]) -> String {
-    if parameters.is_empty() {
-        return String::new();
+pub fn write_comma_separated_list(
+    f: &mut fmt::Formatter,
+    values: &[impl fmt::Display],
+) -> fmt::Result {
+    if values.is_empty() {
+        return Ok(());
     }
 
-    let parameter_str: String = parameters.iter().map(|e| format!("{e}")).collect();
-    format!("({parameter_str})")
+    write!(f, "{}", values[0])?;
+    for value in values[1..].iter() {
+        write!(f, ", {value}")?;
+    }
+    Ok(())
 }
 
-pub fn get_string_parameter_string(parameters: &[String]) -> String {
+pub fn write_expression_parameter_string(
+    f: &mut fmt::Formatter,
+    parameters: &[Expression],
+) -> fmt::Result {
     if parameters.is_empty() {
-        return String::new();
+        return Ok(());
     }
 
-    let parameter_str: String = parameters
-        .iter()
-        .map(|param| format!("%{param}"))
-        .collect::<Vec<_>>()
-        .join(",");
-    format!("({parameter_str})")
+    write!(f, "(")?;
+    write!(f, "{}", parameters[0])?;
+    for parameter in parameters[1..].iter() {
+        write!(f, ", {parameter}")?;
+    }
+    write!(f, ")")
+}
+
+pub fn write_parameter_string(f: &mut fmt::Formatter, parameters: &[String]) -> fmt::Result {
+    if parameters.is_empty() {
+        return Ok(());
+    }
+
+    write!(f, "(")?;
+    write!(f, "%{}", parameters[0])?;
+    for parameter in parameters[1..].iter() {
+        write!(f, ", %{parameter}")?;
+    }
+    write!(f, ")")
 }
 
 impl fmt::Display for Instruction {

--- a/quil-rs/src/instruction/mod.rs
+++ b/quil-rs/src/instruction/mod.rs
@@ -245,15 +245,15 @@ pub fn write_comma_separated_list(
     values: &[impl fmt::Display],
 ) -> fmt::Result {
     let mut iter = values.iter();
-    
+
     if let Some(value) = iter.next() {
         write!(f, "{value}")?;
     }
-    
+
     for value in iter {
         write!(f, ", {value}")?;
     }
-    
+
     Ok(())
 }
 

--- a/quil-rs/src/instruction/mod.rs
+++ b/quil-rs/src/instruction/mod.rs
@@ -228,7 +228,7 @@ fn write_qubits(f: &mut fmt::Formatter, qubits: &[Qubit]) -> fmt::Result {
     Ok(())
 }
 
-/// Format qubits as a Quil parameter list, where each variable qubit must be prefixed with a `%`.
+/// Write qubits as a Quil parameter list, where each variable qubit must be prefixed with a `%`.
 fn write_qubit_parameters(f: &mut fmt::Formatter, qubits: &[Qubit]) -> fmt::Result {
     for qubit in qubits.iter() {
         match qubit {
@@ -240,24 +240,27 @@ fn write_qubit_parameters(f: &mut fmt::Formatter, qubits: &[Qubit]) -> fmt::Resu
     Ok(())
 }
 
-pub fn write_comma_separated_list(
+/// Write the values as a comma separated list, with an optional prefix before each value.
+fn write_comma_separated_list(
     f: &mut fmt::Formatter,
     values: &[impl fmt::Display],
+    prefix: Option<&str>,
 ) -> fmt::Result {
+    let prefix = prefix.unwrap_or_default();
     let mut iter = values.iter();
 
     if let Some(value) = iter.next() {
-        write!(f, "{value}")?;
+        write!(f, "{prefix}{value}")?;
     }
 
     for value in iter {
-        write!(f, ", {value}")?;
+        write!(f, ", {prefix}{value}")?;
     }
 
     Ok(())
 }
 
-pub fn write_expression_parameter_string(
+fn write_expression_parameter_string(
     f: &mut fmt::Formatter,
     parameters: &[Expression],
 ) -> fmt::Result {
@@ -266,23 +269,17 @@ pub fn write_expression_parameter_string(
     }
 
     write!(f, "(")?;
-    write!(f, "{}", parameters[0])?;
-    for parameter in parameters[1..].iter() {
-        write!(f, ", {parameter}")?;
-    }
+    write_comma_separated_list(f, parameters, None)?;
     write!(f, ")")
 }
 
-pub fn write_parameter_string(f: &mut fmt::Formatter, parameters: &[String]) -> fmt::Result {
+fn write_parameter_string(f: &mut fmt::Formatter, parameters: &[String]) -> fmt::Result {
     if parameters.is_empty() {
         return Ok(());
     }
 
     write!(f, "(")?;
-    write!(f, "%{}", parameters[0])?;
-    for parameter in parameters[1..].iter() {
-        write!(f, ", %{parameter}")?;
-    }
+    write_comma_separated_list(f, parameters, Some("%"))?;
     write!(f, ")")
 }
 

--- a/quil-rs/src/instruction/waveform.rs
+++ b/quil-rs/src/instruction/waveform.rs
@@ -33,7 +33,7 @@ impl fmt::Display for WaveformDefinition {
         write!(f, "DEFWAVEFORM {}", self.name)?;
         write_parameter_string(f, &self.definition.parameters)?;
         write!(f, ":\n\t")?;
-        write_comma_separated_list(f, &self.definition.matrix)
+        write_comma_separated_list(f, &self.definition.matrix, None)
     }
 }
 

--- a/quil-rs/src/instruction/waveform.rs
+++ b/quil-rs/src/instruction/waveform.rs
@@ -1,8 +1,8 @@
 use std::{collections::HashMap, fmt};
 
-use crate::expression::Expression;
+use crate::{expression::Expression, instruction::write_comma_separated_list};
 
-use super::get_string_parameter_string;
+use super::write_parameter_string;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Waveform {
@@ -30,18 +30,10 @@ impl WaveformDefinition {
 
 impl fmt::Display for WaveformDefinition {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "DEFWAVEFORM {}{}:\n\t{}",
-            self.name,
-            get_string_parameter_string(&self.definition.parameters),
-            self.definition
-                .matrix
-                .iter()
-                .map(|e| format!("{e}"))
-                .collect::<Vec<_>>()
-                .join(", ")
-        )
+        write!(f, "DEFWAVEFORM {}", self.name)?;
+        write_parameter_string(f, &self.definition.parameters)?;
+        write!(f, ":\n\t")?;
+        write_comma_separated_list(f, &self.definition.matrix)
     }
 }
 


### PR DESCRIPTION
List of expressions were being printed without a delimmiting comma. This fixes that issue, as well as refactors some related methods to not allocate in Display.