### PR TITLE
refactor: optimize terminate_working_block

### DIFF
--- a/quil-rs/Cargo.toml
+++ b/quil-rs/Cargo.toml
@@ -39,3 +39,7 @@ harness = false
 [[bench]]
 name = "get_frames_for_instruction"
 harness = false
+
+[[bench]]
+name = "scheduled_program_from_program"
+harness = false

--- a/quil-rs/benches/corpus.rs
+++ b/quil-rs/benches/corpus.rs
@@ -16,7 +16,7 @@ fn bench_config_from_file(path: &Path) -> Option<QuilBenchConfig> {
         .file_name()
         .expect("path should have file name component")
         .to_str()
-        .expect("bad filename")
+        .expect("filename should be valid")
         .to_string();
 
     if quil_rs::Program::from_str(&program).is_ok() {

--- a/quil-rs/benches/corpus.rs
+++ b/quil-rs/benches/corpus.rs
@@ -1,4 +1,9 @@
-use std::{fs, path::{Path, PathBuf}, process::Command, str::FromStr};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::Command,
+    str::FromStr,
+};
 
 pub struct QuilBenchConfig {
     pub name: String,
@@ -10,8 +15,7 @@ fn bench_config_from_file(path: &Path) -> Option<QuilBenchConfig> {
         return None;
     }
 
-    let program =
-        fs::read_to_string(path).expect("failed to read quil program file");
+    let program = fs::read_to_string(path).expect("failed to read quil program file");
     let name = path
         .file_name()
         .expect("path should have file name component")
@@ -39,12 +43,9 @@ pub fn from_corpus() -> Vec<QuilBenchConfig> {
     let dir = fs::read_dir(corpus_dir).expect("failed to locate quil corpus directory");
 
     dir.filter_map(Result::ok)
-        .filter_map(|entry| {
-            bench_config_from_file(&entry.path())
-        })
-        .chain({
-            bench_config_from_file(&PathBuf::from(SAMPLE_CALIBRATIONS))
-        }).collect()
+        .filter_map(|entry| bench_config_from_file(&entry.path()))
+        .chain({ bench_config_from_file(&PathBuf::from(SAMPLE_CALIBRATIONS)) })
+        .collect()
 }
 
 // in the event someone wants to run the benchmarks locally, this will download the corpus of quil used

--- a/quil-rs/benches/corpus.rs
+++ b/quil-rs/benches/corpus.rs
@@ -1,15 +1,36 @@
-use std::{fs, path::Path, process::Command, str::FromStr};
+use std::{fs, path::{Path, PathBuf}, process::Command, str::FromStr};
 
 pub struct QuilBenchConfig {
     pub name: String,
     pub program: String,
 }
 
+fn bench_config_from_file(path: &Path) -> Option<QuilBenchConfig> {
+    if !path.is_file() {
+        return None;
+    }
+
+    let program =
+        fs::read_to_string(path).expect("failed to read quil program file");
+    let name = path
+        .file_name()
+        .expect("path should have file name component")
+        .to_str()
+        .expect("bad filename")
+        .to_string();
+
+    if quil_rs::Program::from_str(&program).is_ok() {
+        Some(QuilBenchConfig { name, program })
+    } else {
+        None
+    }
+}
+
 pub fn from_corpus() -> Vec<QuilBenchConfig> {
     const PATH_SRC: &str = "benches/quilc/tests/good-test-files";
+    const SAMPLE_CALIBRATIONS: &str = "benches/sample-calibrations.quil";
 
     // collect valid quil programs
-    let mut programs = vec![];
     let corpus_dir = Path::new(PATH_SRC);
     if !corpus_dir.exists() {
         init_submodules()
@@ -18,28 +39,12 @@ pub fn from_corpus() -> Vec<QuilBenchConfig> {
     let dir = fs::read_dir(corpus_dir).expect("failed to locate quil corpus directory");
 
     dir.filter_map(Result::ok)
-        .filter(|entry| {
-            entry
-                .metadata()
-                .expect("failed to read file metadata")
-                .is_file()
+        .filter_map(|entry| {
+            bench_config_from_file(&entry.path())
         })
-        .for_each(|entry| {
-            let program =
-                fs::read_to_string(entry.path()).expect("failed to read quil program file");
-            let name = entry
-                .file_name()
-                .to_str()
-                .expect("bad filename")
-                .to_string();
-
-            // attempt to parse the quil once, ignoring unparsable input (only benchmark parsable code)
-            if quil_rs::Program::from_str(&program).is_ok() {
-                programs.push(QuilBenchConfig { name, program });
-            }
-        });
-
-    programs
+        .chain({
+            bench_config_from_file(&PathBuf::from(SAMPLE_CALIBRATIONS))
+        }).collect()
 }
 
 // in the event someone wants to run the benchmarks locally, this will download the corpus of quil used

--- a/quil-rs/benches/scheduled_program_from_program.rs
+++ b/quil-rs/benches/scheduled_program_from_program.rs
@@ -1,4 +1,4 @@
-use criterion::{criterion_group, criterion_main, Criterion, black_box, BatchSize};
+use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion};
 use quil_rs::program::graph::ScheduledProgram;
 use std::str::FromStr;
 
@@ -6,23 +6,28 @@ mod corpus;
 
 fn benchmark_quil_corpus(c: &mut Criterion) {
     let mut group = c.benchmark_group("ScheduleProgram::from_program");
-    corpus::from_corpus().iter().filter(|cfg| {
-        // Ignore any programs that would fail to schedule
-        match quil_rs::Program::from_str(&cfg.program) {
-            Err(_) => false,
-            Ok(program) => ScheduledProgram::from_program(&program).is_ok(),
-        }
-    }).for_each(|cfg| {
-        group.bench_function(&cfg.name, |b| {
-            b.iter_batched(|| {
-                quil_rs::Program::from_str(&cfg.program).unwrap()
-            }, |program| {
-                let prog = ScheduledProgram::from_program(&program).expect("scheduling should not fail");
-                black_box(prog);
-            },
-            BatchSize::SmallInput)
+    corpus::from_corpus()
+        .iter()
+        .filter(|cfg| {
+            // Ignore any programs that would fail to schedule
+            match quil_rs::Program::from_str(&cfg.program) {
+                Err(_) => false,
+                Ok(program) => ScheduledProgram::from_program(&program).is_ok(),
+            }
+        })
+        .for_each(|cfg| {
+            group.bench_function(&cfg.name, |b| {
+                b.iter_batched(
+                    || quil_rs::Program::from_str(&cfg.program).unwrap(),
+                    |program| {
+                        let prog = ScheduledProgram::from_program(&program)
+                            .expect("scheduling should not fail");
+                        black_box(prog);
+                    },
+                    BatchSize::SmallInput,
+                )
+            });
         });
-    });
     group.finish();
 }
 

--- a/quil-rs/benches/scheduled_program_from_program.rs
+++ b/quil-rs/benches/scheduled_program_from_program.rs
@@ -1,0 +1,30 @@
+use criterion::{criterion_group, criterion_main, Criterion, black_box, BatchSize};
+use quil_rs::program::graph::ScheduledProgram;
+use std::str::FromStr;
+
+mod corpus;
+
+fn benchmark_quil_corpus(c: &mut Criterion) {
+    let mut group = c.benchmark_group("ScheduleProgram::from_program");
+    corpus::from_corpus().iter().filter(|cfg| {
+        // Ignore any programs that would fail to schedule
+        match quil_rs::Program::from_str(&cfg.program) {
+            Err(_) => false,
+            Ok(program) => ScheduledProgram::from_program(&program).is_ok(),
+        }
+    }).for_each(|cfg| {
+        group.bench_function(&cfg.name, |b| {
+            b.iter_batched(|| {
+                quil_rs::Program::from_str(&cfg.program).unwrap()
+            }, |program| {
+                let prog = ScheduledProgram::from_program(&program).expect("scheduling should not fail");
+                black_box(prog);
+            },
+            BatchSize::SmallInput)
+        });
+    });
+    group.finish();
+}
+
+criterion_group!(benches, benchmark_quil_corpus);
+criterion_main!(benches);

--- a/quil-rs/src/expression.rs
+++ b/quil-rs/src/expression.rs
@@ -838,9 +838,8 @@ mod tests {
                 operator: InfixOperator::Plus,
                 right: Box::new(Expression::Number(real!(b))),
             } );
-            let matching = first.clone();
             let differing = Expression::Number(real!(a + b));
-            prop_assert_eq!(&first, &matching);
+            prop_assert_eq!(&first, &first);
             prop_assert_ne!(&first, &differing);
         }
 
@@ -936,7 +935,7 @@ mod tests {
         #[test]
         fn exponentiation_works_as_expected(left in arb_expr(), right in arb_expr()) {
             let expected = Expression::Infix (InfixExpression { left: Box::new(left.clone()), operator: InfixOperator::Caret, right: Box::new(right.clone()) } );
-            prop_assert_eq!(left.clone() ^ right.clone(), expected.clone());
+            prop_assert_eq!(&(left.clone() ^ right.clone()), &expected);
             let mut x = left;
             x ^= right;
             prop_assert_eq!(x, expected);
@@ -945,7 +944,7 @@ mod tests {
         #[test]
         fn addition_works_as_expected(left in arb_expr(), right in arb_expr()) {
             let expected = Expression::Infix (InfixExpression { left: Box::new(left.clone()), operator: InfixOperator::Plus, right: Box::new(right.clone()) } );
-            prop_assert_eq!(left.clone() + right.clone(), expected.clone());
+            prop_assert_eq!(&(left.clone() + right.clone()), &expected);
             let mut x = left;
             x += right;
             prop_assert_eq!(x, expected);
@@ -954,7 +953,7 @@ mod tests {
         #[test]
         fn subtraction_works_as_expected(left in arb_expr(), right in arb_expr()) {
             let expected = Expression::Infix (InfixExpression { left: Box::new(left.clone()), operator: InfixOperator::Minus, right: Box::new(right.clone()) } );
-            prop_assert_eq!(left.clone() - right.clone(), expected.clone());
+            prop_assert_eq!(&(left.clone() - right.clone()), &expected);
             let mut x = left;
             x -= right;
             prop_assert_eq!(x, expected);
@@ -963,7 +962,7 @@ mod tests {
         #[test]
         fn multiplication_works_as_expected(left in arb_expr(), right in arb_expr()) {
             let expected = Expression::Infix (InfixExpression { left: Box::new(left.clone()), operator: InfixOperator::Star, right: Box::new(right.clone()) } );
-            prop_assert_eq!(left.clone() * right.clone(), expected.clone());
+            prop_assert_eq!(&(left.clone() * right.clone()), &expected);
             let mut x = left;
             x *= right;
             prop_assert_eq!(x, expected);
@@ -972,7 +971,7 @@ mod tests {
         #[test]
         fn division_works_as_expected(left in arb_expr(), right in arb_expr()) {
             let expected = Expression::Infix (InfixExpression { left: Box::new(left.clone()), operator: InfixOperator::Slash, right: Box::new(right.clone()) } );
-            prop_assert_eq!(left.clone() / right.clone(), expected.clone());
+            prop_assert_eq!(&(left.clone() / right.clone()), &expected);
             let mut x = left;
             x /= right;
             prop_assert_eq!(x, expected);

--- a/quil-rs/src/program/graph.rs
+++ b/quil-rs/src/program/graph.rs
@@ -176,18 +176,21 @@ impl MemoryAccessQueue {
 
 /// Add a dependency to an edge on the graph, whether that edge currently exists or not.
 macro_rules! add_dependency {
-    ($graph:expr, $source:expr => $target:expr, $dependency:expr) => {
-        match $graph.edge_weight_mut($source, $target) {
+    ($graph:expr, $source:expr => $target:expr, $dependency:expr) => {{
+        let source = $source;
+        let target = $target;
+        let dependency = $dependency;
+        match $graph.edge_weight_mut(source, target) {
             Some(edge) => {
-                edge.insert($dependency);
+                edge.insert(dependency);
             }
             None => {
                 let mut edge = HashSet::new();
-                edge.insert($dependency);
-                $graph.add_edge($source.clone(), $target.clone(), edge);
+                edge.insert(dependency);
+                $graph.add_edge(source, target, edge);
             }
         }
-    };
+    }};
 }
 
 pub type DependencyGraph = GraphMap<ScheduledGraphNode, HashSet<ExecutionDependency>, Directed>;

--- a/quil-rs/src/program/graph.rs
+++ b/quil-rs/src/program/graph.rs
@@ -506,6 +506,11 @@ pub struct ScheduledProgram {
 /// between control instructions (such as `LABEL` and 'JUMP`). When such a control instruction is reached,
 /// this function performs the work to close out and store the instructions in the current "working block"
 /// and then reset the state to prepare for the next block.
+///
+/// # Errors
+///
+/// If an error occurs, `working_instructions` and/or `working_label` may have been emptied and
+/// cannot be relied on to be unchanged.
 fn terminate_working_block(
     terminator: Option<BlockTerminator>,
     working_instructions: &mut Vec<Instruction>,


### PR DESCRIPTION
Another round of performance improvements!

This one is focused primarily on improving the performance of `ScheduledProgram::from_program` and `terminate_working_block`, a function that it calls.

Existing benchmarks `parser` and `get_frames_for_instruction` are largely unchanged with a little bit of noise in either direction. The new benchmark for `ScheduledProgram::from_program` shows no significant performance change at worst and a 16%/1.2µs improvement (from 7.4 to 6.2).

Further, an internal project shows a similar case of no significant change at worst and an improvement of 6.7%/55µs (from 814.24 to 759.69)