### PR TITLE
fix: The destination and source are no longer flipped when parsing CONVERT instructions.

### DIFF
--- a/quil-py/src/instruction/classical.rs
+++ b/quil-py/src/instruction/classical.rs
@@ -241,10 +241,14 @@ impl_str!(PyConvert);
 #[pymethods]
 impl PyConvert {
     #[new]
-    fn new(py: Python<'_>, from: PyMemoryReference, to: PyMemoryReference) -> PyResult<Self> {
+    fn new(
+        py: Python<'_>,
+        destination: PyMemoryReference,
+        source: PyMemoryReference,
+    ) -> PyResult<Self> {
         Ok(Self(Convert::new(
-            MemoryReference::py_try_from(py, &from)?,
-            MemoryReference::py_try_from(py, &to)?,
+            MemoryReference::py_try_from(py, &destination)?,
+            MemoryReference::py_try_from(py, &source)?,
         )))
     }
 

--- a/quil-rs/src/instruction/classical.rs
+++ b/quil-rs/src/instruction/classical.rs
@@ -112,10 +112,10 @@ pub struct Convert {
 }
 
 impl Convert {
-    pub fn new(original: MemoryReference, to: MemoryReference) -> Self {
+    pub fn new(destination: MemoryReference, source: MemoryReference) -> Self {
         Self {
-            destination: original,
-            source: to,
+            destination,
+            source,
         }
     }
 }

--- a/quil-rs/src/parser/command.rs
+++ b/quil-rs/src/parser/command.rs
@@ -147,8 +147,8 @@ pub(crate) fn parse_convert(input: ParserInput) -> InternalParserResult<Instruct
     Ok((
         input,
         Instruction::Convert(Convert {
-            destination: from,
-            source: to,
+            destination: to,
+            source: from,
         }),
     ))
 }

--- a/quil-rs/src/parser/instruction.rs
+++ b/quil-rs/src/parser/instruction.rs
@@ -835,12 +835,12 @@ mod tests {
         "CONVERT theta unadjusted-theta[1]",
         vec![Instruction::Convert(Convert {
             destination: MemoryReference {
-                name: "unadjusted-theta".to_string(),
-                index: 1
-            },
-            source: MemoryReference {
                 name: "theta".to_string(),
                 index: 0
+            },
+            source: MemoryReference {
+                name: "unadjusted-theta".to_string(),
+                index: 1
             },
         })]
     );


### PR DESCRIPTION
Per the quil spec, the destination is the left most argument.

<img width="658" alt="image" src="https://github.com/rigetti/quil-rs/assets/4324359/0274b4d0-45ce-4c5d-9cf7-389f229cad15">
