### PR TITLE
refactor!: optimize clones and collections

### DIFF
--- a/quil-rs/src/expression.rs
+++ b/quil-rs/src/expression.rs
@@ -203,8 +203,9 @@ macro_rules! impl_expr_op {
         }
         impl $name_assign for Expression {
             fn $function_assign(&mut self, other: Self) {
-                let result = self.clone().$function(other);
-                *self = result;
+                // Move out of self to avoid potentially cloning a large value
+                let temp = ::std::mem::replace(self, Self::PiConstant);
+                *self = temp.$function(other);
             }
         }
     };

--- a/quil-rs/src/instruction/gate.rs
+++ b/quil-rs/src/instruction/gate.rs
@@ -188,8 +188,8 @@ impl PauliSum {
 
         if !diff.is_empty() {
             return Err(GateError::PauliSumArgumentMismatch {
-                expected_arguments: arguments.clone(),
                 mismatches: diff.into_iter().cloned().collect(),
+                expected_arguments: arguments,
             });
         }
 

--- a/quil-rs/src/parser/command.rs
+++ b/quil-rs/src/parser/command.rs
@@ -218,7 +218,7 @@ pub(crate) fn parse_defframe<'a>(input: ParserInput<'a>) -> InternalParserResult
     let (input, identifier) = parse_frame_identifier(input)?;
     let (input, _) = token!(Colon)(input)?;
     let (input, attribute_pairs) = many1(parse_frame_attribute)(input)?;
-    let attributes = attribute_pairs.iter().cloned().collect();
+    let attributes = attribute_pairs.into_iter().collect();
 
     Ok((
         input,

--- a/quil-rs/src/parser/instruction.rs
+++ b/quil-rs/src/parser/instruction.rs
@@ -540,7 +540,7 @@ mod tests {
         "DEFFRAME 0 \"ro_rx\":\n\tDIRECTION: \"rx\"\n\n# (Pdb) settings.gates[GateID(name=\"x180\", targets=(0,))]\n\n",
         vec![Instruction::FrameDefinition(FrameDefinition {
             identifier: FrameIdentifier { name: "ro_rx".to_owned(), qubits: vec![Qubit::Fixed(0)] },
-            attributes: [("DIRECTION".to_owned(), AttributeValue::String("rx".to_owned()))].iter().cloned().collect()
+            attributes: [("DIRECTION".to_owned(), AttributeValue::String("rx".to_owned()))].into_iter().collect()
         })]);
 
     make_test!(
@@ -585,8 +585,7 @@ mod tests {
                 waveform: WaveformInvocation {
                     name: "custom_waveform".to_owned(),
                     parameters: [("a".to_owned(), Expression::Number(crate::real![1f64]))]
-                        .iter()
-                        .cloned()
+                        .into_iter()
                         .collect()
                 }
             })]
@@ -606,8 +605,7 @@ mod tests {
                 "INITIAL-FREQUENCY".to_owned(),
                 AttributeValue::Expression(Expression::Number(crate::real![2e9]))
             )]
-            .iter()
-            .cloned()
+            .into_iter()
             .collect()
         })]
     );

--- a/quil-rs/src/program/calibration.rs
+++ b/quil-rs/src/program/calibration.rs
@@ -168,6 +168,7 @@ impl CalibrationSet {
             _ => None,
         };
 
+        // TODO: would allocating with with_capacity help here?
         // Add this instruction to the breadcrumb trail before recursion
         let mut downstream_previous_calibrations = vec![instruction.clone()];
         downstream_previous_calibrations.extend_from_slice(previous_calibrations);
@@ -338,11 +339,13 @@ impl CalibrationSet {
     pub fn to_instructions(&self) -> Vec<Instruction> {
         self.calibrations
             .iter()
-            .map(|c| Instruction::CalibrationDefinition(c.clone()))
+            .cloned()
+            .map(Instruction::CalibrationDefinition)
             .chain(
                 self.measure_calibrations
                     .iter()
-                    .map(|c| Instruction::MeasureCalibrationDefinition(c.clone())),
+                    .cloned()
+                    .map(Instruction::MeasureCalibrationDefinition),
             )
             .collect()
     }

--- a/quil-rs/src/program/calibration.rs
+++ b/quil-rs/src/program/calibration.rs
@@ -169,7 +169,8 @@ impl CalibrationSet {
         };
 
         // Add this instruction to the breadcrumb trail before recursion
-        let mut downstream_previous_calibrations = Vec::with_capacity(previous_calibrations.len() + 1);
+        let mut downstream_previous_calibrations =
+            Vec::with_capacity(previous_calibrations.len() + 1);
         downstream_previous_calibrations.push(instruction.clone());
         downstream_previous_calibrations.extend_from_slice(previous_calibrations);
 

--- a/quil-rs/src/program/calibration.rs
+++ b/quil-rs/src/program/calibration.rs
@@ -168,9 +168,9 @@ impl CalibrationSet {
             _ => None,
         };
 
-        // TODO: would allocating with with_capacity help here?
         // Add this instruction to the breadcrumb trail before recursion
-        let mut downstream_previous_calibrations = vec![instruction.clone()];
+        let mut downstream_previous_calibrations = Vec::with_capacity(previous_calibrations.len() + 1);
+        downstream_previous_calibrations.push(instruction.clone());
         downstream_previous_calibrations.extend_from_slice(previous_calibrations);
 
         Ok(match expanded_once_instructions {

--- a/quil-rs/src/program/frame.rs
+++ b/quil-rs/src/program/frame.rs
@@ -63,7 +63,7 @@ impl FrameSet {
                 // This unusual pattern (fetch key & value by key, discard value) allows us to return
                 // a reference to `self` rather than `condition`, keeping lifetimes simpler.
                 if let Some((frame, _)) = self.frames.get_key_value(frame) {
-                    vec![frame].into_iter().collect()
+                    HashSet::from([frame])
                 } else {
                     HashSet::new()
                 }

--- a/quil-rs/src/program/graph.rs
+++ b/quil-rs/src/program/graph.rs
@@ -285,7 +285,7 @@ impl PreviousNodes {
     }
 
     /// Consume the [PreviousNodes] and return all nodes within.
-    pub fn drain(mut self) -> HashSet<ScheduledGraphNode> {
+    pub fn into_hashset(mut self) -> HashSet<ScheduledGraphNode> {
         if let Some(using) = self.using {
             self.blocking.insert(using);
         }
@@ -408,7 +408,7 @@ impl InstructionBlock {
                         // Test to make sure that no instructions depend directly on themselves
                         if memory_dependency.node_id != node {
                             let execution_dependency = ExecutionDependency::AwaitMemoryAccess(
-                                memory_dependency.access_type.clone(),
+                                memory_dependency.access_type,
                             );
                             add_dependency!(graph, memory_dependency.node_id => node, execution_dependency);
                         }
@@ -422,20 +422,20 @@ impl InstructionBlock {
         add_dependency!(graph, last_classical_instruction => ScheduledGraphNode::BlockEnd, ExecutionDependency::StableOrdering);
 
         for previous_nodes in last_timed_instruction_by_frame.into_values() {
-            for node in previous_nodes.drain() {
+            for node in previous_nodes.into_hashset() {
                 add_dependency!(graph, node => ScheduledGraphNode::BlockEnd, ExecutionDependency::Scheduled);
             }
         }
 
         for previous_nodes in last_instruction_by_frame.into_values() {
-            for node in previous_nodes.drain() {
+            for node in previous_nodes.into_hashset() {
                 add_dependency!(graph, node => ScheduledGraphNode::BlockEnd, ExecutionDependency::StableOrdering);
             }
         }
 
         // Examine all "pending" memory operations for all regions
         let remaining_dependencies = pending_memory_access
-            .drain()
+            .into_iter()
             .flat_map(|(_, queue)| queue.flush())
             .collect::<Vec<MemoryAccessDependency>>();
 

--- a/quil-rs/src/program/graph.rs
+++ b/quil-rs/src/program/graph.rs
@@ -614,7 +614,7 @@ impl ScheduledProgram {
                 Instruction::Jump(Jump { target }) => {
                     terminate_working_block(
                         Some(BlockTerminator::Unconditional {
-                            target: target.clone(),
+                            target,
                         }),
                         &mut working_instructions,
                         &mut blocks,
@@ -626,8 +626,8 @@ impl ScheduledProgram {
                 Instruction::JumpWhen(JumpWhen { target, condition }) => {
                     terminate_working_block(
                         Some(BlockTerminator::Conditional {
-                            target: target.clone(),
-                            condition: condition.clone(),
+                            target,
+                            condition,
                             jump_if_condition_true: true,
                         }),
                         &mut working_instructions,
@@ -640,8 +640,8 @@ impl ScheduledProgram {
                 Instruction::JumpUnless(JumpUnless { target, condition }) => {
                     terminate_working_block(
                         Some(BlockTerminator::Conditional {
-                            target: target.clone(),
-                            condition: condition.clone(),
+                            target,
+                            condition,
                             jump_if_condition_true: false,
                         }),
                         &mut working_instructions,

--- a/quil-rs/src/program/graph.rs
+++ b/quil-rs/src/program/graph.rs
@@ -613,9 +613,7 @@ impl ScheduledProgram {
                 }
                 Instruction::Jump(Jump { target }) => {
                     terminate_working_block(
-                        Some(BlockTerminator::Unconditional {
-                            target,
-                        }),
+                        Some(BlockTerminator::Unconditional { target }),
                         &mut working_instructions,
                         &mut blocks,
                         &mut working_label,

--- a/quil-rs/src/program/memory.rs
+++ b/quil-rs/src/program/memory.rs
@@ -142,7 +142,6 @@ impl Instruction {
                 destination,
                 source,
             }) => MemoryAccesses {
-                // TODO: is it better to use option instead of vec?
                 writes: set_from_memory_references![vec![destination]],
                 reads: set_from_optional_memory_reference![source.get_memory_reference()],
                 ..Default::default()
@@ -316,7 +315,6 @@ impl Expression {
 impl WaveformInvocation {
     /// Return, if any, the memory references contained within this WaveformInvocation.
     pub fn get_memory_references(&self) -> Vec<&MemoryReference> {
-        // TODO: iterators?
         let mut result = vec![];
 
         for expression in self.parameters.values() {

--- a/quil-rs/src/program/memory.rs
+++ b/quil-rs/src/program/memory.rs
@@ -81,7 +81,7 @@ macro_rules! set_from_reference_vec {
 /// Build a HashSet<String> from an Option<&MemoryReference>
 macro_rules! set_from_optional_memory_reference {
     ($reference:expr) => {
-        set_from_reference_vec![$reference.map_or(vec![], |reference| vec![reference.name.clone()])]
+        set_from_reference_vec![$reference.map_or_else(Vec::new, |reference| vec![reference.name.clone()])]
     };
 }
 
@@ -142,6 +142,7 @@ impl Instruction {
                 destination,
                 source,
             }) => MemoryAccesses {
+                // TODO: is it better to use option instead of vec?
                 writes: set_from_memory_references![vec![destination]],
                 reads: set_from_optional_memory_reference![source.get_memory_reference()],
                 ..Default::default()
@@ -315,6 +316,7 @@ impl Expression {
 impl WaveformInvocation {
     /// Return, if any, the memory references contained within this WaveformInvocation.
     pub fn get_memory_references(&self) -> Vec<&MemoryReference> {
+        // TODO: iterators?
         let mut result = vec![];
 
         for expression in self.parameters.values() {

--- a/quil-rs/src/program/memory.rs
+++ b/quil-rs/src/program/memory.rs
@@ -85,7 +85,7 @@ macro_rules! set_from_optional_memory_reference {
     };
 }
 
-/// Build a HashSet<String> from a Vec<&MemoryReference>
+/// Build a HashSet<&String> from a Vec<&MemoryReference>
 macro_rules! set_from_memory_references {
     ($references:expr) => {
         set_from_reference_vec![$references.iter().map(|reference| &reference.name)]

--- a/quil-rs/src/program/memory.rs
+++ b/quil-rs/src/program/memory.rs
@@ -81,14 +81,14 @@ macro_rules! set_from_reference_vec {
 /// Build a HashSet<String> from an Option<&MemoryReference>
 macro_rules! set_from_optional_memory_reference {
     ($reference:expr) => {
-        set_from_reference_vec![$reference.map_or_else(Vec::new, |reference| vec![reference.name.clone()])]
+        set_from_reference_vec![$reference.map_or_else(Vec::new, |reference| vec![&reference.name])]
     };
 }
 
 /// Build a HashSet<String> from a Vec<&MemoryReference>
 macro_rules! set_from_memory_references {
     ($references:expr) => {
-        set_from_reference_vec![$references.iter().map(|reference| reference.name.clone())]
+        set_from_reference_vec![$references.iter().map(|reference| &reference.name)]
     };
 }
 

--- a/quil-rs/src/program/mod.rs
+++ b/quil-rs/src/program/mod.rs
@@ -152,7 +152,6 @@ impl Program {
             }
         }
 
-        // TODO: should this just be a new Program?
         let mut new_program = Self {
             calibrations: self.calibrations.clone(),
             frames: self.frames.clone(),
@@ -161,9 +160,7 @@ impl Program {
             instructions: Vec::new(),
         };
 
-        for instruction in expanded_instructions {
-            new_program.add_instruction(instruction);
-        }
+        new_program.add_instructions(expanded_instructions);
 
         Ok(new_program)
     }

--- a/quil-rs/src/program/mod.rs
+++ b/quil-rs/src/program/mod.rs
@@ -144,7 +144,7 @@ impl Program {
         for instruction in &self.instructions {
             match self.calibrations.expand(instruction, &[])? {
                 Some(expanded) => {
-                    expanded_instructions.extend(expanded.into_iter());
+                    expanded_instructions.extend(expanded);
                 }
                 None => {
                     expanded_instructions.push(instruction.clone());

--- a/quil-rs/src/program/mod.rs
+++ b/quil-rs/src/program/mod.rs
@@ -152,8 +152,14 @@ impl Program {
             }
         }
 
-        let mut new_program = self.clone();
-        new_program.instructions = vec![];
+        // TODO: should this just be a new Program?
+        let mut new_program = Self {
+            calibrations: self.calibrations.clone(),
+            frames: self.frames.clone(),
+            memory_regions: self.memory_regions.clone(),
+            waveforms: self.waveforms.clone(),
+            instructions: Vec::new(),
+        };
 
         for instruction in expanded_instructions {
             new_program.add_instruction(instruction);
@@ -317,6 +323,7 @@ impl From<Vec<Instruction>> for Program {
     }
 }
 
+// TODO: why not use owned values?
 impl<'a, 'b> ops::Add<&'b Program> for &'a Program {
     type Output = Program;
 

--- a/quil-rs/src/program/mod.rs
+++ b/quil-rs/src/program/mod.rs
@@ -320,7 +320,6 @@ impl From<Vec<Instruction>> for Program {
     }
 }
 
-// TODO: why not use owned values?
 impl<'a, 'b> ops::Add<&'b Program> for &'a Program {
     type Output = Program;
 


### PR DESCRIPTION
Another set of optimizations, focused on searching for patterns in the code (e.g. cloning, creating a `Vec`) and seeing if it can be easily optimized in some way.

Each commit was benchmarked separately using an internal project, where any changes with negative results were discarded. I then ran benchmarks for both this project and the internal one, comparing `main` with this branch. The following summarizes the difference between `main` and these changes:

- `ScheduledProgram::from_program` saw a small performance increase overall, roughly 1-3%
- The `parser` saw little change in performance. Notably, only two example programs were called out as significant by `cargo bench`:
    - `empty-quil.quil` had a regression of 2.9% (~0.04 µs)
    - `good-include.quil` had a regression of 16% (~1.5 µs)
- `get_frames_for_instruction` seems noisy, with changes of 2-5% in either direction depending on the file.
    - `cargo bench` lists each benchmark as having 15-20% outliers, which I believe are left out of the statistical analysis
    - There appeared to be a few more improvements than regressions, though the noise limits how much this means anything
    - Outliers:
        - `good-classical-binaries.quil` had an improvement of 14.4% (~7.4 µs)
        - `good-pragmas.quil` had an improvement of ~7% (~0.7 µs)
        - `good-simple-params.quil` had a regression of ~2% (`include_blocked=false`) and ~8% (`include_blocked=true`), amounting to a change of ~0.3 µs and ~2 µs, respectively

The internal project has three main benchmarks. Two saw little change, while the third saw improvements across the board, ranging from 3%/22 µs to 14%/4ms.