### PR TITLE
ci: ignore Cargo.lock in prerelease

### DIFF
--- a/knope.toml
+++ b/knope.toml
@@ -26,7 +26,7 @@ command = "sh ./scripts/sync_versions.sh"
 
 [[workflows.steps]]
 type = "Command"
-command = "git add Cargo.lock quil-py/Cargo.toml"
+command = "git add quil-py/Cargo.toml"
 
 [[workflows.steps]]
 type = "Command"
@@ -50,7 +50,7 @@ command = "sh ./scripts/sync_versions.sh"
 
 [[workflows.steps]]
 type = "Command"
-command = "git add Cargo.lock quil-py/Cargo.toml"
+command = "git add quil-py/Cargo.toml"
 
 [[workflows.steps]]
 type = "Command"

--- a/knope.toml
+++ b/knope.toml
@@ -1,17 +1,11 @@
 [packages.quil-rs]
 versioned_files = ["quil-rs/Cargo.toml"]
-# Temprorarily disabling this so we can manually write the changelog entry
-# for 0.17.0 since knope doesn't handle generating the changelog for a large
-# feature branch very well. This should be re-enabled from the following release.
-# changelog = "quil-rs/CHANGELOG.md"
+changelog = "quil-rs/CHANGELOG.md"
 scopes = ["rs", "rust", "quil-rs"]
 
 [packages.quil-py]
 versioned_files = ["quil-py/Cargo.toml", "quil-py/pyproject.toml"]
-# Temprorarily disabling this so we can manually write the changelog entry
-# for quil-py since knope doesn't handle generating the changelog for a large
-# feature branch very well. This should be re-enabled for the following release.
-# changelog = "quil-py/CHANGELOG.md"
+changelog = "quil-py/CHANGELOG.md"
 scopes = ["py", "python", "quil-py"]
 
 [[workflows]]


### PR DESCRIPTION
This PR follows the advice from the [broken build step in the pipeline](https://github.com/rigetti/quil-rs/actions/runs/5328135255/jobs/9652408753).