### PR TITLE
perf!: optimize Program::get_frames_for_instruction

### DIFF
--- a/quil-rs/benches/get_frames_for_instruction.rs
+++ b/quil-rs/benches/get_frames_for_instruction.rs
@@ -6,33 +6,23 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
 fn benchmark_quil_corpus(c: &mut Criterion) {
     corpus::from_corpus().iter().for_each(|cfg| {
-        for include_blocked in [true, false] {
-            c.bench_function(
-                &format!(
-                    "{} ({}include blocked)",
-                    cfg.name,
-                    if include_blocked { "" } else { "no " }
-                ),
-                |b| {
-                    b.iter_batched(
-                        || {
-                            quil_rs::Program::from_str(&cfg.program)
-                                .expect("program should parse successfully")
-                        },
-                        |prog| {
-                            for instruction in &prog.instructions {
-                                for _ in 0..50 {
-                                    let frames = prog
-                                        .get_frames_for_instruction(instruction, include_blocked);
-                                    black_box(frames);
-                                }
-                            }
-                        },
-                        criterion::BatchSize::SmallInput,
-                    )
+        c.bench_function(&cfg.name, |b| {
+            b.iter_batched(
+                || {
+                    quil_rs::Program::from_str(&cfg.program)
+                        .expect("program should parse successfully")
                 },
-            );
-        }
+                |prog| {
+                    for instruction in &prog.instructions {
+                        for _ in 0..50 {
+                            let frames = prog.get_frames_for_instruction(instruction);
+                            black_box(frames);
+                        }
+                    }
+                },
+                criterion::BatchSize::SmallInput,
+            )
+        });
     })
 }
 

--- a/quil-rs/src/program/frame.rs
+++ b/quil-rs/src/program/frame.rs
@@ -207,10 +207,13 @@ pub struct MatchedFrames<'a> {
 }
 
 impl<'a> MatchedFrames<'a> {
+    /// Which concrete frames are blocked and not used.
+    /// This set is mutually exclusive with `used`.
     pub fn blocked(&self) -> &HashSet<&'a FrameIdentifier> {
         &self.blocked
     }
 
+    /// Which concrete frames are used by the [`Instruction`]
     pub fn used(&self) -> &HashSet<&'a FrameIdentifier> {
         &self.used
     }

--- a/quil-rs/src/program/frame.rs
+++ b/quil-rs/src/program/frame.rs
@@ -190,9 +190,9 @@ pub(crate) struct FrameMatchConditions<'a> {
     /// are blocked by an [`Instruction`]. A "blocked" frame is one which is not used by the
     /// `Instruction` but is not available for use by other instructions while this one executes.
     ///
-    /// **Note**: for efficiency in computation, this may or include frames also matched by `used`.
+    /// **Note**: for efficiency in computation, this may match frames also matched by `used`.
     /// In order to query which frames are _blocked but not used_, both conditions must first
-    /// be evaluated in the scope of the available frames, and
+    /// be evaluated in the scope of the available frames.
     pub blocked: Option<FrameMatchCondition<'a>>,
 }
 

--- a/quil-rs/src/program/frame.rs
+++ b/quil-rs/src/program/frame.rs
@@ -45,12 +45,12 @@ impl FrameSet {
     ) -> MatchedFrames<'s> {
         let used = condition
             .used
-            .map(|c| self.get_matching_keys_for_condition(c));
+            .map_or_else(HashSet::new, |c| self.get_matching_keys_for_condition(c));
 
-        let blocked = condition.blocked.map(|c| {
+        let blocked = condition.blocked.map_or_else(HashSet::new, |c| {
             let mut blocked = self.get_matching_keys_for_condition(c);
 
-            if let Some(used) = &used {
+            if !used.is_empty() {
                 blocked.retain(|&f| !used.contains(&f));
             }
 
@@ -199,9 +199,9 @@ pub(crate) struct FrameMatchConditions<'a> {
 /// The product of evaluating  [`FrameMatchConditions`] in the scope of available frames (such as within a [`crate::Program`]).
 pub struct MatchedFrames<'a> {
     /// Which concrete frames are used by the [`Instruction`]
-    pub used: Option<HashSet<&'a FrameIdentifier>>,
+    pub used: HashSet<&'a FrameIdentifier>,
 
     /// Which concrete frames are blocked and not used.
-    /// This set must be mutually exclusive with `used`.
-    pub blocked: Option<HashSet<&'a FrameIdentifier>>,
+    /// This set is mutually exclusive with `used`.
+    pub blocked: HashSet<&'a FrameIdentifier>,
 }

--- a/quil-rs/src/program/frame.rs
+++ b/quil-rs/src/program/frame.rs
@@ -39,10 +39,31 @@ impl FrameSet {
         self.frames.keys().collect()
     }
 
+    pub(crate) fn get_matching_keys_for_conditions<'s>(
+        &'s self,
+        condition: FrameMatchConditions,
+    ) -> MatchedFrames<'s> {
+        let used = condition
+            .used
+            .map(|c| self.get_matching_keys_for_condition(c));
+
+        let blocked = condition.blocked.map(|c| {
+            let mut blocked = self.get_matching_keys_for_condition(c);
+
+            if let Some(used) = &used {
+                blocked.retain(|&f| !used.contains(&f));
+            }
+
+            blocked
+        });
+
+        MatchedFrames { used, blocked }
+    }
+
     /// Return all frames in the set which match all of these conditions. If a frame _would_ match, but is
     /// not present in this [FrameSet], then it is not returned (notably, the [FrameMatchCondition::Specific]
     /// match condition).
-    pub(crate) fn get_matching_keys<'s>(
+    pub(crate) fn get_matching_keys_for_condition<'s>(
         &'s self,
         condition: FrameMatchCondition,
     ) -> HashSet<&'s FrameIdentifier> {
@@ -70,12 +91,12 @@ impl FrameSet {
             }
             FrameMatchCondition::And(conditions) => conditions
                 .into_iter()
-                .map(|c| self.get_matching_keys(c))
+                .map(|c| self.get_matching_keys_for_condition(c))
                 .reduce(|acc, el| acc.into_iter().filter(|&v| el.contains(v)).collect())
                 .unwrap_or_default(),
             FrameMatchCondition::Or(conditions) => conditions
                 .into_iter()
-                .flat_map(|c| self.get_matching_keys(c))
+                .flat_map(|c| self.get_matching_keys_for_condition(c))
                 .collect(),
         }
     }
@@ -153,4 +174,34 @@ pub(crate) enum FrameMatchCondition<'a> {
 
     /// Return all frames which match any of these conditions
     Or(Vec<FrameMatchCondition<'a>>),
+}
+
+/// A pair of conditions to match frames within a [`crate::Program`] (or another scope).
+///
+/// This allows for deferred evaluation of matching an instruction against available frames.
+pub(crate) struct FrameMatchConditions<'a> {
+    /// A condition to identify which frames within a [`crate::Program`] (or another scope)
+    /// are actively used by an [`Instruction`].
+    ///
+    /// If `None`, then this [`Instruction`] does not use any frames, regardless of which are available.
+    pub used: Option<FrameMatchCondition<'a>>,
+
+    /// A condition to identify which frames within a [`crate::Program`] (or another scope)
+    /// are blocked by an [`Instruction`]. A "blocked" frame is one which is not used by the
+    /// `Instruction` but is not available for use by other instructions while this one executes.
+    ///
+    /// **Note**: for efficiency in computation, this may or include frames also matched by `used`.
+    /// In order to query which frames are _blocked but not used_, both conditions must first
+    /// be evaluated in the scope of the available frames, and
+    pub blocked: Option<FrameMatchCondition<'a>>,
+}
+
+/// The product of evaluating  [`FrameMatchConditions`] in the scope of available frames (such as within a [`crate::Program`]).
+pub struct MatchedFrames<'a> {
+    /// Which concrete frames are used by the [`Instruction`]
+    pub used: Option<HashSet<&'a FrameIdentifier>>,
+
+    /// Which concrete frames are blocked and not used.
+    /// This set must be mutually exclusive with `used`.
+    pub blocked: Option<HashSet<&'a FrameIdentifier>>,
 }

--- a/quil-rs/src/program/frame.rs
+++ b/quil-rs/src/program/frame.rs
@@ -198,10 +198,20 @@ pub(crate) struct FrameMatchConditions<'a> {
 
 /// The product of evaluating  [`FrameMatchConditions`] in the scope of available frames (such as within a [`crate::Program`]).
 pub struct MatchedFrames<'a> {
-    /// Which concrete frames are used by the [`Instruction`]
-    pub used: HashSet<&'a FrameIdentifier>,
-
     /// Which concrete frames are blocked and not used.
     /// This set is mutually exclusive with `used`.
-    pub blocked: HashSet<&'a FrameIdentifier>,
+    blocked: HashSet<&'a FrameIdentifier>,
+
+    /// Which concrete frames are used by the [`Instruction`]
+    used: HashSet<&'a FrameIdentifier>,
+}
+
+impl<'a> MatchedFrames<'a> {
+    pub fn blocked(&self) -> &HashSet<&'a FrameIdentifier> {
+        &self.blocked
+    }
+
+    pub fn used(&self) -> &HashSet<&'a FrameIdentifier> {
+        &self.used
+    }
 }

--- a/quil-rs/src/program/graph.rs
+++ b/quil-rs/src/program/graph.rs
@@ -330,49 +330,45 @@ impl InstructionBlock {
                     let matched_frames = program.get_frames_for_instruction(instruction);
 
                     if let Some(matched_frames) = matched_frames {
-                        if let Some(used_frames) = &matched_frames.used {
-                            for frame in used_frames {
-                                if instruction.is_scheduled() {
-                                    let previous_node_ids = last_timed_instruction_by_frame
-                                        .entry((*frame).clone())
-                                        .or_default()
-                                        .get_dependencies_for_next_user(node);
-
-                                    for previous_node_id in previous_node_ids {
-                                        add_dependency!(graph, previous_node_id => node, ExecutionDependency::Scheduled);
-                                    }
-                                }
-
-                                let previous_node_ids = last_instruction_by_frame
+                        for frame in matched_frames.used {
+                            if instruction.is_scheduled() {
+                                let previous_node_ids = last_timed_instruction_by_frame
                                     .entry((*frame).clone())
                                     .or_default()
                                     .get_dependencies_for_next_user(node);
 
                                 for previous_node_id in previous_node_ids {
-                                    add_dependency!(graph, previous_node_id => node, ExecutionDependency::StableOrdering);
+                                    add_dependency!(graph, previous_node_id => node, ExecutionDependency::Scheduled);
                                 }
+                            }
+
+                            let previous_node_ids = last_instruction_by_frame
+                                .entry((*frame).clone())
+                                .or_default()
+                                .get_dependencies_for_next_user(node);
+
+                            for previous_node_id in previous_node_ids {
+                                add_dependency!(graph, previous_node_id => node, ExecutionDependency::StableOrdering);
                             }
                         }
 
-                        if let Some(blocked_but_not_used_frames) = &matched_frames.blocked {
-                            for frame in blocked_but_not_used_frames.iter() {
-                                if instruction.is_scheduled() {
-                                    if let Some(previous_node_id) = last_timed_instruction_by_frame
-                                        .entry((*frame).clone())
-                                        .or_default()
-                                        .get_dependency_for_next_blocker(node)
-                                    {
-                                        add_dependency!(graph, previous_node_id => node, ExecutionDependency::Scheduled);
-                                    }
-                                }
-
-                                if let Some(previous_node_id) = last_instruction_by_frame
+                        for frame in matched_frames.blocked {
+                            if instruction.is_scheduled() {
+                                if let Some(previous_node_id) = last_timed_instruction_by_frame
                                     .entry((*frame).clone())
                                     .or_default()
                                     .get_dependency_for_next_blocker(node)
                                 {
-                                    add_dependency!(graph, previous_node_id => node, ExecutionDependency::StableOrdering);
+                                    add_dependency!(graph, previous_node_id => node, ExecutionDependency::Scheduled);
                                 }
+                            }
+
+                            if let Some(previous_node_id) = last_instruction_by_frame
+                                .entry((*frame).clone())
+                                .or_default()
+                                .get_dependency_for_next_blocker(node)
+                            {
+                                add_dependency!(graph, previous_node_id => node, ExecutionDependency::StableOrdering);
                             }
                         }
                     }

--- a/quil-rs/src/program/graph.rs
+++ b/quil-rs/src/program/graph.rs
@@ -330,7 +330,7 @@ impl InstructionBlock {
                     let matched_frames = program.get_frames_for_instruction(instruction);
 
                     if let Some(matched_frames) = matched_frames {
-                        for frame in matched_frames.used {
+                        for frame in matched_frames.used() {
                             if instruction.is_scheduled() {
                                 let previous_node_ids = last_timed_instruction_by_frame
                                     .entry((*frame).clone())
@@ -352,7 +352,7 @@ impl InstructionBlock {
                             }
                         }
 
-                        for frame in matched_frames.blocked {
+                        for frame in matched_frames.blocked() {
                             if instruction.is_scheduled() {
                                 if let Some(previous_node_id) = last_timed_instruction_by_frame
                                     .entry((*frame).clone())

--- a/quil-rs/src/program/mod.rs
+++ b/quil-rs/src/program/mod.rs
@@ -237,11 +237,8 @@ impl Program {
         let mut waveforms_used: HashSet<&String> = HashSet::new();
 
         for instruction in &expanded_program.instructions {
-            if let Some(frames) = expanded_program
-                .get_frames_for_instruction(instruction)
-                .map(|f| f.used)
-            {
-                frames_used.extend(frames)
+            if let Some(matched_frames) = expanded_program.get_frames_for_instruction(instruction) {
+                frames_used.extend(matched_frames.used())
             }
 
             if let Some(waveform) = instruction.get_waveform_invocation() {
@@ -548,7 +545,7 @@ DEFFRAME 0 1 \"2q\":
             let instruction = Instruction::parse(instruction_string).unwrap();
             let matched_frames = program.get_frames_for_instruction(&instruction).unwrap();
             let used_frames: HashSet<String> = matched_frames
-                .used
+                .used()
                 .into_iter()
                 .map(|f| f.to_string())
                 .collect();
@@ -562,7 +559,7 @@ DEFFRAME 0 1 \"2q\":
             );
 
             let blocked_frames: HashSet<String> = matched_frames
-                .blocked
+                .blocked()
                 .into_iter()
                 .map(|f| f.to_string())
                 .collect();

--- a/quil-rs/src/program/mod.rs
+++ b/quil-rs/src/program/mod.rs
@@ -239,7 +239,7 @@ impl Program {
         for instruction in &expanded_program.instructions {
             if let Some(frames) = expanded_program
                 .get_frames_for_instruction(instruction)
-                .and_then(|f| f.used)
+                .map(|f| f.used)
             {
                 frames_used.extend(frames)
             }
@@ -549,7 +549,6 @@ DEFFRAME 0 1 \"2q\":
             let matched_frames = program.get_frames_for_instruction(&instruction).unwrap();
             let used_frames: HashSet<String> = matched_frames
                 .used
-                .unwrap_or_default()
                 .into_iter()
                 .map(|f| f.to_string())
                 .collect();
@@ -564,7 +563,6 @@ DEFFRAME 0 1 \"2q\":
 
             let blocked_frames: HashSet<String> = matched_frames
                 .blocked
-                .unwrap_or_default()
                 .into_iter()
                 .map(|f| f.to_string())
                 .collect();

--- a/quil-rs/src/program/mod.rs
+++ b/quil-rs/src/program/mod.rs
@@ -564,7 +564,7 @@ DEFFRAME 0 1 \"2q\":
             let matched_frames = program.get_frames_for_instruction(&instruction).unwrap();
             let used_frames: HashSet<String> = matched_frames
                 .used()
-                .into_iter()
+                .iter()
                 .map(|f| f.to_string())
                 .collect();
             let expected_used_frames: HashSet<String> = expected_used_frames
@@ -578,7 +578,7 @@ DEFFRAME 0 1 \"2q\":
 
             let blocked_frames: HashSet<String> = matched_frames
                 .blocked()
-                .into_iter()
+                .iter()
                 .map(|f| f.to_string())
                 .collect();
             let expected_blocked_frames: HashSet<String> = expected_blocked_frames

--- a/quil-rs/src/program/mod.rs
+++ b/quil-rs/src/program/mod.rs
@@ -27,6 +27,7 @@ use crate::parser::{lex, parse_instructions, ParseError};
 pub use self::calibration::CalibrationSet;
 pub use self::error::{disallow_leftover, map_parsed, recover, ParseProgramError, SyntaxError};
 pub use self::frame::FrameSet;
+use self::frame::MatchedFrames;
 pub use self::memory::MemoryRegion;
 
 mod calibration;
@@ -187,13 +188,12 @@ impl Program {
     pub fn get_frames_for_instruction<'a>(
         &'a self,
         instruction: &'a Instruction,
-        include_blocked: bool,
-    ) -> Option<HashSet<&'a FrameIdentifier>> {
+    ) -> Option<MatchedFrames<'a>> {
         let qubits_used_by_program = self.get_used_qubits();
 
         instruction
-            .get_frame_match_condition(include_blocked, qubits_used_by_program)
-            .map(|condition| self.frames.get_matching_keys(condition))
+            .get_frame_match_condition(qubits_used_by_program)
+            .map(|condition| self.frames.get_matching_keys_for_conditions(condition))
     }
 
     /// Returns a HashSet consisting of every Qubit that is used in the program.
@@ -237,7 +237,10 @@ impl Program {
         let mut waveforms_used: HashSet<&String> = HashSet::new();
 
         for instruction in &expanded_program.instructions {
-            if let Some(frames) = expanded_program.get_frames_for_instruction(instruction, false) {
+            if let Some(frames) = expanded_program
+                .get_frames_for_instruction(instruction)
+                .and_then(|f| f.used)
+            {
                 frames_used.extend(frames)
             }
 
@@ -474,12 +477,12 @@ DEFFRAME 0 1 \"2q\":
             (
                 r#"PULSE 0 "a" custom_waveform"#,
                 vec![r#"0 "a""#],
-                vec![r#"0 "a""#, r#"0 "b""#, r#"0 1 "2q""#],
+                vec![r#"0 "b""#, r#"0 1 "2q""#],
             ),
             (
                 r#"PULSE 1 "c" custom_waveform"#,
                 vec![r#"1 "c""#],
-                vec![r#"1 "c""#, r#"0 1 "2q""#],
+                vec![r#"0 1 "2q""#],
             ),
             // Pulses on non-declared frames and unused qubits do not use or block any frames in the program
             (r#"PULSE 2 "a" custom_waveform"#, vec![], vec![]),
@@ -487,41 +490,41 @@ DEFFRAME 0 1 \"2q\":
             (
                 r#"CAPTURE 0 "a" custom_waveform ro[0]"#,
                 vec![r#"0 "a""#],
-                vec![r#"0 "a""#, r#"0 "b""#, r#"0 1 "2q""#],
+                vec![r#"0 "b""#, r#"0 1 "2q""#],
             ),
             (
                 r#"CAPTURE 1 "c" custom_waveform ro[0]"#,
                 vec![r#"1 "c""#],
-                vec![r#"1 "c""#, r#"0 1 "2q""#],
+                vec![r#"0 1 "2q""#],
             ),
             (r#"CAPTURE 2 "a" custom_waveform ro[0]"#, vec![], vec![]),
             // Raw Captures work identically to Pulses
             (
                 r#"RAW-CAPTURE 0 "a" 1e-6 ro[0]"#,
                 vec![r#"0 "a""#],
-                vec![r#"0 "a""#, r#"0 "b""#, r#"0 1 "2q""#],
+                vec![r#"0 "b""#, r#"0 1 "2q""#],
             ),
             (
                 r#"RAW-CAPTURE 1 "c" 1e-6 ro[0]"#,
                 vec![r#"1 "c""#],
-                vec![r#"1 "c""#, r#"0 1 "2q""#],
+                vec![r#"0 1 "2q""#],
             ),
             (r#"RAW-CAPTURE 2 "a" 1e-6 ro[0]"#, vec![], vec![]),
             // A non-blocking pulse blocks only its precise frame, not other frames on the same qubits
             (
                 r#"NONBLOCKING PULSE 0 "a" custom_waveform"#,
                 vec![r#"0 "a""#],
-                vec![r#"0 "a""#],
+                vec![],
             ),
             (
                 r#"NONBLOCKING PULSE 1 "c" custom_waveform"#,
                 vec![r#"1 "c""#],
-                vec![r#"1 "c""#],
+                vec![],
             ),
             (
                 r#"NONBLOCKING PULSE 0 1 "2q" custom_waveform"#,
                 vec![r#"0 1 "2q""#],
-                vec![r#"0 1 "2q""#],
+                vec![],
             ),
             // A Fence with qubits specified uses and blocks all frames intersecting that qubit
             (r#"FENCE 1"#, vec![], vec![r#"1 "c""#, r#"0 1 "2q""#]),
@@ -532,23 +535,20 @@ DEFFRAME 0 1 \"2q\":
                 vec![r#"0 "a""#, r#"0 "b""#, r#"1 "c""#, r#"0 1 "2q""#],
             ),
             // Delay uses and blocks frames on exactly the given qubits and with any of the given names
-            (
-                r#"DELAY 0 1.0"#,
-                vec![r#"0 "a""#, r#"0 "b""#],
-                vec![r#"0 "a""#, r#"0 "b""#],
-            ),
-            (r#"DELAY 1 1.0"#, vec![r#"1 "c""#], vec![r#"1 "c""#]),
-            (r#"DELAY 1 "c" 1.0"#, vec![r#"1 "c""#], vec![r#"1 "c""#]),
-            (r#"DELAY 0 1 1.0"#, vec![r#"0 1 "2q""#], vec![r#"0 1 "2q""#]),
+            (r#"DELAY 0 1.0"#, vec![r#"0 "a""#, r#"0 "b""#], vec![]),
+            (r#"DELAY 1 1.0"#, vec![r#"1 "c""#], vec![]),
+            (r#"DELAY 1 "c" 1.0"#, vec![r#"1 "c""#], vec![]),
+            (r#"DELAY 0 1 1.0"#, vec![r#"0 1 "2q""#], vec![]),
             (
                 r#"SWAP-PHASES 0 "a" 0 "b""#,
                 vec![r#"0 "a""#, r#"0 "b""#],
-                vec![r#"0 "a""#, r#"0 "b""#],
+                vec![],
             ),
         ] {
             let instruction = Instruction::parse(instruction_string).unwrap();
-            let used_frames: HashSet<String> = program
-                .get_frames_for_instruction(&instruction, false)
+            let matched_frames = program.get_frames_for_instruction(&instruction).unwrap();
+            let used_frames: HashSet<String> = matched_frames
+                .used
                 .unwrap_or_default()
                 .into_iter()
                 .map(|f| f.to_string())
@@ -562,9 +562,9 @@ DEFFRAME 0 1 \"2q\":
                 "Instruction {instruction} *used* frames `{used_frames:?}` but we expected `{expected_used_frames:?}`"
             );
 
-            let blocked_frames: HashSet<String> = program
-                .get_frames_for_instruction(&instruction, true)
-                .unwrap()
+            let blocked_frames: HashSet<String> = matched_frames
+                .blocked
+                .unwrap_or_default()
                 .into_iter()
                 .map(|f| f.to_string())
                 .collect();


### PR DESCRIPTION
* Call this method less frequently
* Return `Option::None` rather than `HashSet::new` when nothing matches

Evaluation against a yet-to-be-published benchmark indicates a 50% performance increase in `ScheduledProgram::from_program`

Closes #231 