### PR TITLE
refactor!: more optimizations

### DIFF
--- a/quil-py/src/program/mod.rs
+++ b/quil-py/src/program/mod.rs
@@ -152,7 +152,7 @@ impl PyProgram {
 
     pub fn add_instructions(&mut self, instructions: Vec<PyInstruction>) {
         self.as_inner_mut()
-            .add_instructions(instructions.into_iter().map(Into::into).collect())
+            .add_instructions(instructions.into_iter().map(Into::into))
     }
 
     pub fn to_instructions(&self, py: Python<'_>) -> PyResult<Vec<PyInstruction>> {

--- a/quil-py/src/program/mod.rs
+++ b/quil-py/src/program/mod.rs
@@ -57,8 +57,7 @@ impl PyProgram {
         Ok(PyList::new(
             py,
             self.as_inner()
-                .instructions
-                .iter()
+                .body_instructions()
                 .map(|i| i.to_python(py))
                 .collect::<PyResult<Vec<PyInstruction>>>()?,
         ))

--- a/quil-rs/benches/get_frames_for_instruction.rs
+++ b/quil-rs/benches/get_frames_for_instruction.rs
@@ -20,7 +20,7 @@ fn benchmark_quil_corpus(c: &mut Criterion) {
                                 .expect("program should parse successfully")
                         },
                         |prog| {
-                            for instruction in &prog.instructions {
+                            for instruction in prog.body_instructions() {
                                 for _ in 0..50 {
                                     let frames = prog
                                         .get_frames_for_instruction(instruction, include_blocked);

--- a/quil-rs/src/instruction/mod.rs
+++ b/quil-rs/src/instruction/mod.rs
@@ -481,7 +481,9 @@ impl Instruction {
             } else {
                 FrameMatchCondition::And(vec![
                     FrameMatchCondition::ExactQubits(qubits.iter().collect()),
-                    FrameMatchCondition::AnyOfNames(frame_names.iter().collect()),
+                    FrameMatchCondition::AnyOfNames(
+                        frame_names.iter().map(String::as_str).collect(),
+                    ),
                 ])
             }),
             Instruction::Fence(Fence { qubits }) => {

--- a/quil-rs/src/instruction/mod.rs
+++ b/quil-rs/src/instruction/mod.rs
@@ -647,7 +647,7 @@ RX(2) 0",
         )
         .unwrap();
         let closure = |expr: &mut Expression| *expr = Expression::Variable(String::from("a"));
-        for instruction in program.instructions.iter_mut() {
+        for instruction in program.body_instructions_mut() {
             instruction.apply_to_expressions(closure);
         }
 

--- a/quil-rs/src/program/frame.rs
+++ b/quil-rs/src/program/frame.rs
@@ -71,7 +71,6 @@ impl FrameSet {
             FrameMatchCondition::And(conditions) => conditions
                 .into_iter()
                 .map(|c| self.get_matching_keys(c))
-                // TODO: avoid excess collecting
                 .reduce(|acc, el| acc.into_iter().filter(|&v| el.contains(v)).collect())
                 .unwrap_or_default(),
             FrameMatchCondition::Or(conditions) => conditions

--- a/quil-rs/src/program/frame.rs
+++ b/quil-rs/src/program/frame.rs
@@ -51,7 +51,7 @@ impl FrameSet {
         match condition {
             FrameMatchCondition::All => keys.collect(),
             FrameMatchCondition::AnyOfNames(names) => {
-                keys.filter(|&f| names.contains(&f.name)).collect()
+                keys.filter(|&f| names.contains(f.name.as_str())).collect()
             }
             FrameMatchCondition::AnyOfQubits(qubits) => keys
                 .filter(|&f| f.qubits.iter().any(|q| qubits.contains(&q)))
@@ -137,7 +137,7 @@ pub(crate) enum FrameMatchCondition<'a> {
     All,
 
     /// Match all frames which share any one of these names
-    AnyOfNames(HashSet<&'a String>),
+    AnyOfNames(HashSet<&'a str>),
 
     /// Match all frames which contain any of these qubits
     AnyOfQubits(HashSet<&'a Qubit>),

--- a/quil-rs/src/program/frame.rs
+++ b/quil-rs/src/program/frame.rs
@@ -71,6 +71,7 @@ impl FrameSet {
             FrameMatchCondition::And(conditions) => conditions
                 .into_iter()
                 .map(|c| self.get_matching_keys(c))
+                // TODO: avoid excess collecting
                 .reduce(|acc, el| acc.into_iter().filter(|&v| el.contains(v)).collect())
                 .unwrap_or_default(),
             FrameMatchCondition::Or(conditions) => conditions

--- a/quil-rs/src/program/graph.rs
+++ b/quil-rs/src/program/graph.rs
@@ -199,13 +199,13 @@ pub type DependencyGraph = GraphMap<ScheduledGraphNode, HashSet<ExecutionDepende
 /// which include no control flow instructions aside from an (optional) terminating control
 /// flow instruction.
 #[derive(Clone, Debug)]
-pub struct InstructionBlock {
-    pub instructions: Vec<Instruction>,
+pub struct InstructionBlock<'a> {
+    pub instructions: Vec<&'a Instruction>,
     pub(super) graph: DependencyGraph,
-    pub terminator: BlockTerminator,
+    pub terminator: BlockTerminator<'a>,
 }
 
-impl Default for InstructionBlock {
+impl<'a> Default for InstructionBlock<'a> {
     fn default() -> Self {
         Self {
             instructions: Default::default(),
@@ -293,11 +293,12 @@ impl PreviousNodes {
     }
 }
 
-impl InstructionBlock {
+impl<'a> InstructionBlock<'a> {
     pub fn build(
-        instructions: Vec<Instruction>,
-        terminator: Option<BlockTerminator>,
-        program: &Program,
+        // The set of instructions in the block, a subset of the `program`.
+        instructions: Vec<&'a Instruction>,
+        terminator: Option<BlockTerminator<'a>>,
+        program: &'a Program,
     ) -> ScheduleResult<Self> {
         let mut graph: DependencyGraph = GraphMap::new();
         // Root node
@@ -306,6 +307,7 @@ impl InstructionBlock {
         let mut last_classical_instruction = ScheduledGraphNode::BlockStart;
 
         // Store the instruction index of the last instruction to block that frame
+        // TODO: with_capacity program.frames.len()
         let mut last_instruction_by_frame: HashMap<FrameIdentifier, PreviousNodes> = HashMap::new();
         let mut last_timed_instruction_by_frame: HashMap<FrameIdentifier, PreviousNodes> =
             HashMap::new();
@@ -316,6 +318,7 @@ impl InstructionBlock {
 
         for (index, instruction) in instructions.iter().enumerate() {
             let node = graph.add_node(ScheduledGraphNode::InstructionIndex(index));
+            let instruction = *instruction;
 
             let instruction_role = InstructionRole::from(instruction);
             match instruction_role {
@@ -461,7 +464,7 @@ impl InstructionBlock {
 
     /// Return a particular-indexed instruction (if present).
     pub fn get_instruction(&self, node_id: usize) -> Option<&Instruction> {
-        self.instructions.get(node_id)
+        self.instructions.get(node_id).copied()
     }
 
     /// Return the count of executable instructions in this block.
@@ -474,29 +477,30 @@ impl InstructionBlock {
         self.instructions.is_empty()
     }
 
-    pub fn set_exit_condition(&mut self, terminator: BlockTerminator) {
-        self.terminator = terminator
+    pub fn set_exit_condition(&mut self, terminator: BlockTerminator<'a>) {
+        self.terminator = terminator;
     }
 }
 
 #[derive(Clone, Debug)]
-pub enum BlockTerminator {
+pub enum BlockTerminator<'a> {
     Conditional {
-        condition: MemoryReference,
-        target: String,
+        condition: &'a MemoryReference,
+        target: &'a String,
         jump_if_condition_true: bool,
     },
     Unconditional {
-        target: String,
+        target: &'a String,
     },
     Continue,
     Halt,
 }
 
+// TODO: make dependent on the lifetime of Program
 #[derive(Clone, Debug)]
-pub struct ScheduledProgram {
+pub struct ScheduledProgram<'a> {
     /// All blocks within the ScheduledProgram, keyed on string label.
-    pub blocks: IndexMap<String, InstructionBlock>,
+    pub blocks: IndexMap<String, InstructionBlock<'a>>,
 }
 
 /// Builds an [`InstructionBlock`] from provided instructions, terminator, and program, then tracks
@@ -511,12 +515,12 @@ pub struct ScheduledProgram {
 ///
 /// If an error occurs, `working_instructions` and/or `working_label` may have been emptied and
 /// cannot be relied on to be unchanged.
-fn terminate_working_block(
-    terminator: Option<BlockTerminator>,
-    working_instructions: &mut Vec<Instruction>,
-    blocks: &mut IndexMap<String, InstructionBlock>,
-    working_label: &mut Option<String>,
-    program: &Program,
+fn terminate_working_block<'a>(
+    terminator: Option<BlockTerminator<'a>>,
+    working_instructions: &mut Vec<&'a Instruction>,
+    blocks: &mut IndexMap<String, InstructionBlock<'a>>,
+    working_label: &mut Option<&'a String>,
+    program: &'a Program,
     instruction_index: Option<usize>,
 ) -> ScheduleResult<()> {
     // If this "block" has no instructions and no terminator, it's not worth storing - skip it
@@ -528,6 +532,7 @@ fn terminate_working_block(
     let block = InstructionBlock::build(std::mem::take(working_instructions), terminator, program)?;
     let label = working_label
         .take()
+        .cloned()
         .unwrap_or_else(|| ScheduledProgram::generate_autoincremented_label(blocks));
 
     if blocks.insert(label.clone(), block).is_some() {
@@ -541,17 +546,17 @@ fn terminate_working_block(
     Ok(())
 }
 
-impl ScheduledProgram {
+impl<'a> ScheduledProgram<'a> {
     /// Structure a sequential program
     #[allow(unused_assignments)]
-    pub fn from_program(program: &Program) -> ScheduleResult<Self> {
+    pub fn from_program(program: &'a Program) -> ScheduleResult<Self> {
         let mut working_label = None;
-        let mut working_instructions: Vec<Instruction> = vec![];
+        let mut working_instructions: Vec<&'a Instruction> = vec![];
         let mut blocks = IndexMap::new();
 
-        let instructions = program.to_instructions();
+        // let instructions = program.to_instructions();
 
-        for (index, instruction) in instructions.into_iter().enumerate() {
+        for (index, instruction) in program.instructions.iter().enumerate() {
             let instruction_index = Some(index);
             match instruction {
                 Instruction::Arithmetic(_)
@@ -583,7 +588,7 @@ impl ScheduledProgram {
                 Instruction::Gate(_) | Instruction::Measurement(_) => {
                     return Err(ScheduleError {
                         instruction_index,
-                        instruction,
+                        instruction: instruction.clone(),
                         variant: ScheduleErrorVariant::UncalibratedInstruction,
                     })
                 }

--- a/quil-rs/src/program/graph.rs
+++ b/quil-rs/src/program/graph.rs
@@ -485,11 +485,11 @@ impl<'a> InstructionBlock<'a> {
 pub enum BlockTerminator<'a> {
     Conditional {
         condition: &'a MemoryReference,
-        target: &'a String,
+        target: &'a str,
         jump_if_condition_true: bool,
     },
     Unconditional {
-        target: &'a String,
+        target: &'a str,
     },
     Continue,
     Halt,
@@ -517,7 +517,7 @@ fn terminate_working_block<'a>(
     terminator: Option<BlockTerminator<'a>>,
     working_instructions: &mut Vec<&'a Instruction>,
     blocks: &mut IndexMap<String, InstructionBlock<'a>>,
-    working_label: &mut Option<&'a String>,
+    working_label: &mut Option<&'a str>,
     program: &'a Program,
     instruction_index: Option<usize>,
 ) -> ScheduleResult<()> {
@@ -530,7 +530,7 @@ fn terminate_working_block<'a>(
     let block = InstructionBlock::build(std::mem::take(working_instructions), terminator, program)?;
     let label = working_label
         .take()
-        .cloned()
+        .map(String::from)
         .unwrap_or_else(|| ScheduledProgram::generate_autoincremented_label(blocks));
 
     if blocks.insert(label.clone(), block).is_some() {

--- a/quil-rs/src/program/graph.rs
+++ b/quil-rs/src/program/graph.rs
@@ -307,7 +307,6 @@ impl<'a> InstructionBlock<'a> {
         let mut last_classical_instruction = ScheduledGraphNode::BlockStart;
 
         // Store the instruction index of the last instruction to block that frame
-        // TODO: with_capacity program.frames.len()
         let mut last_instruction_by_frame: HashMap<FrameIdentifier, PreviousNodes> = HashMap::new();
         let mut last_timed_instruction_by_frame: HashMap<FrameIdentifier, PreviousNodes> =
             HashMap::new();
@@ -496,7 +495,6 @@ pub enum BlockTerminator<'a> {
     Halt,
 }
 
-// TODO: make dependent on the lifetime of Program
 #[derive(Clone, Debug)]
 pub struct ScheduledProgram<'a> {
     /// All blocks within the ScheduledProgram, keyed on string label.

--- a/quil-rs/src/program/graph.rs
+++ b/quil-rs/src/program/graph.rs
@@ -552,9 +552,7 @@ impl<'a> ScheduledProgram<'a> {
         let mut working_instructions: Vec<&'a Instruction> = vec![];
         let mut blocks = IndexMap::new();
 
-        // let instructions = program.to_instructions();
-
-        for (index, instruction) in program.instructions.iter().enumerate() {
+        for (index, instruction) in program.body_instructions().enumerate() {
             let instruction_index = Some(index);
             match instruction {
                 Instruction::Arithmetic(_)

--- a/quil-rs/src/program/graphviz_dot.rs
+++ b/quil-rs/src/program/graphviz_dot.rs
@@ -21,7 +21,7 @@ use crate::program::graph::{
     ScheduledProgram,
 };
 
-impl InstructionBlock {
+impl<'a> InstructionBlock<'a> {
     /// Given a [`dot_writer::Scope`] representing a subgraph/cluster, write the timing graph for this block into it.
     /// Uses the `node_prefix` argument for namespacing so that node IDs remain unique within the overall graph.
     fn write_dot_format(&self, cluster: &mut dot_writer::Scope, node_prefix: &str) {
@@ -80,7 +80,7 @@ impl InstructionBlock {
     }
 }
 
-impl ScheduledProgram {
+impl<'a> ScheduledProgram<'a> {
     /// Return a DOT format string (as bytes) for use with Graphviz.
     ///
     /// This outputs a `digraph` object with a `subgraph` for each block to inform the layout engine.

--- a/quil-rs/src/program/memory.rs
+++ b/quil-rs/src/program/memory.rs
@@ -315,6 +315,7 @@ impl Expression {
 impl WaveformInvocation {
     /// Return, if any, the memory references contained within this WaveformInvocation.
     pub fn get_memory_references(&self) -> Vec<&MemoryReference> {
+        // TODO: iterator + collect
         let mut result = vec![];
 
         for expression in self.parameters.values() {

--- a/quil-rs/src/program/memory.rs
+++ b/quil-rs/src/program/memory.rs
@@ -315,13 +315,9 @@ impl Expression {
 impl WaveformInvocation {
     /// Return, if any, the memory references contained within this WaveformInvocation.
     pub fn get_memory_references(&self) -> Vec<&MemoryReference> {
-        // TODO: iterator + collect
-        let mut result = vec![];
-
-        for expression in self.parameters.values() {
-            result.extend(expression.get_memory_references());
-        }
-
-        result
+        self.parameters
+            .values()
+            .flat_map(Expression::get_memory_references)
+            .collect()
     }
 }

--- a/quil-rs/src/program/mod.rs
+++ b/quil-rs/src/program/mod.rs
@@ -84,7 +84,8 @@ impl Program {
     }
 
     /// Returns an iterator over mutable references to the instructions that make up the body of the program.
-    pub fn body_instructions_mut(&mut self) -> impl Iterator<Item = &mut Instruction> {
+    #[cfg(test)]
+    pub(crate) fn body_instructions_mut(&mut self) -> impl Iterator<Item = &mut Instruction> {
         self.instructions.iter_mut()
     }
 

--- a/quil-rs/src/program/mod.rs
+++ b/quil-rs/src/program/mod.rs
@@ -83,6 +83,10 @@ impl Program {
         self.instructions.iter()
     }
 
+    pub fn into_body_instructions(self) -> impl Iterator<Item = Instruction> {
+        self.instructions.into_iter()
+    }
+
     /// Returns an iterator over mutable references to the instructions that make up the body of the program.
     #[cfg(test)]
     pub(crate) fn body_instructions_mut(&mut self) -> impl Iterator<Item = &mut Instruction> {
@@ -119,7 +123,10 @@ impl Program {
         }
     }
 
-    pub fn add_instructions(&mut self, instructions: Vec<Instruction>) {
+    pub fn add_instructions<I>(&mut self, instructions: I)
+    where
+        I: IntoIterator<Item = Instruction>,
+    {
         instructions
             .into_iter()
             .for_each(|i| self.add_instruction(i));

--- a/quil-rs/src/program/mod.rs
+++ b/quil-rs/src/program/mod.rs
@@ -64,7 +64,7 @@ pub struct Program {
     pub frames: FrameSet,
     pub memory_regions: BTreeMap<String, MemoryRegion>,
     pub waveforms: BTreeMap<String, Waveform>,
-    pub instructions: Vec<Instruction>,
+    instructions: Vec<Instruction>,
 }
 
 impl Program {
@@ -76,6 +76,16 @@ impl Program {
             waveforms: BTreeMap::new(),
             instructions: vec![],
         }
+    }
+
+    /// Returns an iterator over immutable references to the instructions that make up the body of the program.
+    pub fn body_instructions(&self) -> impl Iterator<Item=&Instruction> {
+        self.instructions.iter()
+    }
+
+    /// Returns an iterator over mutable references to the instructions that make up the body of the program.
+    pub fn body_instructions_mut(&mut self) -> impl Iterator<Item=&mut Instruction> {
+        self.instructions.iter_mut()
     }
 
     /// Add an instruction to the end of the program.

--- a/quil-rs/src/program/mod.rs
+++ b/quil-rs/src/program/mod.rs
@@ -79,12 +79,12 @@ impl Program {
     }
 
     /// Returns an iterator over immutable references to the instructions that make up the body of the program.
-    pub fn body_instructions(&self) -> impl Iterator<Item=&Instruction> {
+    pub fn body_instructions(&self) -> impl Iterator<Item = &Instruction> {
         self.instructions.iter()
     }
 
     /// Returns an iterator over mutable references to the instructions that make up the body of the program.
-    pub fn body_instructions_mut(&mut self) -> impl Iterator<Item=&mut Instruction> {
+    pub fn body_instructions_mut(&mut self) -> impl Iterator<Item = &mut Instruction> {
         self.instructions.iter_mut()
     }
 


### PR DESCRIPTION
There are two primary changes here:

1. The qubits used by a `Program` is now tracked when adding instructions using `add_instruction(s)`. This removes the need to built the `HashSet` whenever the set of qubits is requested.
    - The downside is that the `instructions` field should no longer be `pub` to avoid accidentally working around this behavior. This is my next step.
    - This change introduced an improvement of 5-7% in the relevant benchmarks, and no difference otherwise.
2. `ScheduledProgram::from_program` used to take a `&Program` and clone the parts it needed. It now instead takes references to those things, removing the excess clones.
    - With real-world programs, this saw a ~14% improvement in benchmarking. A few benchmark programs saw improvements of ~60%! (I'm not sure how much I trust that number, but everything saw _some_ improvement.