### PR TITLE
fix: hash PiConstant like Expression::Number

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1061,7 +1061,7 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quil-py"
-version = "0.2.0-rc.7"
+version = "0.2.0-rc.8"
 dependencies = [
  "ndarray",
  "numpy",
@@ -1074,7 +1074,7 @@ dependencies = [
 
 [[package]]
 name = "quil-rs"
-version = "0.18.0-rc.7"
+version = "0.18.0-rc.8"
 dependencies = [
  "approx",
  "criterion",

--- a/quil-rs/src/expression/mod.rs
+++ b/quil-rs/src/expression/mod.rs
@@ -155,16 +155,16 @@ impl Hash for Expression {
                     }
                 }
             }
-            Number(c) => {
+            Number(n) => {
                 "Number".hash(state);
                 // Skip zero values (akin to `format_complex`).
                 // Also, since f64 isn't hashable, use the u64 binary representation.
                 // The docs claim this is rather portable: https://doc.rust-lang.org/std/primitive.f64.html#method.to_bits
-                if c.re.abs() > 0f64 {
-                    hash_f64(c.re, state);
+                if n.re.abs() > 0f64 {
+                    hash_f64(n.re, state)
                 }
-                if c.im.abs() > 0f64 {
-                    hash_f64(c.im, state);
+                if n.im.abs() > 0f64 {
+                    hash_f64(n.im, state)
                 }
             }
             PiConstant => {


### PR DESCRIPTION
We've noticed some issues in downstream consumers of `quil-rs` pertaining to, e.g., calibrations. If a user has a `DEFCAL RX(pi) 0 …` somewhere, `quil-rs` will keep the `Expression::PiConstant` around, but "simplify" it in the calibration to `RX(std::f64::consts::PI) 0` in practice. This will _not_ match the user-given calibration, causing sorrow and strife.

Since we have the `PartialEq` and `Eq` traits for `Expression` based on its `Hash` implementation, this PR changes the hash step for `PIConstant` to act like the equivalent `Expression::Number`'s hash.