### PR TITLE
fix: Expand all analog control instructions

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -31,7 +31,14 @@ ignore = []
 # https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html
 [licenses]
 unlicensed = "deny"
-allow = ["Apache-2.0", "Apache-2.0 WITH LLVM-exception", "BSD-2-Clause", "BSD-3-Clause", "MIT", "Unicode-DFS-2016"]
+allow = [
+  "Apache-2.0",
+  "Apache-2.0 WITH LLVM-exception",
+  "BSD-2-Clause",
+  "BSD-3-Clause",
+  "MIT",
+  "Unicode-DFS-2016",
+]
 # List of explictly disallowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses
 # [possible values: any SPDX 3.11 short identifier (+ optional exception)].
@@ -69,13 +76,14 @@ multiple-versions = "deny"
 wildcards = "deny"
 highlight = "all"
 skip-tree = [
-    { name = "syn", version = "*", depth = 5 }, # Used in both serde_derive and proptest-derive
-    { name = "quick-error", version = "*" },    # proptest relies on two versions of this
-    { name = "itoa", version = "*" },           # various dependencies rely on two versions of this
-    { name = "hermit-abi", version = "*" },     # various dependencies rely on two versions of this
-    { name = "memoffset", version = "*" },      # various dependencies rely on two versions of this
-    { name = "windows-sys", version = "*" },    # various dependencies rely on two versions of this
-    { name = "redox_syscall", version = "*" },  # proptest and pyo3 rely on two versions of this
+  { name = "syn", version = "*", depth = 5 }, # Used in both serde_derive and proptest-derive
+  { name = "quick-error", version = "*" },    # proptest relies on two versions of this
+  { name = "itoa", version = "*" },           # various dependencies rely on two versions of this
+  { name = "hermit-abi", version = "*" },     # various dependencies rely on two versions of this
+  { name = "memoffset", version = "*" },      # various dependencies rely on two versions of this
+  { name = "windows-sys", version = "*" },    # various dependencies rely on two versions of this
+  { name = "regex-syntax", version = "*" },   # proptest and criterion rely on two versions of this
+  { name = "redox_syscall", version = "*" },  # proptest and pyo3 rely on two versions of this
 ]
 
 # This section is considered when running `cargo deny check sources`.
@@ -91,4 +99,3 @@ unknown-git = "deny"
 # List of URLs for allowed crate registries. Defaults to the crates.io index
 # if not specified. If it is specified but empty, no registries are allowed.
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
-

--- a/quil-rs/src/program/calibration.rs
+++ b/quil-rs/src/program/calibration.rs
@@ -17,7 +17,9 @@ use std::collections::HashMap;
 use crate::{
     expression::Expression,
     instruction::{
-        Calibration, Delay, Gate, Instruction, MeasureCalibrationDefinition, Measurement, Qubit,
+        Calibration, Capture, Delay, FrameIdentifier, Gate, Instruction,
+        MeasureCalibrationDefinition, Measurement, Pulse, Qubit, RawCapture, SetFrequency,
+        SetPhase, SetScale, ShiftFrequency, ShiftPhase,
     },
 };
 
@@ -107,7 +109,39 @@ impl CalibrationSet {
                         for instruction in instructions.iter_mut() {
                             match instruction {
                                 Instruction::Gate(Gate { qubits, .. })
-                                | Instruction::Delay(Delay { qubits, .. }) => {
+                                | Instruction::Delay(Delay { qubits, .. })
+                                | Instruction::Capture(Capture {
+                                    frame: FrameIdentifier { qubits, .. },
+                                    ..
+                                })
+                                | Instruction::RawCapture(RawCapture {
+                                    frame: FrameIdentifier { qubits, .. },
+                                    ..
+                                })
+                                | Instruction::SetFrequency(SetFrequency {
+                                    frame: FrameIdentifier { qubits, .. },
+                                    ..
+                                })
+                                | Instruction::SetPhase(SetPhase {
+                                    frame: FrameIdentifier { qubits, .. },
+                                    ..
+                                })
+                                | Instruction::SetScale(SetScale {
+                                    frame: FrameIdentifier { qubits, .. },
+                                    ..
+                                })
+                                | Instruction::ShiftFrequency(ShiftFrequency {
+                                    frame: FrameIdentifier { qubits, .. },
+                                    ..
+                                })
+                                | Instruction::ShiftPhase(ShiftPhase {
+                                    frame: FrameIdentifier { qubits, .. },
+                                    ..
+                                })
+                                | Instruction::Pulse(Pulse {
+                                    frame: FrameIdentifier { qubits, .. },
+                                    ..
+                                }) => {
                                     // Swap all qubits for their concrete implementations
                                     for qubit in qubits {
                                         match qubit {
@@ -413,6 +447,14 @@ mod tests {
     #[case(
         "Calibration-Variable-Qubit",
         concat!("DEFCAL I %q:\n", "    DELAY q 4e-8\n", "I 0\n",),
+    )]
+    #[case(
+        "ShiftPhase",
+        concat!(
+            "DEFCAL RZ(%theta) %q:\n",
+            "    SHIFT-PHASE %q \"rf\" -%theta\n",
+            "RZ(pi) 0\n",
+        )
     )]
     fn test_expansion(#[case] description: &str, #[case] input: &str) {
         let program = Program::from_str(input).unwrap();

--- a/quil-rs/src/program/snapshots/quil_rs__program__calibration__tests__expansion@ShiftPhase.snap
+++ b/quil-rs/src/program/snapshots/quil_rs__program__calibration__tests__expansion@ShiftPhase.snap
@@ -1,0 +1,8 @@
+---
+source: quil-rs/src/program/calibration.rs
+expression: calibrated_program.to_string()
+---
+DEFCAL RZ(%theta) %q:
+	SHIFT-PHASE q "rf" -%theta
+SHIFT-PHASE 0 "rf" -pi
+


### PR DESCRIPTION
Closes #227 - calibration expansion was actually working fine, we just weren't account for every type of instruction that could be in the calibration.