### PR TITLE
fix(rs): 'simplify' pi expression to floating-point form

### DIFF
--- a/quil-rs/src/expression/mod.rs
+++ b/quil-rs/src/expression/mod.rs
@@ -1043,7 +1043,7 @@ mod tests {
     #[test]
     fn specific_simplification_tests() {
         for (input, expected) in vec![
-            // ("pi", Expression::Number(PI.into())),
+            ("pi", Expression::Number(PI.into())),
             ("pi/2", Expression::Number((PI / 2.0).into())),
             ("pi * pi", Expression::Number((PI.powi(2)).into())),
         ] {

--- a/quil-rs/src/expression/simplification.rs
+++ b/quil-rs/src/expression/simplification.rs
@@ -11,6 +11,7 @@ use egg::{define_language, rewrite as rw, Id, Language, RecExpr};
 use once_cell::sync::Lazy;
 use std::{
     cmp::Ordering,
+    f64::consts::PI,
     hash::{Hash, Hasher},
     ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign},
     str::FromStr,
@@ -268,7 +269,7 @@ fn expression_to_recexpr(expression: &Expression) -> RecExpr<Expr> {
 fn recexpr_to_expression(recexpr: RecExpr<Expr>) -> Result<Expression, SimplificationError> {
     fn helper(nodes: &[Expr], i: usize) -> Result<Expression, SimplificationError> {
         match nodes[i] {
-            Expr::Pi => Ok(Expression::PiConstant),
+            Expr::Pi => Ok(Expression::Number(PI.into())),
             Expr::Number(x) => Ok(Expression::Number(x.0)),
             Expr::Cis(id) => {
                 let expression = Box::new(helper(nodes, id.into())?);

--- a/quil-rs/src/program/calibration.rs
+++ b/quil-rs/src/program/calibration.rs
@@ -385,6 +385,14 @@ mod tests {
         ),
     )]
     #[case(
+        "Calibration-Literal-Parameter",
+        concat!(
+            "DEFCAL RX(3.141592653589793) 0:\n",
+            "    NOP\n",
+            "RX(3.141592653589793) 0\n",
+        ),
+    )]
+    #[case(
         "Calibration-Instruction-Match",
         concat!(
             "DEFCAL X 0:\n",

--- a/quil-rs/src/program/snapshots/quil_rs__program__calibration__tests__expansion@Calibration-Literal-Parameter.snap
+++ b/quil-rs/src/program/snapshots/quil_rs__program__calibration__tests__expansion@Calibration-Literal-Parameter.snap
@@ -1,0 +1,8 @@
+---
+source: quil-rs/src/program/calibration.rs
+expression: calibrated_program.to_string()
+---
+DEFCAL RX(3.141592653589793) 0:
+	NOP
+NOP
+


### PR DESCRIPTION
This change makes expression simplification consistent between the following:

* `pi` is the root expression
* `pi` is a member of the expression

Previously, `pi/2` simplified to its floating point form (`1.57...`) while `pi` did not. This amends that, so that `simplify(pi) == 3.14...`).