### PR TITLE
feat(rs): Program::into_instructions

### DIFF
--- a/quil-rs/src/program/calibration.rs
+++ b/quil-rs/src/program/calibration.rs
@@ -336,6 +336,19 @@ impl CalibrationSet {
         self.measure_calibrations.extend(other.measure_calibrations);
     }
 
+    /// Return the Quil instructions which describe the contained calibrations, consuming the [`CalibrationSet`].
+    pub fn into_instructions(self) -> Vec<Instruction> {
+        self.calibrations
+            .into_iter()
+            .map(Instruction::CalibrationDefinition)
+            .chain(
+                self.measure_calibrations
+                    .into_iter()
+                    .map(Instruction::MeasureCalibrationDefinition),
+            )
+            .collect()
+    }
+
     /// Return the Quil instructions which describe the contained calibrations.
     pub fn to_instructions(&self) -> Vec<Instruction> {
         self.calibrations

--- a/quil-rs/src/program/frame.rs
+++ b/quil-rs/src/program/frame.rs
@@ -139,6 +139,19 @@ impl FrameSet {
         self.frames.is_empty()
     }
 
+    /// Return the Quil instructions which describe the contained frames, consuming the [`FrameSet`].
+    pub fn into_instructions(self) -> Vec<Instruction> {
+        self.frames
+            .into_iter()
+            .map(|(identifier, attributes)| {
+                Instruction::FrameDefinition(FrameDefinition {
+                    identifier,
+                    attributes,
+                })
+            })
+            .collect()
+    }
+
     /// Return the Quil instructions which describe the contained frames.
     pub fn to_instructions(&self) -> Vec<Instruction> {
         self.frames


### PR DESCRIPTION
Closes #241 

Simple enough.

I did not see a neat way to share code between `Program::into_instructions` and `Program::to_instructions` without cloning more than strictly needs to be cloned in the latter.

I'd like to be able to support `as_instructions(&self) -> Vec<&Instruction>` but many of the owned instructions are created within the method (and not just referenced). If `CalibrationSet` et al were to be restructured so as to maintain their backing instructions in `Instruction` form (rather than decomposing them), we could do that (in another PR).