### PR TITLE
feat(rs): wasm-bindgen cargo feature

### DIFF
--- a/quil-rs/Cargo.toml
+++ b/quil-rs/Cargo.toml
@@ -33,8 +33,10 @@ proptest = "1.0.0"
 proptest-derive = "0.3.0"
 rstest = "0.15.0"
 
+# These are described in the crate README.md
 [features]
 graphviz-dot = ["dot-writer"]
+wasm-bindgen = ["egg/wasm-bindgen"]
 
 [[bench]]
 name = "parser"

--- a/quil-rs/README.md
+++ b/quil-rs/README.md
@@ -10,6 +10,13 @@ It serves three purposes:
 
 It should be considered unstable until the release of v1.0.
 
+## Crate Features
+
+| Feature      | Description                                                        |   |   |   |
+|--------------|--------------------------------------------------------------------|---|---|---|
+| graphviz-dot | Enable plotting `ScheduledProgram`s in Graphviz dotfile format.    |   |   |   |
+| wasm-bindgen | Enable compilation to `wasm32-unknown-unknown` with `wasm-bindgen` |   |   |   |
+
 
 ## Testing
 


### PR DESCRIPTION
Adds `wasm-bindgen` crate feature so that users don't have to discover themselves that `egg` requires `instant` which requires the same feature to be set.

Also adds a feature table to the Readme.