### PR TITLE
Specify minimum rust version to improve compile-failure error message

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -545,6 +545,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -1070,7 +1073,7 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quil-py"
-version = "0.2.0-rc.10"
+version = "0.2.0"
 dependencies = [
  "ndarray",
  "numpy",
@@ -1083,7 +1086,7 @@ dependencies = [
 
 [[package]]
 name = "quil-rs"
-version = "0.18.0-rc.10"
+version = "0.18.0"
 dependencies = [
  "approx",
  "criterion",

--- a/quil-rs/Cargo.toml
+++ b/quil-rs/Cargo.toml
@@ -3,6 +3,7 @@ name = "quil-rs"
 description = "Rust tooling for Quil (Quantum Instruction Language)"
 version = "0.18.0"
 edition = "2021"
+rust-version = "1.70"
 license = "Apache-2.0"
 repository = "https://github.com/rigetti/quil-rust"
 keywords = ["Quil", "Quantum", "Rigetti"]


### PR DESCRIPTION
We recently added code that only compiles with Rust 1.70, leading to a confusing error message ([reported in Slack](https://rigetti.slack.com/archives/C02BBP9A60J/p1689182934952119)).

This sets the minimum required Rust version to 1.70 for `quil-rs`. For now, no change is made to `quil-py`. If we frequently break Rust version compatibility for users, we should consider using a tool to automate setting the version; [this one](https://github.com/foresterre/cargo-msrv) looks promising.