### PR TITLE
fix(rs): escape Quil strings for display

### DIFF
--- a/quil-rs/src/instruction/frame.rs
+++ b/quil-rs/src/instruction/frame.rs
@@ -16,7 +16,7 @@ impl fmt::Display for AttributeValue {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use AttributeValue::*;
         match self {
-            String(value) => write!(f, "\"{value}\""),
+            String(value) => write!(f, "{value:?}"),
             Expression(value) => write!(f, "{value}"),
         }
     }
@@ -67,7 +67,7 @@ impl FrameIdentifier {
 
 impl fmt::Display for FrameIdentifier {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{} \"{}\"", format_qubits(&self.qubits), self.name)
+        write!(f, "{} {:?}", format_qubits(&self.qubits), &self.name)
     }
 }
 

--- a/quil-rs/src/instruction/gate.rs
+++ b/quil-rs/src/instruction/gate.rs
@@ -198,7 +198,7 @@ fn lifted_gate_matrix(matrix: &Matrix, qubits: &[u64], n_qubits: u64) -> Matrix 
 ///          /          \                            /          \
 ///      RX(a) 3      RX(b) 3                    RX(c) 3      RX(d) 3
 /// ```
-fn gate_matrix(mut gate: &mut Gate) -> Result<Matrix, GateError> {
+fn gate_matrix(gate: &mut Gate) -> Result<Matrix, GateError> {
     static ZERO: Lazy<Matrix> =
         Lazy::new(|| array![[real!(1.0), real!(0.0)], [real!(0.0), real!(0.0)]]);
     static ONE: Lazy<Matrix> =

--- a/quil-rs/src/instruction/pragma.rs
+++ b/quil-rs/src/instruction/pragma.rs
@@ -24,7 +24,7 @@ impl fmt::Display for Pragma {
             write!(f, " {arg}")?;
         }
         if let Some(data) = &self.data {
-            write!(f, " \"{data}\"")?;
+            write!(f, " {data:?}")?;
         }
         Ok(())
     }

--- a/quil-rs/src/parser/lexer/quoted_strings.rs
+++ b/quil-rs/src/parser/lexer/quoted_strings.rs
@@ -107,10 +107,17 @@ mod tests {
     #[case("\"foo bar (baz) 123\" after", "foo bar (baz) 123", " after")]
     #[case(r#""{\"name\": \"quoted json\"}""#, r#"{"name": "quoted json"}"#, "")]
     #[case(r#""hello"\n"world""#, "hello", "\\n\"world\"")]
-    fn test_string_parser(#[case] input: &str, #[case] output: &str, #[case] leftover: &str) {
-        let input = LocatedSpan::new(input);
-        let (remaining, parsed) = unescaped_quoted_string(input).finish().unwrap();
+    fn string_parser(#[case] input: &str, #[case] output: &str, #[case] leftover: &str) {
+        let span = LocatedSpan::new(input);
+        let (remaining, parsed) = unescaped_quoted_string(span).finish().unwrap();
         assert_eq!(parsed, output);
         assert_eq!(remaining.fragment(), &leftover);
+        let round_tripped = format!("{:?}", parsed);
+        assert!(
+            input.starts_with(&round_tripped),
+            "expected `{}` to start with `{}`",
+            input,
+            round_tripped
+        );
     }
 }


### PR DESCRIPTION
Adds escaping for the two special characters, and a round-trip table test to validate.

Edit: the original version had a bug which made the escaping a no-op; this prompted me to realize that Debug formatting of strings basically just does what we need. "Basically" because it also escapes unicode graphemes, which is not called for in the Quil spec, but it's also not contrary to the Quil spec and could save us a bug report in the future.

Closes #257.