### PR TITLE
feat!: allow overriding Instruction getters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1073,7 +1073,7 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quil-py"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "ndarray",
  "numpy",
@@ -1086,7 +1086,7 @@ dependencies = [
 
 [[package]]
 name = "quil-rs"
-version = "0.18.0"
+version = "0.19.1-rc.0"
 dependencies = [
  "approx",
  "criterion",

--- a/quil-rs/src/program/frame.rs
+++ b/quil-rs/src/program/frame.rs
@@ -210,13 +210,14 @@ pub(crate) struct FrameMatchConditions<'a> {
 }
 
 /// The product of evaluating  [`FrameMatchConditions`] in the scope of available frames (such as within a [`crate::Program`]).
+#[derive(Debug)]
 pub struct MatchedFrames<'a> {
     /// Which concrete frames are blocked and not used.
     /// This set is mutually exclusive with `used`.
-    blocked: HashSet<&'a FrameIdentifier>,
+    pub blocked: HashSet<&'a FrameIdentifier>,
 
     /// Which concrete frames are used by the [`Instruction`]
-    used: HashSet<&'a FrameIdentifier>,
+    pub used: HashSet<&'a FrameIdentifier>,
 }
 
 impl<'a> MatchedFrames<'a> {

--- a/quil-rs/src/program/graph.rs
+++ b/quil-rs/src/program/graph.rs
@@ -26,7 +26,6 @@ use crate::instruction::{
 };
 use crate::{instruction::InstructionRole, program::Program};
 
-use super::frame::MatchedFrames;
 pub use super::memory::MemoryAccessType;
 
 #[derive(Debug, Clone)]
@@ -329,8 +328,7 @@ impl<'a> InstructionBlock<'a> {
                     Ok(())
                 }
                 InstructionRole::RFControl => {
-                    let matched_frames: Option<MatchedFrames<'_>> =
-                        custom_handler.matching_frames(instruction, program);
+                    let matched_frames = custom_handler.matching_frames(instruction, program);
                     let is_scheduled = custom_handler.is_scheduled(instruction);
 
                     if let Some(matched_frames) = matched_frames {

--- a/quil-rs/src/program/graph.rs
+++ b/quil-rs/src/program/graph.rs
@@ -22,7 +22,7 @@ use petgraph::Directed;
 
 use crate::instruction::{
     FrameIdentifier, Instruction, InstructionHandler, Jump, JumpUnless, JumpWhen, Label,
-    MeasureCalibrationDefinition, MemoryReference,
+    MemoryReference,
 };
 use crate::{instruction::InstructionRole, program::Program};
 

--- a/quil-rs/src/program/graph.rs
+++ b/quil-rs/src/program/graph.rs
@@ -457,14 +457,6 @@ impl<'a> InstructionBlock<'a> {
         &self.graph
     }
 
-    /// Get a mutable reference to the dependency graph for this block.
-    ///
-    /// This allows modifying the graph. There are no checks to prevent putting the graph into an
-    /// invalid state, so be careful when modifying it.
-    pub fn get_dependency_graph_mut(&mut self) -> &mut DependencyGraph {
-        &mut self.graph
-    }
-
     /// Return a particular-indexed instruction (if present).
     pub fn get_instruction(&self, node_id: usize) -> Option<&Instruction> {
         self.instructions.get(node_id).copied()

--- a/quil-rs/src/program/graph.rs
+++ b/quil-rs/src/program/graph.rs
@@ -455,6 +455,10 @@ impl<'a> InstructionBlock<'a> {
         &self.graph
     }
 
+    pub fn get_dependency_graph_mut(&mut self) -> &mut DependencyGraph {
+        &mut self.graph
+    }
+
     /// Return a particular-indexed instruction (if present).
     pub fn get_instruction(&self, node_id: usize) -> Option<&Instruction> {
         self.instructions.get(node_id).copied()

--- a/quil-rs/src/program/graph.rs
+++ b/quil-rs/src/program/graph.rs
@@ -21,11 +21,12 @@ use petgraph::graphmap::GraphMap;
 use petgraph::Directed;
 
 use crate::instruction::{
-    FrameIdentifier, Instruction, Jump, JumpUnless, JumpWhen, Label, MeasureCalibrationDefinition,
-    MemoryReference,
+    FrameIdentifier, Instruction, InstructionHandler, Jump, JumpUnless, JumpWhen, Label,
+    MeasureCalibrationDefinition, MemoryReference,
 };
 use crate::{instruction::InstructionRole, program::Program};
 
+use super::frame::MatchedFrames;
 pub use super::memory::MemoryAccessType;
 
 #[derive(Debug, Clone)]
@@ -299,6 +300,7 @@ impl<'a> InstructionBlock<'a> {
         instructions: Vec<&'a Instruction>,
         terminator: Option<BlockTerminator<'a>>,
         program: &'a Program,
+        custom_handler: &mut InstructionHandler,
     ) -> ScheduleResult<Self> {
         let mut graph: DependencyGraph = GraphMap::new();
         // Root node
@@ -315,12 +317,10 @@ impl<'a> InstructionBlock<'a> {
         // NOTE: this may be refined to serialize by memory region offset rather than by entire region.
         let mut pending_memory_access: HashMap<String, MemoryAccessQueue> = HashMap::new();
 
-        for (index, instruction) in instructions.iter().enumerate() {
+        for (index, &instruction) in instructions.iter().enumerate() {
             let node = graph.add_node(ScheduledGraphNode::InstructionIndex(index));
-            let instruction = *instruction;
 
-            let instruction_role = InstructionRole::from(instruction);
-            match instruction_role {
+            match custom_handler.role_for_instruction(instruction) {
                 // Classical instructions must be ordered by appearance in the program
                 InstructionRole::ClassicalCompute => {
                     add_dependency!(graph, last_classical_instruction => node, ExecutionDependency::StableOrdering);
@@ -329,11 +329,13 @@ impl<'a> InstructionBlock<'a> {
                     Ok(())
                 }
                 InstructionRole::RFControl => {
-                    let matched_frames = program.get_frames_for_instruction(instruction);
+                    let matched_frames: Option<MatchedFrames<'_>> =
+                        custom_handler.matching_frames(instruction, program);
+                    let is_scheduled = custom_handler.is_scheduled(instruction);
 
                     if let Some(matched_frames) = matched_frames {
                         for frame in matched_frames.used() {
-                            if instruction.is_scheduled() {
+                            if is_scheduled {
                                 let previous_node_ids = last_timed_instruction_by_frame
                                     .entry((*frame).clone())
                                     .or_default()
@@ -355,7 +357,7 @@ impl<'a> InstructionBlock<'a> {
                         }
 
                         for frame in matched_frames.blocked() {
-                            if instruction.is_scheduled() {
+                            if is_scheduled {
                                 if let Some(previous_node_id) = last_timed_instruction_by_frame
                                     .entry((*frame).clone())
                                     .or_default()
@@ -389,7 +391,7 @@ impl<'a> InstructionBlock<'a> {
                 }),
             }?;
 
-            let accesses = instruction.get_memory_accesses();
+            let accesses = custom_handler.memory_accesses(instruction);
             for (regions, access_type) in [
                 (accesses.reads, MemoryAccessType::Read),
                 (accesses.writes, MemoryAccessType::Write),
@@ -522,6 +524,7 @@ fn terminate_working_block<'a>(
     working_label: &mut Option<&'a str>,
     program: &'a Program,
     instruction_index: Option<usize>,
+    custom_handler: &mut InstructionHandler,
 ) -> ScheduleResult<()> {
     // If this "block" has no instructions and no terminator, it's not worth storing - skip it
     if working_instructions.is_empty() && terminator.is_none() && working_label.is_none() {
@@ -529,7 +532,13 @@ fn terminate_working_block<'a>(
     }
 
     // This leaves working_instructions and working_label in their respective "empty" states.
-    let block = InstructionBlock::build(std::mem::take(working_instructions), terminator, program)?;
+    let block = InstructionBlock::build(
+        std::mem::take(working_instructions),
+        terminator,
+        program,
+        custom_handler,
+    )?;
+
     let label = working_label
         .take()
         .map(String::from)
@@ -549,7 +558,10 @@ fn terminate_working_block<'a>(
 impl<'a> ScheduledProgram<'a> {
     /// Structure a sequential program
     #[allow(unused_assignments)]
-    pub fn from_program(program: &'a Program) -> ScheduleResult<Self> {
+    pub fn from_program(
+        program: &'a Program,
+        custom_handler: &mut InstructionHandler,
+    ) -> ScheduleResult<Self> {
         let mut working_label = None;
         let mut working_instructions: Vec<&'a Instruction> = vec![];
         let mut blocks = IndexMap::new();
@@ -595,9 +607,7 @@ impl<'a> ScheduledProgram<'a> {
                 | Instruction::Declaration(_)
                 | Instruction::GateDefinition(_)
                 | Instruction::FrameDefinition(_)
-                | Instruction::MeasureCalibrationDefinition(MeasureCalibrationDefinition {
-                    ..
-                })
+                | Instruction::MeasureCalibrationDefinition(_)
                 | Instruction::WaveformDefinition(_) => {}
                 Instruction::Pragma(_) => {
                     working_instructions.push(instruction);
@@ -610,6 +620,7 @@ impl<'a> ScheduledProgram<'a> {
                         &mut working_label,
                         program,
                         instruction_index,
+                        custom_handler,
                     )?;
 
                     working_label = Some(value);
@@ -622,6 +633,7 @@ impl<'a> ScheduledProgram<'a> {
                         &mut working_label,
                         program,
                         instruction_index,
+                        custom_handler,
                     )?;
                 }
                 Instruction::JumpWhen(JumpWhen { target, condition }) => {
@@ -636,6 +648,7 @@ impl<'a> ScheduledProgram<'a> {
                         &mut working_label,
                         program,
                         instruction_index,
+                        custom_handler,
                     )?;
                 }
                 Instruction::JumpUnless(JumpUnless { target, condition }) => {
@@ -650,6 +663,7 @@ impl<'a> ScheduledProgram<'a> {
                         &mut working_label,
                         program,
                         instruction_index,
+                        custom_handler,
                     )?;
                 }
                 Instruction::Halt => terminate_working_block(
@@ -659,6 +673,7 @@ impl<'a> ScheduledProgram<'a> {
                     &mut working_label,
                     program,
                     instruction_index,
+                    custom_handler,
                 )?,
             };
         }
@@ -670,6 +685,7 @@ impl<'a> ScheduledProgram<'a> {
             &mut working_label,
             program,
             None,
+            custom_handler,
         )?;
 
         Ok(ScheduledProgram { blocks })

--- a/quil-rs/src/program/graph.rs
+++ b/quil-rs/src/program/graph.rs
@@ -455,6 +455,10 @@ impl<'a> InstructionBlock<'a> {
         &self.graph
     }
 
+    /// Get a mutable reference to the dependency graph for this block.
+    ///
+    /// This allows modifying the graph. There are no checks to prevent putting the graph into an
+    /// invalid state, so be careful when modifying it.
     pub fn get_dependency_graph_mut(&mut self) -> &mut DependencyGraph {
         &mut self.graph
     }

--- a/quil-rs/src/program/graphviz_dot.rs
+++ b/quil-rs/src/program/graphviz_dot.rs
@@ -182,7 +182,7 @@ impl<'a> ScheduledProgram<'a> {
 
 /// Escape a string for safe use as a Graphviz node ID or label
 fn escape_label(original: &str) -> String {
-    original.replace('\"', "\\\"")
+    original.replace('\\', "\\\\").replace('"', "\\\"")
 }
 
 /// Return a string to be used as the node ID within the graph text.
@@ -206,6 +206,7 @@ mod tests {
     mod graph {
         use std::str::FromStr;
 
+        use crate::instruction::InstructionHandler;
         use crate::program::Program;
 
         use super::super::ScheduledProgram;
@@ -239,7 +240,11 @@ DEFFRAME 0 1 \"cz\":
 
                     let program =
                         Program::from_str(&format!("{}\n{}", FRAME_DEFINITIONS, $input)).unwrap();
-                    let scheduled_program = ScheduledProgram::from_program(&program).unwrap();
+                    let scheduled_program = ScheduledProgram::from_program(
+                        &program,
+                        &mut InstructionHandler::default(),
+                    )
+                    .unwrap();
 
                     for block in scheduled_program.blocks.values() {
                         let graph = block.get_dependency_graph();

--- a/quil-rs/src/program/mod.rs
+++ b/quil-rs/src/program/mod.rs
@@ -395,6 +395,7 @@ impl Program {
         Ok(umat)
     }
 
+    /// Get a reference to the [`Instruction`] at the given index, if present.
     pub fn get_instruction(&self, index: usize) -> Option<&Instruction> {
         self.instructions.get(index)
     }

--- a/quil-rs/src/program/mod.rs
+++ b/quil-rs/src/program/mod.rs
@@ -29,8 +29,8 @@ use crate::parser::{lex, parse_instructions, ParseError};
 pub use self::calibration::CalibrationSet;
 pub use self::error::{disallow_leftover, map_parsed, recover, ParseProgramError, SyntaxError};
 pub use self::frame::FrameSet;
-use self::frame::MatchedFrames;
-pub use self::memory::MemoryRegion;
+pub use self::frame::MatchedFrames;
+pub use self::memory::{MemoryAccesses, MemoryRegion};
 
 mod calibration;
 mod error;

--- a/quil-rs/src/program/mod.rs
+++ b/quil-rs/src/program/mod.rs
@@ -394,6 +394,10 @@ impl Program {
         }
         Ok(umat)
     }
+
+    pub fn get_instruction(&self, index: usize) -> Option<&Instruction> {
+        self.instructions.get(index)
+    }
 }
 
 impl fmt::Display for Program {


### PR DESCRIPTION
This adds a couple simple getters that are needed for an internal project and should be generally useful for any consumers of `quil-rs`.

Edit: this expanded from the initial PR, but with the same goal of allowing custom handling of instructions when scheduling, especially for `PRAGMA` instructions.