### PR TITLE
Don't rely on egg to simplify pi/c for constant c

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1117,7 +1117,7 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quil-py"
-version = "0.5.0-rc.0"
+version = "0.5.0"
 dependencies = [
  "ndarray",
  "numpy",
@@ -1130,7 +1130,7 @@ dependencies = [
 
 [[package]]
 name = "quil-rs"
-version = "0.21.0-rc.0"
+version = "0.21.0"
 dependencies = [
  "approx",
  "clap",


### PR DESCRIPTION
This patch makes quil-rs simplify `pi/c` expressions without invoking `egg`.

It reduces the runtime of `expand_calibrations` on my RB program by 90%