### PR TITLE
feat(python): Instruction classes now implement `__copy__`, and `__deepcopy__`, making them compatible with Python's `copy` module.

### DIFF
--- a/quil-py/quil/instructions/__init__.pyi
+++ b/quil-py/quil/instructions/__init__.pyi
@@ -372,12 +372,10 @@ class Instruction:
         Convert the instruction to a Quil string. If any part of the instruction can't
         be converted to valid Quil, it will be printed in a human-readable debug format.
         """
-    def copy(self) -> Self:
-        """Creates and returns a deep copy of the class."""
-    def __deepcopy__(self) -> Self:
-        """Creates and returns a deep copy of the class."""
+    def __deepcopy__(self, _: Dict) -> Self:
+        """ Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
     def __copy__(self) -> Self:
-        """Creates and returns a copy of the class."""
+        """Returns a shallow copy of the class."""
 
 @final
 class ArithmeticOperand:
@@ -478,6 +476,10 @@ class Arithmetic:
         Convert the instruction to a Quil string. If any part of the instruction can't
         be converted to valid Quil, it will be printed in a human-readable debug format.
         """
+    def __deepcopy__(self, _: Dict) -> Self:
+        """ Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
+    def __copy__(self) -> Self:
+        """Returns a shallow copy of the class."""
 
 @final
 class BinaryOperand:
@@ -581,6 +583,10 @@ class BinaryLogic:
         Convert the instruction to a Quil string. If any part of the instruction can't
         be converted to valid Quil, it will be printed in a human-readable debug format.
         """
+    def __deepcopy__(self, _: Dict) -> Self:
+        """ Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
+    def __copy__(self) -> Self:
+        """Returns a shallow copy of the class."""
 
 class Convert:
     def __new__(cls, destination: MemoryReference, source: MemoryReference) -> Self: ...
@@ -603,6 +609,10 @@ class Convert:
         Convert the instruction to a Quil string. If any part of the instruction can't
         be converted to valid Quil, it will be printed in a human-readable debug format.
         """
+    def __deepcopy__(self, _: Dict) -> Self:
+        """ Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
+    def __copy__(self) -> Self:
+        """Returns a shallow copy of the class."""
 
 class Move:
     def __new__(cls, destination: MemoryReference, source: ArithmeticOperand) -> Self: ...
@@ -625,6 +635,10 @@ class Move:
         Convert the instruction to a Quil string. If any part of the instruction can't
         be converted to valid Quil, it will be printed in a human-readable debug format.
         """
+    def __deepcopy__(self, _: Dict) -> Self:
+        """ Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
+    def __copy__(self) -> Self:
+        """Returns a shallow copy of the class."""
 
 class Exchange:
     def __new__(cls, left: MemoryReference, right: MemoryReference) -> Self: ...
@@ -647,6 +661,10 @@ class Exchange:
         Convert the instruction to a Quil string. If any part of the instruction can't
         be converted to valid Quil, it will be printed in a human-readable debug format.
         """
+    def __deepcopy__(self, _: Dict) -> Self:
+        """ Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
+    def __copy__(self) -> Self:
+        """Returns a shallow copy of the class."""
 
 @final
 class ComparisonOperand:
@@ -734,6 +752,10 @@ class Comparison:
         Convert the instruction to a Quil string. If any part of the instruction can't
         be converted to valid Quil, it will be printed in a human-readable debug format.
         """
+    def __deepcopy__(self, _: Dict) -> Self:
+        """ Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
+    def __copy__(self) -> Self:
+        """Returns a shallow copy of the class."""
 
 @final
 class UnaryOperator(Enum):
@@ -772,6 +794,10 @@ class UnaryLogic:
         Convert the instruction to a Quil string. If any part of the instruction can't
         be converted to valid Quil, it will be printed in a human-readable debug format.
         """
+    def __deepcopy__(self, _: Dict) -> Self:
+        """ Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
+    def __copy__(self) -> Self:
+        """Returns a shallow copy of the class."""
 
 class Calibration:
     def __new__(
@@ -813,6 +839,10 @@ class Calibration:
         Convert the instruction to a Quil string. If any part of the instruction can't
         be converted to valid Quil, it will be printed in a human-readable debug format.
         """
+    def __deepcopy__(self, _: Dict) -> Self:
+        """ Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
+    def __copy__(self) -> Self:
+        """Returns a shallow copy of the class."""
 
 class MeasureCalibrationDefinition:
     def __new__(
@@ -844,6 +874,10 @@ class MeasureCalibrationDefinition:
         Convert the instruction to a Quil string. If any part of the instruction can't
         be converted to valid Quil, it will be printed in a human-readable debug format.
         """
+    def __deepcopy__(self, _: Dict) -> Self:
+        """ Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
+    def __copy__(self) -> Self:
+        """Returns a shallow copy of the class."""
 
 class CircuitDefinition:
     def __new__(
@@ -880,6 +914,10 @@ class CircuitDefinition:
         Convert the instruction to a Quil string. If any part of the instruction can't
         be converted to valid Quil, it will be printed in a human-readable debug format.
         """
+    def __deepcopy__(self, _: Dict) -> Self:
+        """ Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
+    def __copy__(self) -> Self:
+        """Returns a shallow copy of the class."""
 
 class Offset:
     def __new__(
@@ -947,6 +985,10 @@ class Declaration:
         Convert the instruction to a Quil string. If any part of the instruction can't
         be converted to valid Quil, it will be printed in a human-readable debug format.
         """
+    def __deepcopy__(self, _: Dict) -> Self:
+        """ Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
+    def __copy__(self) -> Self:
+        """Returns a shallow copy of the class."""
 
 class Vector:
     def __new__(cls, data_type: ScalarType, length: int) -> Self: ...
@@ -1057,6 +1099,10 @@ class FrameDefinition:
         Convert the instruction to a Quil string. If any part of the instruction can't
         be converted to valid Quil, it will be printed in a human-readable debug format.
         """
+    def __deepcopy__(self, _: Dict) -> Self:
+        """ Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
+    def __copy__(self) -> Self:
+        """Returns a shallow copy of the class."""
 
 class FrameIdentifier:
     def __new__(cls, name: str, qubits: Sequence[Qubit]) -> Self: ...
@@ -1115,6 +1161,10 @@ class Capture:
         Convert the instruction to a Quil string. If any part of the instruction can't
         be converted to valid Quil, it will be printed in a human-readable debug format.
         """
+    def __deepcopy__(self, _: Dict) -> Self:
+        """ Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
+    def __copy__(self) -> Self:
+        """Returns a shallow copy of the class."""
 
 class Pulse:
     def __new__(
@@ -1146,6 +1196,10 @@ class Pulse:
         Convert the instruction to a Quil string. If any part of the instruction can't
         be converted to valid Quil, it will be printed in a human-readable debug format.
         """
+    def __deepcopy__(self, _: Dict) -> Self:
+        """ Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
+    def __copy__(self) -> Self:
+        """Returns a shallow copy of the class."""
 
 class RawCapture:
     def __new__(
@@ -1182,6 +1236,10 @@ class RawCapture:
         Convert the instruction to a Quil string. If any part of the instruction can't
         be converted to valid Quil, it will be printed in a human-readable debug format.
         """
+    def __deepcopy__(self, _: Dict) -> Self:
+        """ Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
+    def __copy__(self) -> Self:
+        """Returns a shallow copy of the class."""
 
 class SetFrequency:
     def __new__(cls, frame: FrameIdentifier, frequency: Expression) -> Self: ...
@@ -1204,6 +1262,10 @@ class SetFrequency:
         Convert the instruction to a Quil string. If any part of the instruction can't
         be converted to valid Quil, it will be printed in a human-readable debug format.
         """
+    def __deepcopy__(self, _: Dict) -> Self:
+        """ Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
+    def __copy__(self) -> Self:
+        """Returns a shallow copy of the class."""
 
 class SetPhase:
     def __new__(cls, frame: FrameIdentifier, phase: Expression) -> Self: ...
@@ -1226,6 +1288,10 @@ class SetPhase:
         Convert the instruction to a Quil string. If any part of the instruction can't
         be converted to valid Quil, it will be printed in a human-readable debug format.
         """
+    def __deepcopy__(self, _: Dict) -> Self:
+        """ Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
+    def __copy__(self) -> Self:
+        """Returns a shallow copy of the class."""
 
 class SetScale:
     def __new__(cls, frame: FrameIdentifier, phase: Expression) -> Self: ...
@@ -1248,6 +1314,10 @@ class SetScale:
         Convert the instruction to a Quil string. If any part of the instruction can't
         be converted to valid Quil, it will be printed in a human-readable debug format.
         """
+    def __deepcopy__(self, _: Dict) -> Self:
+        """ Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
+    def __copy__(self) -> Self:
+        """Returns a shallow copy of the class."""
 
 class ShiftFrequency:
     def __new__(cls, frame: FrameIdentifier, frequency: Expression) -> Self: ...
@@ -1270,6 +1340,10 @@ class ShiftFrequency:
         Convert the instruction to a Quil string. If any part of the instruction can't
         be converted to valid Quil, it will be printed in a human-readable debug format.
         """
+    def __deepcopy__(self, _: Dict) -> Self:
+        """ Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
+    def __copy__(self) -> Self:
+        """Returns a shallow copy of the class."""
 
 class ShiftPhase:
     def __new__(cls, frame: FrameIdentifier, phase: Expression) -> Self: ...
@@ -1292,6 +1366,10 @@ class ShiftPhase:
         Convert the instruction to a Quil string. If any part of the instruction can't
         be converted to valid Quil, it will be printed in a human-readable debug format.
         """
+    def __deepcopy__(self, _: Dict) -> Self:
+        """ Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
+    def __copy__(self) -> Self:
+        """Returns a shallow copy of the class."""
 
 class SwapPhases:
     def __new__(cls, frame_1: FrameIdentifier, frame_2: FrameIdentifier) -> Self: ...
@@ -1314,6 +1392,10 @@ class SwapPhases:
         Convert the instruction to a Quil string. If any part of the instruction can't
         be converted to valid Quil, it will be printed in a human-readable debug format.
         """
+    def __deepcopy__(self, _: Dict) -> Self:
+        """ Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
+    def __copy__(self) -> Self:
+        """Returns a shallow copy of the class."""
 
 class GateError(ValueError):
     """An error that may occur when performing operations on a ``Gate``"""
@@ -1398,6 +1480,10 @@ class Gate:
         Convert the instruction to a Quil string. If any part of the instruction can't
         be converted to valid Quil, it will be printed in a human-readable debug format.
         """
+    def __deepcopy__(self, _: Dict) -> Self:
+        """ Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
+    def __copy__(self) -> Self:
+        """Returns a shallow copy of the class."""
 
 @final
 class PauliGate(Enum):
@@ -1517,6 +1603,10 @@ class GateDefinition:
         Convert the instruction to a Quil string. If any part of the instruction can't
         be converted to valid Quil, it will be printed in a human-readable debug format.
         """
+    def __deepcopy__(self, _: Dict) -> Self:
+        """ Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
+    def __copy__(self) -> Self:
+        """Returns a shallow copy of the class."""
 
 @final
 class Qubit:
@@ -1592,6 +1682,10 @@ class Reset:
         Convert the instruction to a Quil string. If any part of the instruction can't
         be converted to valid Quil, it will be printed in a human-readable debug format.
         """
+    def __deepcopy__(self, _: Dict) -> Self:
+        """ Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
+    def __copy__(self) -> Self:
+        """Returns a shallow copy of the class."""
 
 class Delay:
     def __new__(cls, duration: Expression, frame_names: Sequence[str], qubits: Sequence[Qubit]) -> Self: ...
@@ -1618,6 +1712,10 @@ class Delay:
         Convert the instruction to a Quil string. If any part of the instruction can't
         be converted to valid Quil, it will be printed in a human-readable debug format.
         """
+    def __deepcopy__(self, _: Dict) -> Self:
+        """ Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
+    def __copy__(self) -> Self:
+        """Returns a shallow copy of the class."""
 
 class Fence:
     def __new__(cls, qubits: Sequence[Qubit]) -> Self: ...
@@ -1636,6 +1734,10 @@ class Fence:
         Convert the instruction to a Quil string. If any part of the instruction can't
         be converted to valid Quil, it will be printed in a human-readable debug format.
         """
+    def __deepcopy__(self, _: Dict) -> Self:
+        """ Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
+    def __copy__(self) -> Self:
+        """Returns a shallow copy of the class."""
 
 @final
 class PragmaArgument:
@@ -1696,6 +1798,10 @@ class Include:
         Convert the instruction to a Quil string. If any part of the instruction can't
         be converted to valid Quil, it will be printed in a human-readable debug format.
         """
+    def __deepcopy__(self, _: Dict) -> Self:
+        """ Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
+    def __copy__(self) -> Self:
+        """Returns a shallow copy of the class."""
 
 class Pragma:
     def __new__(cls, name: str, arguments: Sequence[PragmaArgument], data: Optional[str]) -> Self: ...
@@ -1722,6 +1828,10 @@ class Pragma:
         Convert the instruction to a Quil string. If any part of the instruction can't
         be converted to valid Quil, it will be printed in a human-readable debug format.
         """
+    def __deepcopy__(self, _: Dict) -> Self:
+        """ Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
+    def __copy__(self) -> Self:
+        """Returns a shallow copy of the class."""
 
 class Measurement:
     def __new__(cls, qubit: Qubit, target: Optional[MemoryReference]) -> Self: ...
@@ -1744,6 +1854,10 @@ class Measurement:
         Convert the instruction to a Quil string. If any part of the instruction can't
         be converted to valid Quil, it will be printed in a human-readable debug format.
         """
+    def __deepcopy__(self, _: Dict) -> Self:
+        """ Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
+    def __copy__(self) -> Self:
+        """Returns a shallow copy of the class."""
 
 class ParseMemoryReferenceError(ValueError):
     """Errors that may occur while parsing a ``MemoryReference``"""
@@ -1802,6 +1916,10 @@ class Load:
         Convert the instruction to a Quil string. If any part of the instruction can't
         be converted to valid Quil, it will be printed in a human-readable debug format.
         """
+    def __deepcopy__(self, _: Dict) -> Self:
+        """ Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
+    def __copy__(self) -> Self:
+        """Returns a shallow copy of the class."""
 
 class Store:
     def __new__(cls, destination: str, offset: MemoryReference, source: ArithmeticOperand) -> Self: ...
@@ -1828,6 +1946,10 @@ class Store:
         Convert the instruction to a Quil string. If any part of the instruction can't
         be converted to valid Quil, it will be printed in a human-readable debug format.
         """
+    def __deepcopy__(self, _: Dict) -> Self:
+        """ Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
+    def __copy__(self) -> Self:
+        """Returns a shallow copy of the class."""
 
 class Waveform:
     def __new__(cls, matrix: Sequence[Expression], parameters: Sequence[str]) -> Self: ...
@@ -1861,6 +1983,10 @@ class WaveformDefinition:
         Convert the instruction to a Quil string. If any part of the instruction can't
         be converted to valid Quil, it will be printed in a human-readable debug format.
         """
+    def __deepcopy__(self, _: Dict) -> Self:
+        """ Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
+    def __copy__(self) -> Self:
+        """Returns a shallow copy of the class."""
 
 class WaveformInvocation:
     def __new__(cls, name: str, parameters: Dict[str, Expression]) -> Self: ...
@@ -1901,6 +2027,10 @@ class Label:
         Convert the instruction to a Quil string. If any part of the instruction can't
         be converted to valid Quil, it will be printed in a human-readable debug format.
         """
+    def __deepcopy__(self, _: Dict) -> Self:
+        """ Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
+    def __copy__(self) -> Self:
+        """Returns a shallow copy of the class."""
 
 @final
 class Target:
@@ -1971,6 +2101,10 @@ class Jump:
         Convert the instruction to a Quil string. If any part of the instruction can't
         be converted to valid Quil, it will be printed in a human-readable debug format.
         """
+    def __deepcopy__(self, _: Dict) -> Self:
+        """ Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
+    def __copy__(self) -> Self:
+        """Returns a shallow copy of the class."""
 
 class JumpWhen:
     def __new__(cls, target: Target, condition: MemoryReference) -> Self: ...
@@ -1993,6 +2127,10 @@ class JumpWhen:
         Convert the instruction to a Quil string. If any part of the instruction can't
         be converted to valid Quil, it will be printed in a human-readable debug format.
         """
+    def __deepcopy__(self, _: Dict) -> Self:
+        """ Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
+    def __copy__(self) -> Self:
+        """Returns a shallow copy of the class."""
 
 class JumpUnless:
     def __new__(cls, target: Target, condition: MemoryReference) -> Self: ...
@@ -2015,3 +2153,7 @@ class JumpUnless:
         Convert the instruction to a Quil string. If any part of the instruction can't
         be converted to valid Quil, it will be printed in a human-readable debug format.
         """
+    def __deepcopy__(self, _: Dict) -> Self:
+        """ Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
+    def __copy__(self) -> Self:
+        """Returns a shallow copy of the class."""

--- a/quil-py/quil/instructions/__init__.pyi
+++ b/quil-py/quil/instructions/__init__.pyi
@@ -372,6 +372,12 @@ class Instruction:
         Convert the instruction to a Quil string. If any part of the instruction can't
         be converted to valid Quil, it will be printed in a human-readable debug format.
         """
+    def copy(self) -> Self:
+        """Creates and returns a deep copy of the class."""
+    def __deepcopy__(self) -> Self:
+        """Creates and returns a deep copy of the class."""
+    def __copy__(self) -> Self:
+        """Creates and returns a copy of the class."""
 
 @final
 class ArithmeticOperand:

--- a/quil-py/quil/instructions/__init__.pyi
+++ b/quil-py/quil/instructions/__init__.pyi
@@ -373,7 +373,7 @@ class Instruction:
         be converted to valid Quil, it will be printed in a human-readable debug format.
         """
     def __deepcopy__(self, _: Dict) -> Self:
-        """ Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
+        """Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
     def __copy__(self) -> Self:
         """Returns a shallow copy of the class."""
 
@@ -477,7 +477,7 @@ class Arithmetic:
         be converted to valid Quil, it will be printed in a human-readable debug format.
         """
     def __deepcopy__(self, _: Dict) -> Self:
-        """ Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
+        """Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
     def __copy__(self) -> Self:
         """Returns a shallow copy of the class."""
 
@@ -584,7 +584,7 @@ class BinaryLogic:
         be converted to valid Quil, it will be printed in a human-readable debug format.
         """
     def __deepcopy__(self, _: Dict) -> Self:
-        """ Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
+        """Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
     def __copy__(self) -> Self:
         """Returns a shallow copy of the class."""
 
@@ -610,7 +610,7 @@ class Convert:
         be converted to valid Quil, it will be printed in a human-readable debug format.
         """
     def __deepcopy__(self, _: Dict) -> Self:
-        """ Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
+        """Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
     def __copy__(self) -> Self:
         """Returns a shallow copy of the class."""
 
@@ -636,7 +636,7 @@ class Move:
         be converted to valid Quil, it will be printed in a human-readable debug format.
         """
     def __deepcopy__(self, _: Dict) -> Self:
-        """ Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
+        """Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
     def __copy__(self) -> Self:
         """Returns a shallow copy of the class."""
 
@@ -662,7 +662,7 @@ class Exchange:
         be converted to valid Quil, it will be printed in a human-readable debug format.
         """
     def __deepcopy__(self, _: Dict) -> Self:
-        """ Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
+        """Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
     def __copy__(self) -> Self:
         """Returns a shallow copy of the class."""
 
@@ -753,7 +753,7 @@ class Comparison:
         be converted to valid Quil, it will be printed in a human-readable debug format.
         """
     def __deepcopy__(self, _: Dict) -> Self:
-        """ Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
+        """Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
     def __copy__(self) -> Self:
         """Returns a shallow copy of the class."""
 
@@ -795,7 +795,7 @@ class UnaryLogic:
         be converted to valid Quil, it will be printed in a human-readable debug format.
         """
     def __deepcopy__(self, _: Dict) -> Self:
-        """ Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
+        """Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
     def __copy__(self) -> Self:
         """Returns a shallow copy of the class."""
 
@@ -840,7 +840,7 @@ class Calibration:
         be converted to valid Quil, it will be printed in a human-readable debug format.
         """
     def __deepcopy__(self, _: Dict) -> Self:
-        """ Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
+        """Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
     def __copy__(self) -> Self:
         """Returns a shallow copy of the class."""
 
@@ -875,7 +875,7 @@ class MeasureCalibrationDefinition:
         be converted to valid Quil, it will be printed in a human-readable debug format.
         """
     def __deepcopy__(self, _: Dict) -> Self:
-        """ Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
+        """Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
     def __copy__(self) -> Self:
         """Returns a shallow copy of the class."""
 
@@ -915,7 +915,7 @@ class CircuitDefinition:
         be converted to valid Quil, it will be printed in a human-readable debug format.
         """
     def __deepcopy__(self, _: Dict) -> Self:
-        """ Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
+        """Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
     def __copy__(self) -> Self:
         """Returns a shallow copy of the class."""
 
@@ -986,7 +986,7 @@ class Declaration:
         be converted to valid Quil, it will be printed in a human-readable debug format.
         """
     def __deepcopy__(self, _: Dict) -> Self:
-        """ Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
+        """Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
     def __copy__(self) -> Self:
         """Returns a shallow copy of the class."""
 
@@ -1100,7 +1100,7 @@ class FrameDefinition:
         be converted to valid Quil, it will be printed in a human-readable debug format.
         """
     def __deepcopy__(self, _: Dict) -> Self:
-        """ Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
+        """Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
     def __copy__(self) -> Self:
         """Returns a shallow copy of the class."""
 
@@ -1162,7 +1162,7 @@ class Capture:
         be converted to valid Quil, it will be printed in a human-readable debug format.
         """
     def __deepcopy__(self, _: Dict) -> Self:
-        """ Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
+        """Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
     def __copy__(self) -> Self:
         """Returns a shallow copy of the class."""
 
@@ -1197,7 +1197,7 @@ class Pulse:
         be converted to valid Quil, it will be printed in a human-readable debug format.
         """
     def __deepcopy__(self, _: Dict) -> Self:
-        """ Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
+        """Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
     def __copy__(self) -> Self:
         """Returns a shallow copy of the class."""
 
@@ -1237,7 +1237,7 @@ class RawCapture:
         be converted to valid Quil, it will be printed in a human-readable debug format.
         """
     def __deepcopy__(self, _: Dict) -> Self:
-        """ Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
+        """Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
     def __copy__(self) -> Self:
         """Returns a shallow copy of the class."""
 
@@ -1263,7 +1263,7 @@ class SetFrequency:
         be converted to valid Quil, it will be printed in a human-readable debug format.
         """
     def __deepcopy__(self, _: Dict) -> Self:
-        """ Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
+        """Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
     def __copy__(self) -> Self:
         """Returns a shallow copy of the class."""
 
@@ -1289,7 +1289,7 @@ class SetPhase:
         be converted to valid Quil, it will be printed in a human-readable debug format.
         """
     def __deepcopy__(self, _: Dict) -> Self:
-        """ Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
+        """Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
     def __copy__(self) -> Self:
         """Returns a shallow copy of the class."""
 
@@ -1315,7 +1315,7 @@ class SetScale:
         be converted to valid Quil, it will be printed in a human-readable debug format.
         """
     def __deepcopy__(self, _: Dict) -> Self:
-        """ Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
+        """Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
     def __copy__(self) -> Self:
         """Returns a shallow copy of the class."""
 
@@ -1341,7 +1341,7 @@ class ShiftFrequency:
         be converted to valid Quil, it will be printed in a human-readable debug format.
         """
     def __deepcopy__(self, _: Dict) -> Self:
-        """ Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
+        """Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
     def __copy__(self) -> Self:
         """Returns a shallow copy of the class."""
 
@@ -1367,7 +1367,7 @@ class ShiftPhase:
         be converted to valid Quil, it will be printed in a human-readable debug format.
         """
     def __deepcopy__(self, _: Dict) -> Self:
-        """ Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
+        """Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
     def __copy__(self) -> Self:
         """Returns a shallow copy of the class."""
 
@@ -1393,7 +1393,7 @@ class SwapPhases:
         be converted to valid Quil, it will be printed in a human-readable debug format.
         """
     def __deepcopy__(self, _: Dict) -> Self:
-        """ Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
+        """Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
     def __copy__(self) -> Self:
         """Returns a shallow copy of the class."""
 
@@ -1481,7 +1481,7 @@ class Gate:
         be converted to valid Quil, it will be printed in a human-readable debug format.
         """
     def __deepcopy__(self, _: Dict) -> Self:
-        """ Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
+        """Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
     def __copy__(self) -> Self:
         """Returns a shallow copy of the class."""
 
@@ -1604,7 +1604,7 @@ class GateDefinition:
         be converted to valid Quil, it will be printed in a human-readable debug format.
         """
     def __deepcopy__(self, _: Dict) -> Self:
-        """ Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
+        """Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
     def __copy__(self) -> Self:
         """Returns a shallow copy of the class."""
 
@@ -1683,7 +1683,7 @@ class Reset:
         be converted to valid Quil, it will be printed in a human-readable debug format.
         """
     def __deepcopy__(self, _: Dict) -> Self:
-        """ Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
+        """Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
     def __copy__(self) -> Self:
         """Returns a shallow copy of the class."""
 
@@ -1713,7 +1713,7 @@ class Delay:
         be converted to valid Quil, it will be printed in a human-readable debug format.
         """
     def __deepcopy__(self, _: Dict) -> Self:
-        """ Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
+        """Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
     def __copy__(self) -> Self:
         """Returns a shallow copy of the class."""
 
@@ -1735,7 +1735,7 @@ class Fence:
         be converted to valid Quil, it will be printed in a human-readable debug format.
         """
     def __deepcopy__(self, _: Dict) -> Self:
-        """ Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
+        """Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
     def __copy__(self) -> Self:
         """Returns a shallow copy of the class."""
 
@@ -1799,7 +1799,7 @@ class Include:
         be converted to valid Quil, it will be printed in a human-readable debug format.
         """
     def __deepcopy__(self, _: Dict) -> Self:
-        """ Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
+        """Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
     def __copy__(self) -> Self:
         """Returns a shallow copy of the class."""
 
@@ -1829,7 +1829,7 @@ class Pragma:
         be converted to valid Quil, it will be printed in a human-readable debug format.
         """
     def __deepcopy__(self, _: Dict) -> Self:
-        """ Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
+        """Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
     def __copy__(self) -> Self:
         """Returns a shallow copy of the class."""
 
@@ -1855,7 +1855,7 @@ class Measurement:
         be converted to valid Quil, it will be printed in a human-readable debug format.
         """
     def __deepcopy__(self, _: Dict) -> Self:
-        """ Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
+        """Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
     def __copy__(self) -> Self:
         """Returns a shallow copy of the class."""
 
@@ -1917,7 +1917,7 @@ class Load:
         be converted to valid Quil, it will be printed in a human-readable debug format.
         """
     def __deepcopy__(self, _: Dict) -> Self:
-        """ Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
+        """Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
     def __copy__(self) -> Self:
         """Returns a shallow copy of the class."""
 
@@ -1947,7 +1947,7 @@ class Store:
         be converted to valid Quil, it will be printed in a human-readable debug format.
         """
     def __deepcopy__(self, _: Dict) -> Self:
-        """ Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
+        """Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
     def __copy__(self) -> Self:
         """Returns a shallow copy of the class."""
 
@@ -1984,7 +1984,7 @@ class WaveformDefinition:
         be converted to valid Quil, it will be printed in a human-readable debug format.
         """
     def __deepcopy__(self, _: Dict) -> Self:
-        """ Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
+        """Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
     def __copy__(self) -> Self:
         """Returns a shallow copy of the class."""
 
@@ -2028,7 +2028,7 @@ class Label:
         be converted to valid Quil, it will be printed in a human-readable debug format.
         """
     def __deepcopy__(self, _: Dict) -> Self:
-        """ Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
+        """Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
     def __copy__(self) -> Self:
         """Returns a shallow copy of the class."""
 
@@ -2102,7 +2102,7 @@ class Jump:
         be converted to valid Quil, it will be printed in a human-readable debug format.
         """
     def __deepcopy__(self, _: Dict) -> Self:
-        """ Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
+        """Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
     def __copy__(self) -> Self:
         """Returns a shallow copy of the class."""
 
@@ -2128,7 +2128,7 @@ class JumpWhen:
         be converted to valid Quil, it will be printed in a human-readable debug format.
         """
     def __deepcopy__(self, _: Dict) -> Self:
-        """ Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
+        """Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
     def __copy__(self) -> Self:
         """Returns a shallow copy of the class."""
 
@@ -2154,6 +2154,6 @@ class JumpUnless:
         be converted to valid Quil, it will be printed in a human-readable debug format.
         """
     def __deepcopy__(self, _: Dict) -> Self:
-        """ Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
+        """Creates and returns a deep copy of the class. If the instruction contains any ``QubitPlaceholder`` or ``TargetPlaceholder``, then they will be replaced with new placeholders so resolving them in the copy will not resolve them in the original.  Should be used by passing an instance of the class to ``copy.deepcopy``"""
     def __copy__(self) -> Self:
         """Returns a shallow copy of the class."""

--- a/quil-py/src/instruction/calibration.rs
+++ b/quil-py/src/instruction/calibration.rs
@@ -13,7 +13,7 @@ use rigetti_pyo3::{
 
 use crate::{
     expression::PyExpression,
-    impl_to_quil,
+    impl_copy_for_instruction, impl_to_quil,
     instruction::{PyGateModifier, PyInstruction, PyQubit},
     validation::identifier::RustIdentifierValidationError,
 };
@@ -31,6 +31,7 @@ py_wrap_data_struct! {
 }
 impl_repr!(PyCalibration);
 impl_to_quil!(PyCalibration);
+impl_copy_for_instruction!(PyCalibration);
 
 #[pymethods]
 impl PyCalibration {
@@ -75,6 +76,7 @@ py_wrap_data_struct! {
 }
 impl_repr!(PyMeasureCalibrationDefinition);
 impl_to_quil!(PyMeasureCalibrationDefinition);
+impl_copy_for_instruction!(PyMeasureCalibrationDefinition);
 
 #[pymethods]
 impl PyMeasureCalibrationDefinition {

--- a/quil-py/src/instruction/circuit.rs
+++ b/quil-py/src/instruction/circuit.rs
@@ -9,7 +9,7 @@ use rigetti_pyo3::{
 };
 
 use super::PyInstruction;
-use crate::impl_to_quil;
+use crate::{impl_copy_for_instruction, impl_to_quil};
 
 py_wrap_data_struct! {
     #[derive(Debug, PartialEq)]
@@ -23,6 +23,7 @@ py_wrap_data_struct! {
 }
 impl_repr!(PyCircuitDefinition);
 impl_to_quil!(PyCircuitDefinition);
+impl_copy_for_instruction!(PyCircuitDefinition);
 
 #[pymethods]
 impl PyCircuitDefinition {

--- a/quil-py/src/instruction/classical.rs
+++ b/quil-py/src/instruction/classical.rs
@@ -17,7 +17,7 @@ use rigetti_pyo3::{
 };
 
 use super::PyMemoryReference;
-use crate::impl_to_quil;
+use crate::{impl_copy_for_instruction, impl_to_quil};
 
 py_wrap_data_struct! {
     #[derive(Debug, PartialEq)]
@@ -30,6 +30,7 @@ py_wrap_data_struct! {
 }
 impl_repr!(PyArithmetic);
 impl_to_quil!(PyArithmetic);
+impl_copy_for_instruction!(PyArithmetic);
 impl_hash!(PyArithmetic);
 
 #[pymethods]
@@ -212,6 +213,7 @@ py_wrap_data_struct! {
 }
 impl_repr!(PyBinaryLogic);
 impl_to_quil!(PyBinaryLogic);
+impl_copy_for_instruction!(PyBinaryLogic);
 
 #[pymethods]
 impl PyBinaryLogic {
@@ -245,6 +247,7 @@ py_wrap_data_struct! {
 }
 impl_repr!(PyConvert);
 impl_to_quil!(PyConvert);
+impl_copy_for_instruction!(PyConvert);
 impl_hash!(PyConvert);
 
 #[pymethods]
@@ -279,6 +282,7 @@ py_wrap_data_struct! {
 }
 impl_repr!(PyMove);
 impl_to_quil!(PyMove);
+impl_copy_for_instruction!(PyMove);
 impl_hash!(PyMove);
 
 #[pymethods]
@@ -313,6 +317,7 @@ py_wrap_data_struct! {
 }
 impl_repr!(PyExchange);
 impl_to_quil!(PyExchange);
+impl_copy_for_instruction!(PyExchange);
 impl_hash!(PyExchange);
 
 #[pymethods]
@@ -392,6 +397,7 @@ py_wrap_data_struct! {
 }
 impl_repr!(PyComparison);
 impl_to_quil!(PyComparison);
+impl_copy_for_instruction!(PyComparison);
 impl_hash!(PyComparison);
 
 #[pymethods]
@@ -468,6 +474,7 @@ py_wrap_data_struct! {
 }
 impl_repr!(PyUnaryLogic);
 impl_to_quil!(PyUnaryLogic);
+impl_copy_for_instruction!(PyUnaryLogic);
 impl_hash!(PyUnaryLogic);
 
 #[pymethods]

--- a/quil-py/src/instruction/control_flow.rs
+++ b/quil-py/src/instruction/control_flow.rs
@@ -12,7 +12,10 @@ use crate::{impl_to_quil, instruction::PyMemoryReference};
 /// Implements __copy__ and __deepcopy__ for instructions containing a [`Target`].
 ///
 /// __copy__ implements a shallow copy by returning a reference to the object.
-/// __deepcopy__
+///
+/// __deepcopy__ performs a deep copy by cloning the Rust reference, and replacing
+/// any [`TargetPlaceholder`]s from the original intruction with new instances so
+/// that resolving placeholders on the copy does not affect the original.
 macro_rules! impl_copy_for_target_containing_instructions {
     ($name: ident) => {
         #[pyo3::pymethods]

--- a/quil-py/src/instruction/control_flow.rs
+++ b/quil-py/src/instruction/control_flow.rs
@@ -7,7 +7,7 @@ use rigetti_pyo3::{
     PyWrapper,
 };
 
-use crate::{impl_to_quil, instruction::PyMemoryReference};
+use crate::{impl_copy_for_instruction, impl_to_quil, instruction::PyMemoryReference};
 
 py_wrap_data_struct! {
     #[pyo3(subclass)]
@@ -19,6 +19,7 @@ py_wrap_data_struct! {
 impl_repr!(PyLabel);
 impl_hash!(PyLabel);
 impl_to_quil!(PyLabel);
+impl_copy_for_instruction!(PyLabel);
 
 #[pymethods]
 impl PyLabel {
@@ -86,6 +87,7 @@ py_wrap_data_struct! {
 }
 impl_repr!(PyJump);
 impl_to_quil!(PyJump);
+impl_copy_for_instruction!(PyJump);
 
 #[pymethods]
 impl PyJump {
@@ -104,6 +106,7 @@ py_wrap_data_struct! {
 }
 impl_repr!(PyJumpWhen);
 impl_to_quil!(PyJumpWhen);
+impl_copy_for_instruction!(PyJumpWhen);
 
 #[pymethods]
 impl PyJumpWhen {

--- a/quil-py/src/instruction/declaration.rs
+++ b/quil-py/src/instruction/declaration.rs
@@ -4,7 +4,7 @@ use quil_rs::instruction::{
 };
 
 use super::PyArithmeticOperand;
-use crate::impl_to_quil;
+use crate::{impl_copy_for_instruction, impl_to_quil};
 
 use rigetti_pyo3::{
     impl_from_str, impl_hash, impl_parse, impl_repr, py_wrap_data_struct, py_wrap_error,
@@ -139,6 +139,7 @@ py_wrap_data_struct! {
 }
 impl_repr!(PyDeclaration);
 impl_to_quil!(PyDeclaration);
+impl_copy_for_instruction!(PyDeclaration);
 impl_hash!(PyDeclaration);
 
 #[pymethods]
@@ -205,6 +206,7 @@ py_wrap_data_struct! {
 }
 impl_repr!(PyLoad);
 impl_to_quil!(PyLoad);
+impl_copy_for_instruction!(PyLoad);
 impl_hash!(PyLoad);
 
 #[pymethods]
@@ -242,6 +244,7 @@ py_wrap_data_struct! {
 }
 impl_repr!(PyStore);
 impl_to_quil!(PyStore);
+impl_copy_for_instruction!(PyStore);
 impl_hash!(PyStore);
 
 #[pymethods]

--- a/quil-py/src/instruction/frame.rs
+++ b/quil-py/src/instruction/frame.rs
@@ -36,7 +36,6 @@ py_wrap_union_enum! {
 }
 impl_repr!(PyAttributeValue);
 impl_to_quil!(PyAttributeValue);
-impl_copy_for_instruction!(PyAttributeValue);
 impl_hash!(PyAttributeValue);
 
 #[pymethods]

--- a/quil-py/src/instruction/frame.rs
+++ b/quil-py/src/instruction/frame.rs
@@ -23,7 +23,7 @@ use rigetti_pyo3::{
 use super::PyQubit;
 use crate::{
     expression::PyExpression,
-    impl_to_quil,
+    impl_copy_for_instruction, impl_to_quil,
     instruction::{PyMemoryReference, PyWaveformInvocation},
 };
 
@@ -36,6 +36,7 @@ py_wrap_union_enum! {
 }
 impl_repr!(PyAttributeValue);
 impl_to_quil!(PyAttributeValue);
+impl_copy_for_instruction!(PyAttributeValue);
 impl_hash!(PyAttributeValue);
 
 #[pymethods]
@@ -60,6 +61,7 @@ py_wrap_data_struct! {
 }
 impl_repr!(PyFrameDefinition);
 impl_to_quil!(PyFrameDefinition);
+impl_copy_for_instruction!(PyFrameDefinition);
 
 #[pymethods]
 impl PyFrameDefinition {
@@ -125,6 +127,7 @@ py_wrap_data_struct! {
 }
 impl_repr!(PyCapture);
 impl_to_quil!(PyCapture);
+impl_copy_for_instruction!(PyCapture);
 
 #[pymethods]
 impl PyCapture {
@@ -164,6 +167,7 @@ py_wrap_data_struct! {
 
 impl_repr!(PyPulse);
 impl_to_quil!(PyPulse);
+impl_copy_for_instruction!(PyPulse);
 
 #[pymethods]
 impl PyPulse {
@@ -202,6 +206,7 @@ py_wrap_data_struct! {
 
 impl_repr!(PyRawCapture);
 impl_to_quil!(PyRawCapture);
+impl_copy_for_instruction!(PyRawCapture);
 impl_hash!(PyRawCapture);
 
 #[pymethods]
@@ -240,6 +245,7 @@ py_wrap_data_struct! {
 }
 impl_repr!(PySetFrequency);
 impl_to_quil!(PySetFrequency);
+impl_copy_for_instruction!(PySetFrequency);
 impl_hash!(PySetFrequency);
 
 #[pymethods]
@@ -274,6 +280,7 @@ py_wrap_data_struct! {
 }
 impl_repr!(PySetPhase);
 impl_to_quil!(PySetPhase);
+impl_copy_for_instruction!(PySetPhase);
 impl_hash!(PySetPhase);
 
 #[pymethods]
@@ -304,6 +311,7 @@ py_wrap_data_struct! {
 }
 impl_repr!(PySetScale);
 impl_to_quil!(PySetScale);
+impl_copy_for_instruction!(PySetScale);
 impl_hash!(PySetScale);
 
 #[pymethods]
@@ -334,6 +342,7 @@ py_wrap_data_struct! {
 }
 impl_repr!(PyShiftFrequency);
 impl_to_quil!(PyShiftFrequency);
+impl_copy_for_instruction!(PyShiftFrequency);
 impl_hash!(PyShiftFrequency);
 
 #[pymethods]
@@ -368,6 +377,7 @@ py_wrap_data_struct! {
 }
 impl_repr!(PyShiftPhase);
 impl_to_quil!(PyShiftPhase);
+impl_copy_for_instruction!(PyShiftPhase);
 impl_hash!(PyShiftPhase);
 
 #[pymethods]
@@ -398,6 +408,7 @@ py_wrap_data_struct! {
 }
 impl_repr!(PySwapPhases);
 impl_to_quil!(PySwapPhases);
+impl_copy_for_instruction!(PySwapPhases);
 impl_hash!(PySwapPhases);
 
 #[pymethods]

--- a/quil-py/src/instruction/gate.rs
+++ b/quil-py/src/instruction/gate.rs
@@ -298,6 +298,7 @@ py_wrap_data_struct! {
 }
 impl_repr!(PyGateDefinition);
 impl_to_quil!(PyGateDefinition);
+impl_copy_for_instruction!(PyGateDefinition);
 impl_hash!(PyGateDefinition);
 
 #[pymethods]

--- a/quil-py/src/instruction/gate.rs
+++ b/quil-py/src/instruction/gate.rs
@@ -21,7 +21,9 @@ use rigetti_pyo3::{
 };
 use strum;
 
-use crate::{expression::PyExpression, impl_to_quil, instruction::PyQubit};
+use crate::{
+    expression::PyExpression, impl_copy_for_instruction, impl_to_quil, instruction::PyQubit,
+};
 
 wrap_error!(RustGateError(quil_rs::instruction::GateError));
 py_wrap_error!(quil, RustGateError, GateError, PyValueError);
@@ -39,6 +41,7 @@ py_wrap_data_struct! {
     }
 }
 impl_repr!(PyGate);
+impl_copy_for_instruction!(PyGate);
 impl_to_quil!(PyGate);
 impl_hash!(PyGate);
 

--- a/quil-py/src/instruction/measurement.rs
+++ b/quil-py/src/instruction/measurement.rs
@@ -6,7 +6,7 @@ use rigetti_pyo3::{
 };
 
 use crate::{
-    impl_to_quil,
+    impl_copy_for_instruction, impl_to_quil,
     instruction::{PyMemoryReference, PyQubit},
 };
 
@@ -19,6 +19,7 @@ py_wrap_data_struct! {
     }
 }
 impl_to_quil!(PyMeasurement);
+impl_copy_for_instruction!(PyMeasurement);
 impl_hash!(PyMeasurement);
 impl_repr!(PyMeasurement);
 

--- a/quil-py/src/instruction/mod.rs
+++ b/quil-py/src/instruction/mod.rs
@@ -208,8 +208,10 @@ create_init_submodule! {
 /// The `__copy__` method returns a reference to the instruction, making it shallow: any changes
 /// to the copy will update the original.
 ///
-/// The `__deepcopy__` method returns a deep copy. Because [`QubitPlaceholder`]s are implemented
-/// with [`Arc`], the implementation will find and replace any [`QubitPlaceholder`]s with new ones.
+/// The `__deepcopy__` method creates a deep copy by cloning the inner instruction, querying its
+/// qubits, and replacing any [`quil_rs::instruction::QubitPlaceholder`]s with new instances so
+/// that resolving them in one copy doesn't affect the other. Duplicates of the same instruction in
+/// the original instruction will be replaced with the same copy in the new instruction.
 #[macro_export]
 macro_rules! impl_copy_for_instruction {
     ($py_name: ident) => {

--- a/quil-py/src/instruction/mod.rs
+++ b/quil-py/src/instruction/mod.rs
@@ -252,8 +252,8 @@ macro_rules! impl_copy_for_instruction {
                     .expect("a copy of a type should extract to the same type"))
             }
 
-            pub fn __copy__(&self, py: Python<'_>) -> pyo3::PyObject {
-                pyo3::ToPyObject::to_object(&self, py).clone_ref(py)
+            pub fn __copy__(&self) -> Self {
+                self.clone()
             }
         }
     };

--- a/quil-py/src/instruction/pragma.rs
+++ b/quil-py/src/instruction/pragma.rs
@@ -11,7 +11,7 @@ use rigetti_pyo3::{
     PyTryFrom, PyWrapper,
 };
 
-use crate::impl_to_quil;
+use crate::{impl_copy_for_instruction, impl_to_quil};
 
 py_wrap_data_struct! {
     #[derive(Debug, PartialEq, Eq)]
@@ -24,6 +24,7 @@ py_wrap_data_struct! {
 }
 impl_repr!(PyPragma);
 impl_to_quil!(PyPragma);
+impl_copy_for_instruction!(PyPragma);
 impl_hash!(PyPragma);
 
 #[pymethods]
@@ -95,4 +96,5 @@ impl PyInclude {
 }
 impl_repr!(PyInclude);
 impl_to_quil!(PyInclude);
+impl_copy_for_instruction!(PyInclude);
 impl_hash!(PyInclude);

--- a/quil-py/src/instruction/reset.rs
+++ b/quil-py/src/instruction/reset.rs
@@ -6,7 +6,7 @@ use rigetti_pyo3::{
     PyTryFrom, PyWrapper,
 };
 
-use crate::{impl_to_quil, instruction::PyQubit};
+use crate::{impl_copy_for_instruction, impl_to_quil, instruction::PyQubit};
 
 py_wrap_data_struct! {
     #[derive(Debug, PartialEq, Eq)]
@@ -16,6 +16,7 @@ py_wrap_data_struct! {
     }
 }
 impl_repr!(PyReset);
+impl_copy_for_instruction!(PyReset);
 impl_to_quil!(PyReset);
 impl_hash!(PyReset);
 

--- a/quil-py/src/instruction/timing.rs
+++ b/quil-py/src/instruction/timing.rs
@@ -10,7 +10,7 @@ use rigetti_pyo3::{
 };
 
 use super::PyQubit;
-use crate::{expression::PyExpression, impl_to_quil};
+use crate::{expression::PyExpression, impl_copy_for_instruction, impl_to_quil};
 
 py_wrap_data_struct! {
     #[derive(Debug, PartialEq, Eq)]
@@ -23,6 +23,7 @@ py_wrap_data_struct! {
 }
 impl_repr!(PyDelay);
 impl_to_quil!(PyDelay);
+impl_copy_for_instruction!(PyDelay);
 impl_hash!(PyDelay);
 
 #[pymethods]
@@ -58,6 +59,7 @@ py_wrap_data_struct! {
 }
 impl_repr!(PyFence);
 impl_to_quil!(PyFence);
+impl_copy_for_instruction!(PyFence);
 impl_hash!(PyFence);
 
 #[pymethods]

--- a/quil-py/src/instruction/waveform.rs
+++ b/quil-py/src/instruction/waveform.rs
@@ -13,7 +13,7 @@ use rigetti_pyo3::{
     PyTryFrom, PyWrapper,
 };
 
-use crate::{expression::PyExpression, impl_to_quil};
+use crate::{expression::PyExpression, impl_copy_for_instruction, impl_to_quil};
 
 py_wrap_data_struct! {
     #[derive(Debug, PartialEq, Eq)]
@@ -23,6 +23,7 @@ py_wrap_data_struct! {
         parameters: Vec<String> => Vec<Py<PyString>>
     }
 }
+impl_copy_for_instruction!(PyWaveform);
 impl_repr!(PyWaveform);
 impl_hash!(PyWaveform);
 
@@ -58,6 +59,7 @@ py_wrap_data_struct! {
 }
 impl_repr!(PyWaveformDefinition);
 impl_to_quil!(PyWaveformDefinition);
+impl_copy_for_instruction!(PyWaveformDefinition);
 impl_hash!(PyWaveformDefinition);
 
 #[pymethods]
@@ -88,6 +90,7 @@ py_wrap_data_struct! {
 }
 impl_repr!(PyWaveformInvocation);
 impl_to_quil!(PyWaveformInvocation);
+impl_copy_for_instruction!(PyWaveformInvocation);
 
 #[pymethods]
 impl PyWaveformInvocation {

--- a/quil-py/src/instruction/waveform.rs
+++ b/quil-py/src/instruction/waveform.rs
@@ -23,7 +23,6 @@ py_wrap_data_struct! {
         parameters: Vec<String> => Vec<Py<PyString>>
     }
 }
-impl_copy_for_instruction!(PyWaveform);
 impl_repr!(PyWaveform);
 impl_hash!(PyWaveform);
 
@@ -90,7 +89,6 @@ py_wrap_data_struct! {
 }
 impl_repr!(PyWaveformInvocation);
 impl_to_quil!(PyWaveformInvocation);
-impl_copy_for_instruction!(PyWaveformInvocation);
 
 #[pymethods]
 impl PyWaveformInvocation {

--- a/quil-py/src/program/mod.rs
+++ b/quil-py/src/program/mod.rs
@@ -313,8 +313,8 @@ impl PyProgram {
     // placeholders. This is because they can't be converted to valid quil,
     // nor can they be serialized and deserialized in a consistent
     // way.
-    pub fn __getstate__<'a>(&self, py: Python<'a>) -> PyResult<&'a PyBytes> {
-        Ok(PyBytes::new(py, self.to_quil()?.as_bytes()))
+    pub fn __getstate__(&self, py: Python<'_>) -> PyResult<Py<PyBytes>> {
+        Ok(PyBytes::new(py, self.to_quil()?.as_bytes()).into_py(py))
     }
 
     pub fn __setstate__(&mut self, py: Python<'_>, state: &PyBytes) -> PyResult<()> {

--- a/quil-py/test/instructions/test_copy.py
+++ b/quil-py/test/instructions/test_copy.py
@@ -1,6 +1,7 @@
 from copy import copy, deepcopy
 
-from quil.instructions import Qubit, QubitPlaceholder, FrameIdentifier, Pulse, WaveformInvocation, Instruction
+from quil.expression import Expression
+from quil.instructions import Qubit, QubitPlaceholder, FrameIdentifier, Pulse, WaveformInvocation, Instruction, Calibration, Delay
 
 def test_instruction_with_qubit():
     frame_identifier = FrameIdentifier("frame", [Qubit.from_placeholder(QubitPlaceholder())])
@@ -8,6 +9,8 @@ def test_instruction_with_qubit():
     pulse = Pulse(False, frame_identifier, waveform_invocation)
 
     pulse_copy = copy(pulse)
+    assert pulse_copy == pulse
+    pulse_copy.frame.name = "renamed_frame"
     assert pulse_copy == pulse
 
     pulse_deepcopy = deepcopy(pulse)
@@ -19,3 +22,28 @@ def test_instruction_with_qubit():
     instruction = Instruction(pulse)
     instruction_deepcopy = deepcopy(instruction)
     assert instruction_deepcopy != instruction
+
+
+def test_instruction_with_duplicate_placeholders():
+    placeholder = Qubit.from_placeholder(QubitPlaceholder())
+
+    calibration = Calibration(
+            "MYCAL",
+            [],
+            [placeholder],
+            [
+                Instruction.from_delay(
+                    Delay(Expression.from_number(complex(0.5)), [], [placeholder])
+                )
+            ],
+            [])
+
+    calibration_copy = copy(calibration)
+    assert calibration_copy == calibration
+
+    calibration_deepcopy = deepcopy(calibration)
+    assert calibration_deepcopy != calibration
+
+    assert calibration_deepcopy.qubits == calibration_deepcopy.instructions[0].to_delay().qubits
+
+

--- a/quil-py/test/instructions/test_copy.py
+++ b/quil-py/test/instructions/test_copy.py
@@ -1,0 +1,21 @@
+from copy import copy, deepcopy
+
+from quil.instructions import Qubit, QubitPlaceholder, FrameIdentifier, Pulse, WaveformInvocation, Instruction
+
+def test_instruction_with_qubit():
+    frame_identifier = FrameIdentifier("frame", [Qubit.from_placeholder(QubitPlaceholder())])
+    waveform_invocation = WaveformInvocation("wf", {})
+    pulse = Pulse(False, frame_identifier, waveform_invocation)
+
+    pulse_copy = copy(pulse)
+    assert pulse_copy == pulse
+
+    pulse_deepcopy = deepcopy(pulse)
+    assert pulse_deepcopy.blocking == pulse.blocking
+    assert pulse_deepcopy.waveform == pulse.waveform
+    assert pulse_deepcopy.frame.name == pulse.frame.name
+    assert pulse_deepcopy.frame.qubits != pulse.frame.qubits
+    
+    instruction = Instruction(pulse)
+    instruction_deepcopy = deepcopy(instruction)
+    assert instruction_deepcopy != instruction

--- a/quil-rs/src/instruction/mod.rs
+++ b/quil-rs/src/instruction/mod.rs
@@ -552,7 +552,7 @@ impl Instruction {
 
     /// Return immutable references to the [`Qubit`]s contained within an instruction
     #[allow(dead_code)]
-    pub(crate) fn get_qubits(&self) -> Vec<&Qubit> {
+    pub fn get_qubits(&self) -> Vec<&Qubit> {
         match self {
             Instruction::Gate(gate) => gate.qubits.iter().collect(),
             Instruction::Measurement(measurement) => vec![&measurement.qubit],
@@ -570,7 +570,7 @@ impl Instruction {
     }
 
     /// Return mutable references to the [`Qubit`]s contained within an instruction
-    pub(crate) fn get_qubits_mut(&mut self) -> Vec<&mut Qubit> {
+    pub fn get_qubits_mut(&mut self) -> Vec<&mut Qubit> {
         match self {
             Instruction::Gate(gate) => gate.qubits.iter_mut().collect(),
             Instruction::Measurement(measurement) => vec![&mut measurement.qubit],


### PR DESCRIPTION
It's not uncommon to want to create a copy of something using Python's copy module, so this makes all instruction types compatible with it.
