### PR TITLE
fix: no percent symbol in variable qubit outputs

### DIFF
--- a/quil-rs/src/instruction/mod.rs
+++ b/quil-rs/src/instruction/mod.rs
@@ -219,23 +219,16 @@ fn write_qubits(
     Ok(())
 }
 
-/// Write qubits as a Quil parameter list, where each variable qubit must be prefixed with a `%`
-/// and all are prefixed with ` `. Return an error if any is a qubit placeholder.
+/// Write qubits as a Quil parameter list, where all are prefixed with ` `.
 fn write_qubit_parameters(
     f: &mut impl std::fmt::Write,
     fall_back_to_debug: bool,
     qubits: &[Qubit],
 ) -> ToQuilResult<()> {
     for qubit in qubits.iter() {
-        match qubit {
-            Qubit::Variable(var) => write!(f, " %{var}")?,
-            other => {
-                write!(f, " ")?;
-                other.write(f, fall_back_to_debug)?;
-            }
-        }
+        write!(f, " ")?;
+        qubit.write(f, fall_back_to_debug)?;
     }
-
     Ok(())
 }
 

--- a/quil-rs/src/program/snapshots/quil_rs__program__calibration__tests__expansion@Calibration-Param-Precedence.snap
+++ b/quil-rs/src/program/snapshots/quil_rs__program__calibration__tests__expansion@Calibration-Param-Precedence.snap
@@ -1,8 +1,8 @@
 ---
 source: quil-rs/src/program/calibration.rs
-expression: calibrated_program.to_string()
+expression: calibrated_program.to_quil_or_debug()
 ---
-DEFCAL RX(%theta) %qubit:
+DEFCAL RX(%theta) qubit:
 	PULSE 1 "xy" gaussian(duration: 1, fwhm: 2, t0: 3)
 DEFCAL RX(%theta) 0:
 	PULSE 2 "xy" gaussian(duration: 1, fwhm: 2, t0: 3)

--- a/quil-rs/src/program/snapshots/quil_rs__program__calibration__tests__expansion@Calibration-Variable-Qubit.snap
+++ b/quil-rs/src/program/snapshots/quil_rs__program__calibration__tests__expansion@Calibration-Variable-Qubit.snap
@@ -1,8 +1,8 @@
 ---
 source: quil-rs/src/program/calibration.rs
-expression: calibrated_program.to_string()
+expression: calibrated_program.to_quil_or_debug()
 ---
-DEFCAL I %q:
+DEFCAL I q:
 	DELAY q 4e-8
 DELAY 0 4e-8
 

--- a/quil-rs/src/program/snapshots/quil_rs__program__calibration__tests__expansion@ShiftPhase.snap
+++ b/quil-rs/src/program/snapshots/quil_rs__program__calibration__tests__expansion@ShiftPhase.snap
@@ -1,8 +1,8 @@
 ---
 source: quil-rs/src/program/calibration.rs
-expression: calibrated_program.to_string()
+expression: calibrated_program.to_quil_or_debug()
 ---
-DEFCAL RZ(%theta) %q:
+DEFCAL RZ(%theta) q:
 	SHIFT-PHASE q "rf" -%theta
 SHIFT-PHASE 0 "rf" -pi
 


### PR DESCRIPTION
In [this pyQuil issue](https://github.com/rigetti/pyquil/issues/1673), we saw that the v3 version of pyQuil can't parse `DEFCALS` with a variable qubit; e.g.

```
DEFCAL I %q:
	DELAY q 4e-8
```

would cause pyQuil to crash, complaining about the `%` symbol. While the [spec claims](https://quil-lang.github.io/#12-6Defining-Calibrations) this is a valid way of writing variable qubits for calibrations, the percent symbol prefix is only otherwise used for parameters (e.g. angles for rotational gates), not for qubits themselves. This PR changes how variable qubits are printed, removing the `%` prefix.

If this change is merged into `quil-rs`, chances are we probably want to update the spec accordingly as well.