### PR TITLE
fix: use internal QuotedString wrapper to quote Quil strings correctly

### DIFF
--- a/quil-rs/src/instruction/frame.rs
+++ b/quil-rs/src/instruction/frame.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, str::FromStr};
 
 use nom_locate::LocatedSpan;
 
-use super::{MemoryReference, Qubit, WaveformInvocation};
+use super::{MemoryReference, Qubit, QuotedString, WaveformInvocation};
 use crate::{
     expression::Expression,
     parser::{common::parse_frame_identifier, lex, ParseError},
@@ -24,7 +24,7 @@ impl Quil for AttributeValue {
     ) -> crate::quil::ToQuilResult<()> {
         use AttributeValue::*;
         match self {
-            String(value) => write!(f, "{value:?}").map_err(Into::into),
+            String(value) => write!(f, "{}", QuotedString(value)).map_err(Into::into),
             Expression(value) => value.write(f, fall_back_to_debug),
         }
     }
@@ -87,7 +87,7 @@ impl Quil for FrameIdentifier {
             qubit.write(writer, fall_back_to_debug)?;
             write!(writer, " ")?;
         }
-        write!(writer, "{:?}", self.name).map_err(Into::into)
+        write!(writer, "{}", QuotedString(&self.name)).map_err(Into::into)
     }
 }
 

--- a/quil-rs/src/instruction/mod.rs
+++ b/quil-rs/src/instruction/mod.rs
@@ -319,6 +319,25 @@ impl Quil for Instruction {
     }
 }
 
+pub(crate) struct QuotedString<S>(pub(crate) S);
+
+impl<S> fmt::Display for QuotedString<S>
+where
+    S: AsRef<str>,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "\"")?;
+        for c in self.0.as_ref().chars() {
+            match c {
+                '"' => write!(f, "\\\"")?,
+                '\\' => write!(f, "\\\\")?,
+                c => write!(f, "{}", c)?,
+            }
+        }
+        write!(f, "\"")
+    }
+}
+
 #[cfg(test)]
 mod test_instruction_display {
     use crate::{instruction::PragmaArgument, quil::Quil};

--- a/quil-rs/src/instruction/pragma.rs
+++ b/quil-rs/src/instruction/pragma.rs
@@ -1,5 +1,7 @@
 use crate::quil::Quil;
 
+use super::QuotedString;
+
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Pragma {
     pub name: String,
@@ -29,7 +31,7 @@ impl Quil for Pragma {
             arg.write(f, fall_back_to_debug)?;
         }
         if let Some(data) = &self.data {
-            write!(f, " {data:?}")?;
+            write!(f, " {}", QuotedString(data))?;
         }
         Ok(())
     }
@@ -66,7 +68,7 @@ impl Quil for Include {
         f: &mut impl std::fmt::Write,
         _fall_back_to_debug: bool,
     ) -> crate::quil::ToQuilResult<()> {
-        write!(f, r#"INCLUDE {:?}"#, self.filename).map_err(Into::into)
+        write!(f, r#"INCLUDE {}"#, QuotedString(&self.filename)).map_err(Into::into)
     }
 }
 

--- a/quil-rs/src/parser/lexer/quoted_strings.rs
+++ b/quil-rs/src/parser/lexer/quoted_strings.rs
@@ -95,6 +95,7 @@ fn surrounded(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::instruction::QuotedString;
     use nom::Finish;
     use nom_locate::LocatedSpan;
     use rstest::rstest;
@@ -107,12 +108,17 @@ mod tests {
     #[case("\"foo bar (baz) 123\" after", "foo bar (baz) 123", " after")]
     #[case(r#""{\"name\": \"quoted json\"}""#, r#"{"name": "quoted json"}"#, "")]
     #[case(r#""hello"\n"world""#, "hello", "\\n\"world\"")]
+    #[case(
+        "\"a \\\"string\\\" \n with newlines\"",
+        "a \"string\" \n with newlines",
+        ""
+    )]
     fn string_parser(#[case] input: &str, #[case] output: &str, #[case] leftover: &str) {
         let span = LocatedSpan::new(input);
         let (remaining, parsed) = unescaped_quoted_string(span).finish().unwrap();
         assert_eq!(parsed, output);
         assert_eq!(remaining.fragment(), &leftover);
-        let round_tripped = format!("{:?}", parsed);
+        let round_tripped = QuotedString(&parsed).to_string();
         assert!(
             input.starts_with(&round_tripped),
             "expected `{}` to start with `{}`",

--- a/quil-rs/src/parser/token.rs
+++ b/quil-rs/src/parser/token.rs
@@ -1,3 +1,4 @@
+use crate::instruction::QuotedString;
 use crate::parser::lexer::{Command, DataType, LexInput, LexResult, Modifier, Operator};
 use std::fmt;
 use std::fmt::Formatter;
@@ -125,7 +126,7 @@ impl fmt::Display for Token {
             Token::RParenthesis => write!(f, ")"),
             Token::Semicolon => write!(f, ";"),
             Token::Sharing => write!(f, "SHARING"),
-            Token::String(s) => write!(f, "{s:?}"),
+            Token::String(s) => write!(f, "{}", QuotedString(s)),
             Token::Variable(v) => write!(f, "{v}"),
         }
     }


### PR DESCRIPTION
Fixes #315.

This uses a new `QuotedString` wrapper with a custom `Display` impl to only escape quotation marks and backslashes in strings, and nothing else.