### PR TITLE
Reduce number of classical instruction edges in InstructionBlock::gra…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ __pycache__
 # quil-py documentation
 quil-py/build
 
+# unversioned developer notes
+scratch/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1047,7 +1047,7 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quil-py"
-version = "0.6.1-rc.0"
+version = "0.6.3"
 dependencies = [
  "ndarray",
  "numpy",
@@ -1060,7 +1060,7 @@ dependencies = [
 
 [[package]]
 name = "quil-rs"
-version = "0.22.1-rc.0"
+version = "0.22.3"
 dependencies = [
  "approx",
  "clap",

--- a/quil-rs/Cargo.toml
+++ b/quil-rs/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.22.3"
 edition = "2021"
 rust-version = "1.70"
 license = "Apache-2.0"
-repository = "https://github.com/rigetti/quil-rust"
+repository = "https://github.com/rigetti/quil-rs"
 keywords = ["Quil", "Quantum", "Rigetti"]
 categories = ["parser-implementations", "science", "compilers", "emulators"]
 

--- a/quil-rs/src/program/snapshots/quil_rs__program__graph__tests__classical_no_memory_pragma.snap
+++ b/quil-rs/src/program/snapshots/quil_rs__program__graph__tests__classical_no_memory_pragma.snap
@@ -1,0 +1,18 @@
+---
+source: quil-rs/src/program/graph.rs
+expression: dot_format
+---
+digraph {
+  entry -> "block_0_start";
+  entry [label="Entry Point"];
+  subgraph cluster_0 {
+    label="block_0";
+    node [style="filled"];
+    "block_0_start" [shape=circle, label="start"];
+    "block_0_start" -> "block_0_0" [label="ordering"];
+    "block_0_0" [shape=rectangle, label="[0] PRAGMA example"];
+    "block_0_0" -> "block_0_end" [label="ordering"];
+    "block_0_end" [shape=circle, label="end"];
+  }
+}
+

--- a/quil-rs/src/program/snapshots/quil_rs__program__graph__tests__classical_read_write_load_load.snap
+++ b/quil-rs/src/program/snapshots/quil_rs__program__graph__tests__classical_read_write_load_load.snap
@@ -1,0 +1,20 @@
+---
+source: quil-rs/src/program/graph.rs
+expression: dot_format
+---
+digraph {
+  entry -> "block_0_start";
+  entry [label="Entry Point"];
+  subgraph cluster_0 {
+    label="block_0";
+    node [style="filled"];
+    "block_0_start" [shape=circle, label="start"];
+    "block_0_start" -> "block_0_0" [label="ordering"];
+    "block_0_0" [shape=rectangle, label="[0] LOAD params1[0] params2 integers[0]"];
+    "block_0_0" -> "block_0_1" [label="await read"];
+    "block_0_1" [shape=rectangle, label="[1] LOAD params2[0] params3 integers[0]"];
+    "block_0_1" -> "block_0_end" [label="ordering"];
+    "block_0_end" [shape=circle, label="end"];
+  }
+}
+

--- a/quil-rs/src/program/snapshots/quil_rs__program__graph__tests__classical_read_write_load_mul.snap
+++ b/quil-rs/src/program/snapshots/quil_rs__program__graph__tests__classical_read_write_load_mul.snap
@@ -1,0 +1,20 @@
+---
+source: quil-rs/src/program/graph.rs
+expression: dot_format
+---
+digraph {
+  entry -> "block_0_start";
+  entry [label="Entry Point"];
+  subgraph cluster_0 {
+    label="block_0";
+    node [style="filled"];
+    "block_0_start" [shape=circle, label="start"];
+    "block_0_start" -> "block_0_0" [label="ordering"];
+    "block_0_0" [shape=rectangle, label="[0] LOAD params1[0] params2 integers[0]"];
+    "block_0_0" -> "block_0_1" [label="await read"];
+    "block_0_1" [shape=rectangle, label="[1] MUL params2[0] 2"];
+    "block_0_1" -> "block_0_end" [label="ordering"];
+    "block_0_end" [shape=circle, label="end"];
+  }
+}
+

--- a/quil-rs/src/program/snapshots/quil_rs__program__graph__tests__classical_write_read_add_mul.snap
+++ b/quil-rs/src/program/snapshots/quil_rs__program__graph__tests__classical_write_read_add_mul.snap
@@ -1,0 +1,20 @@
+---
+source: quil-rs/src/program/graph.rs
+expression: dot_format
+---
+digraph {
+  entry -> "block_0_start";
+  entry [label="Entry Point"];
+  subgraph cluster_0 {
+    label="block_0";
+    node [style="filled"];
+    "block_0_start" [shape=circle, label="start"];
+    "block_0_start" -> "block_0_0" [label="ordering"];
+    "block_0_0" [shape=rectangle, label="[0] ADD params1[0] 1"];
+    "block_0_0" -> "block_0_1" [label="await write"];
+    "block_0_1" [shape=rectangle, label="[1] MUL params1[0] 2"];
+    "block_0_1" -> "block_0_end" [label="ordering"];
+    "block_0_end" [shape=circle, label="end"];
+  }
+}
+

--- a/quil-rs/src/program/snapshots/quil_rs__program__graph__tests__classical_write_read_load_load.snap
+++ b/quil-rs/src/program/snapshots/quil_rs__program__graph__tests__classical_write_read_load_load.snap
@@ -1,0 +1,20 @@
+---
+source: quil-rs/src/program/graph.rs
+expression: dot_format
+---
+digraph {
+  entry -> "block_0_start";
+  entry [label="Entry Point"];
+  subgraph cluster_0 {
+    label="block_0";
+    node [style="filled"];
+    "block_0_start" [shape=circle, label="start"];
+    "block_0_start" -> "block_0_0" [label="ordering"];
+    "block_0_0" [shape=rectangle, label="[0] LOAD params2[0] params3 integers[0]"];
+    "block_0_0" -> "block_0_1" [label="await write"];
+    "block_0_1" [shape=rectangle, label="[1] LOAD params1[0] params2 integers[0]"];
+    "block_0_1" -> "block_0_end" [label="ordering"];
+    "block_0_end" [shape=circle, label="end"];
+  }
+}
+

--- a/quil-rs/src/program/snapshots/quil_rs__program__graph__tests__classical_write_read_mul_load.snap
+++ b/quil-rs/src/program/snapshots/quil_rs__program__graph__tests__classical_write_read_mul_load.snap
@@ -1,0 +1,20 @@
+---
+source: quil-rs/src/program/graph.rs
+expression: dot_format
+---
+digraph {
+  entry -> "block_0_start";
+  entry [label="Entry Point"];
+  subgraph cluster_0 {
+    label="block_0";
+    node [style="filled"];
+    "block_0_start" [shape=circle, label="start"];
+    "block_0_start" -> "block_0_0" [label="ordering"];
+    "block_0_0" [shape=rectangle, label="[0] MUL params2[0] 2"];
+    "block_0_0" -> "block_0_1" [label="await write"];
+    "block_0_1" [shape=rectangle, label="[1] LOAD params1[0] params2 integers[0]"];
+    "block_0_1" -> "block_0_end" [label="ordering"];
+    "block_0_end" [shape=circle, label="end"];
+  }
+}
+

--- a/quil-rs/src/program/snapshots/quil_rs__program__graph__tests__classical_write_write_load_mul.snap
+++ b/quil-rs/src/program/snapshots/quil_rs__program__graph__tests__classical_write_write_load_mul.snap
@@ -1,0 +1,31 @@
+---
+source: quil-rs/src/program/graph.rs
+expression: dot_format
+---
+digraph {
+  entry -> "block_0_start";
+  entry [label="Entry Point"];
+  subgraph cluster_0 {
+    label="block_0";
+    node [style="filled"];
+    "block_0_start" [shape=circle, label="start"];
+    "block_0_start" -> "block_0_0" [label="ordering"];
+    "block_0_start" -> "block_0_1" [label="ordering
+timing"];
+    "block_0_start" -> "block_0_3" [label="ordering
+timing"];
+    "block_0_0" [shape=rectangle, label="[0] LOAD params2[0] params1 integers[0]"];
+    "block_0_0" -> "block_0_1" [label="await write"];
+    "block_0_1" [shape=rectangle, label="[1] SHIFT-PHASE 0 \"rf\" params2[0]"];
+    "block_0_1" -> "block_0_2" [label="await read"];
+    "block_0_1" -> "block_0_end" [label="ordering
+timing"];
+    "block_0_2" [shape=rectangle, label="[2] LOAD params2[0] params1 integers[1]"];
+    "block_0_2" -> "block_0_3" [label="await write"];
+    "block_0_3" [shape=rectangle, label="[3] SHIFT-PHASE 1 \"rf\" params2[0]"];
+    "block_0_3" -> "block_0_end" [label="ordering
+timing"];
+    "block_0_end" [shape=circle, label="end"];
+  }
+}
+

--- a/quil-rs/src/program/snapshots/quil_rs__program__graph__tests__custom_handler__load_dependencies.snap
+++ b/quil-rs/src/program/snapshots/quil_rs__program__graph__tests__custom_handler__load_dependencies.snap
@@ -1,0 +1,126 @@
+---
+source: quil-rs/src/program/graph.rs
+expression: dot_format
+---
+digraph {
+  entry -> "block_0_start";
+  entry [label="Entry Point"];
+  subgraph cluster_0 {
+    label="block_0";
+    node [style="filled"];
+    "block_0_start" [shape=circle, label="start"];
+    "block_0_start" -> "block_0_2" [label="ordering
+timing"];
+    "block_0_start" -> "block_0_3" [label="ordering
+timing"];
+    "block_0_start" -> "block_0_9" [label="ordering
+timing"];
+    "block_0_start" -> "block_0_10" [label="ordering
+timing"];
+    "block_0_start" -> "block_0_end" [label="ordering"];
+    "block_0_0" [shape=rectangle, label="[0] LOAD param01[0] params01 shot_index0[0]"];
+    "block_0_0" -> "block_0_5" [label="await write"];
+    "block_0_0" -> "block_0_end" [label="await read"];
+    "block_0_1" [shape=rectangle, label="[1] LOAD param02[0] params02 shot_index1[0]"];
+    "block_0_1" -> "block_0_10" [label="await write"];
+    "block_0_1" -> "block_0_end" [label="await read"];
+    "block_0_2" [shape=rectangle, label="[2] FENCE 0"];
+    "block_0_2" -> "block_0_3" [label="ordering
+timing"];
+    "block_0_3" [shape=rectangle, label="[3] SHIFT-PHASE 0 \"rf\" -0.14945171144281807"];
+    "block_0_3" -> "block_0_4" [label="ordering
+timing"];
+    "block_0_4" [shape=rectangle, label="[4] SHIFT-PHASE 0 \"rf\" -0.17773989418736816"];
+    "block_0_4" -> "block_0_5" [label="ordering
+timing"];
+    "block_0_5" [shape=rectangle, label="[5] SHIFT-PHASE 0 \"rf\" -1*param01[0]"];
+    "block_0_5" -> "block_0_8" [label="ordering
+timing"];
+    "block_0_5" -> "block_0_15" [label="ordering
+timing"];
+    "block_0_5" -> "block_0_16" [label="ordering
+timing"];
+    "block_0_5" -> "block_0_24" [label="ordering
+timing"];
+    "block_0_5" -> "block_0_25" [label="ordering
+timing"];
+    "block_0_5" -> "block_0_end" [label="await read
+ordering
+timing"];
+    "block_0_6" [shape=rectangle, label="[6] SHIFT-PHASE 0 1 \"xy\" -0.5*param01[0]"];
+    "block_0_6" -> "block_0_end" [label="await read"];
+    "block_0_7" [shape=rectangle, label="[7] SHIFT-PHASE 0 7 \"xy\" -0.5*param01[0]"];
+    "block_0_7" -> "block_0_end" [label="await read"];
+    "block_0_8" [shape=rectangle, label="[8] FENCE 0"];
+    "block_0_8" -> "block_0_end" [label="ordering
+timing"];
+    "block_0_9" [shape=rectangle, label="[9] FENCE 1"];
+    "block_0_9" -> "block_0_10" [label="ordering
+timing"];
+    "block_0_10" [shape=rectangle, label="[10] SHIFT-PHASE 1 \"rf\" -1*param02[0]"];
+    "block_0_10" -> "block_0_14" [label="ordering
+timing"];
+    "block_0_10" -> "block_0_26" [label="ordering
+timing"];
+    "block_0_10" -> "block_0_27" [label="ordering
+timing"];
+    "block_0_10" -> "block_0_35" [label="ordering
+timing"];
+    "block_0_10" -> "block_0_36" [label="ordering
+timing"];
+    "block_0_10" -> "block_0_end" [label="await read
+ordering
+timing"];
+    "block_0_11" [shape=rectangle, label="[11] SHIFT-PHASE 0 1 \"xy\" 0.5*param02[0]"];
+    "block_0_11" -> "block_0_end" [label="await read"];
+    "block_0_12" [shape=rectangle, label="[12] SHIFT-PHASE 1 16 \"xy\" 0.5*param02[0]"];
+    "block_0_12" -> "block_0_end" [label="await read"];
+    "block_0_13" [shape=rectangle, label="[13] SHIFT-PHASE 1 2 \"xy\" 0.5*param02[0]"];
+    "block_0_13" -> "block_0_end" [label="await read"];
+    "block_0_14" [shape=rectangle, label="[14] FENCE 1"];
+    "block_0_14" -> "block_0_end" [label="ordering
+timing"];
+    "block_0_15" [shape=rectangle, label="[15] FENCE 0"];
+    "block_0_15" -> "block_0_end" [label="ordering
+timing"];
+    "block_0_16" [shape=rectangle, label="[16] PULSE 0 \"rf_f12\" gaussian(detuning: 0, duration: 6.000000000000001e-8, fwhm: 1.5000000000000002e-8, phase: 0, scale: 0.16297407445283926, t0: 3.0000000000000004e-8)"];
+    "block_0_16" -> "block_0_end" [label="ordering
+timing"];
+    "block_0_17" [shape=rectangle, label="[17] NONBLOCKING PULSE 0 \"ro_tx\" flat(detuning: 0, duration: 1.48e-6, iq: 1, phase: 0, scale: 0.070794578438414)"];
+    "block_0_18" [shape=rectangle, label="[18] NONBLOCKING CAPTURE 0 \"ro_rx\" boxcar_kernel(detuning: 0, duration: 1.48e-6, phase: -2.399526580341531, scale: 1) ro[0]"];
+    "block_0_18" -> "block_0_29" [label="await capture"];
+    "block_0_19" [shape=rectangle, label="[19] PRAGMA FILTER-NODE q0_unclassified \"{'module':'lodgepole.filters.io','filter_type':'DataBuffer','source':'q0_ro_rx/filter','publish':true,'params':{},'_type':'FilterNode'}\""];
+    "block_0_20" [shape=rectangle, label="[20] PRAGMA LOAD-MEMORY q0_unclassified \"q0_unclassified[0]\""];
+    "block_0_21" [shape=rectangle, label="[21] PRAGMA FILTER-NODE q0_classified \"{'module':'lodgepole.filters.classifiers','filter_type':'SingleQLinear','source':'q0_ro_rx/filter','publish':false,'params':{'a':[1.0,0.0],'threshold':0.0004483948973233858},'_type':'FilterNode'}\""];
+    "block_0_22" [shape=rectangle, label="[22] PRAGMA FILTER-NODE q0 \"{'module':'lodgepole.filters.io','filter_type':'DataBuffer','source':'q0_classified','publish':true,'params':{},'_type':'FilterNode'}\""];
+    "block_0_23" [shape=rectangle, label="[23] PRAGMA LOAD-MEMORY q0 \"ro[0]\""];
+    "block_0_24" [shape=rectangle, label="[24] PULSE 0 \"rf_f12\" gaussian(detuning: 0, duration: 6.000000000000001e-8, fwhm: 1.5000000000000002e-8, phase: 0, scale: 0.16297407445283926, t0: 3.0000000000000004e-8)"];
+    "block_0_24" -> "block_0_end" [label="ordering
+timing"];
+    "block_0_25" [shape=rectangle, label="[25] FENCE 0"];
+    "block_0_25" -> "block_0_end" [label="ordering
+timing"];
+    "block_0_26" [shape=rectangle, label="[26] FENCE 1"];
+    "block_0_26" -> "block_0_end" [label="ordering
+timing"];
+    "block_0_27" [shape=rectangle, label="[27] PULSE 1 \"rf_f12\" gaussian(detuning: 0, duration: 6.000000000000001e-8, fwhm: 1.5000000000000002e-8, phase: 0, scale: 0.14420836465022144, t0: 3.0000000000000004e-8)"];
+    "block_0_27" -> "block_0_end" [label="ordering
+timing"];
+    "block_0_28" [shape=rectangle, label="[28] NONBLOCKING PULSE 1 \"ro_tx\" flat(detuning: 0, duration: 2e-6, iq: 1, phase: 0, scale: 0.0891250938133745)"];
+    "block_0_29" [shape=rectangle, label="[29] NONBLOCKING CAPTURE 1 \"ro_rx\" boxcar_kernel(detuning: 0, duration: 2e-6, phase: 0.8107443195373324, scale: 1) ro[1]"];
+    "block_0_29" -> "block_0_end" [label="await capture"];
+    "block_0_30" [shape=rectangle, label="[30] PRAGMA FILTER-NODE q1_unclassified \"{'module':'lodgepole.filters.io','filter_type':'DataBuffer','source':'q1_ro_rx/filter','publish':true,'params':{},'_type':'FilterNode'}\""];
+    "block_0_31" [shape=rectangle, label="[31] PRAGMA LOAD-MEMORY q1_unclassified \"q1_unclassified[0]\""];
+    "block_0_32" [shape=rectangle, label="[32] PRAGMA FILTER-NODE q1_classified \"{'module':'lodgepole.filters.classifiers','filter_type':'SingleQLinear','source':'q1_ro_rx/filter','publish':false,'params':{'a':[1.0,0.0],'threshold':5.6536894061896907e-05},'_type':'FilterNode'}\""];
+    "block_0_33" [shape=rectangle, label="[33] PRAGMA FILTER-NODE q1 \"{'module':'lodgepole.filters.io','filter_type':'DataBuffer','source':'q1_classified','publish':true,'params':{},'_type':'FilterNode'}\""];
+    "block_0_34" [shape=rectangle, label="[34] PRAGMA LOAD-MEMORY q1 \"ro[1]\""];
+    "block_0_35" [shape=rectangle, label="[35] PULSE 1 \"rf_f12\" gaussian(detuning: 0, duration: 6.000000000000001e-8, fwhm: 1.5000000000000002e-8, phase: 0, scale: 0.14420836465022144, t0: 3.0000000000000004e-8)"];
+    "block_0_35" -> "block_0_end" [label="ordering
+timing"];
+    "block_0_36" [shape=rectangle, label="[36] FENCE 1"];
+    "block_0_36" -> "block_0_end" [label="ordering
+timing"];
+    "block_0_end" [shape=circle, label="end"];
+  }
+}
+

--- a/quil-rs/src/program/snapshots/quil_rs__program__graph__tests__custom_handler__mixed_pragmas_and_pulses.snap
+++ b/quil-rs/src/program/snapshots/quil_rs__program__graph__tests__custom_handler__mixed_pragmas_and_pulses.snap
@@ -14,20 +14,21 @@ digraph {
 timing"];
     "block_0_start" -> "block_0_2" [label="ordering
 timing"];
+    "block_0_start" -> "block_0_4" [label="ordering"];
     "block_0_start" -> "block_0_5" [label="ordering
 timing"];
     "block_0_start" -> "block_0_7" [label="ordering
 timing"];
     "block_0_start" -> "block_0_8" [label="ordering
 timing"];
+    "block_0_start" -> "block_0_9" [label="ordering"];
     "block_0_start" -> "block_0_end" [label="ordering
 timing"];
     "block_0_0" [shape=rectangle, label="[0] PRAGMA NO-OP"];
-    "block_0_0" -> "block_0_4" [label="ordering"];
+    "block_0_0" -> "block_0_end" [label="ordering"];
     "block_0_1" [shape=rectangle, label="[1] PRAGMA RAW-INSTRUCTION foo"];
     "block_0_1" -> "block_0_3" [label="ordering
 timing"];
-    "block_0_1" -> "block_0_end" [label="await read"];
     "block_0_2" [shape=rectangle, label="[2] PULSE 1 \"bar\" gaussian(duration: 1, fwhm: 2, t0: 3)"];
     "block_0_2" -> "block_0_3" [label="ordering
 timing"];
@@ -38,9 +39,8 @@ timing"];
 timing"];
     "block_0_3" -> "block_0_6" [label="ordering
 timing"];
-    "block_0_3" -> "block_0_end" [label="await read"];
     "block_0_4" [shape=rectangle, label="[4] PRAGMA NO-OP"];
-    "block_0_4" -> "block_0_9" [label="ordering"];
+    "block_0_4" -> "block_0_end" [label="ordering"];
     "block_0_5" [shape=rectangle, label="[5] PULSE 0 \"foo\" gaussian(duration: 1, fwhm: 2, t0: 3)"];
     "block_0_5" -> "block_0_7" [label="ordering
 timing"];
@@ -49,7 +49,6 @@ timing"];
     "block_0_6" [shape=rectangle, label="[6] PRAGMA RAW-INSTRUCTION bar"];
     "block_0_6" -> "block_0_8" [label="ordering
 timing"];
-    "block_0_6" -> "block_0_end" [label="await read"];
     "block_0_7" [shape=rectangle, label="[7] PULSE 0 \"foo\" gaussian(duration: 1, fwhm: 2, t0: 3)"];
     "block_0_7" -> "block_0_10" [label="ordering
 timing"];
@@ -61,8 +60,7 @@ timing"];
     "block_0_9" [shape=rectangle, label="[9] PRAGMA NO-OP"];
     "block_0_9" -> "block_0_end" [label="ordering"];
     "block_0_10" [shape=rectangle, label="[10] PRAGMA RAW-INSTRUCTION foo"];
-    "block_0_10" -> "block_0_end" [label="await read
-ordering
+    "block_0_10" -> "block_0_end" [label="ordering
 timing"];
     "block_0_end" [shape=circle, label="end"];
   }

--- a/quil-rs/src/program/snapshots/quil_rs__program__graph__tests__custom_handler__only_pragmas_with_frames.snap
+++ b/quil-rs/src/program/snapshots/quil_rs__program__graph__tests__custom_handler__only_pragmas_with_frames.snap
@@ -14,29 +14,27 @@ digraph {
 timing"];
     "block_0_start" -> "block_0_2" [label="ordering
 timing"];
+    "block_0_start" -> "block_0_3" [label="ordering"];
+    "block_0_start" -> "block_0_5" [label="ordering"];
     "block_0_0" [shape=rectangle, label="[0] PRAGMA NO-OP"];
-    "block_0_0" -> "block_0_3" [label="ordering"];
+    "block_0_0" -> "block_0_end" [label="ordering"];
     "block_0_1" [shape=rectangle, label="[1] PRAGMA RAW-INSTRUCTION foo"];
     "block_0_1" -> "block_0_4" [label="ordering
 timing"];
-    "block_0_1" -> "block_0_end" [label="await read"];
     "block_0_2" [shape=rectangle, label="[2] PRAGMA RAW-INSTRUCTION bar"];
     "block_0_2" -> "block_0_4" [label="ordering
 timing"];
-    "block_0_2" -> "block_0_end" [label="await read"];
     "block_0_3" [shape=rectangle, label="[3] PRAGMA NO-OP"];
-    "block_0_3" -> "block_0_5" [label="ordering"];
+    "block_0_3" -> "block_0_end" [label="ordering"];
     "block_0_4" [shape=rectangle, label="[4] PRAGMA RAW-INSTRUCTION foo bar"];
     "block_0_4" -> "block_0_6" [label="ordering
 timing"];
-    "block_0_4" -> "block_0_end" [label="await read
-ordering
+    "block_0_4" -> "block_0_end" [label="ordering
 timing"];
     "block_0_5" [shape=rectangle, label="[5] PRAGMA NO-OP"];
     "block_0_5" -> "block_0_end" [label="ordering"];
     "block_0_6" [shape=rectangle, label="[6] PRAGMA RAW-INSTRUCTION foo"];
-    "block_0_6" -> "block_0_end" [label="await read
-ordering
+    "block_0_6" -> "block_0_end" [label="ordering
 timing"];
     "block_0_end" [shape=circle, label="end"];
   }

--- a/quil-rs/src/program/snapshots/quil_rs__program__graph__tests__custom_handler__only_pragmas_without_frames.snap
+++ b/quil-rs/src/program/snapshots/quil_rs__program__graph__tests__custom_handler__only_pragmas_without_frames.snap
@@ -12,21 +12,19 @@ digraph {
     "block_0_start" -> "block_0_0" [label="ordering"];
     "block_0_start" -> "block_0_1" [label="ordering
 timing"];
+    "block_0_start" -> "block_0_3" [label="ordering"];
     "block_0_0" [shape=rectangle, label="[0] PRAGMA NO-OP"];
-    "block_0_0" -> "block_0_3" [label="ordering"];
+    "block_0_0" -> "block_0_end" [label="ordering"];
     "block_0_1" [shape=rectangle, label="[1] PRAGMA RAW-INSTRUCTION"];
     "block_0_1" -> "block_0_2" [label="ordering
 timing"];
-    "block_0_1" -> "block_0_end" [label="await read"];
     "block_0_2" [shape=rectangle, label="[2] PRAGMA RAW-INSTRUCTION"];
     "block_0_2" -> "block_0_4" [label="ordering
 timing"];
-    "block_0_2" -> "block_0_end" [label="await read"];
     "block_0_3" [shape=rectangle, label="[3] PRAGMA NO-OP"];
     "block_0_3" -> "block_0_end" [label="ordering"];
     "block_0_4" [shape=rectangle, label="[4] PRAGMA RAW-INSTRUCTION"];
-    "block_0_4" -> "block_0_end" [label="await read
-ordering
+    "block_0_4" -> "block_0_end" [label="ordering
 timing"];
     "block_0_end" [shape=circle, label="end"];
   }

--- a/quil-rs/src/program/snapshots/quil_rs__program__graph__tests__quantum_write_parameterized_operations.snap
+++ b/quil-rs/src/program/snapshots/quil_rs__program__graph__tests__quantum_write_parameterized_operations.snap
@@ -1,0 +1,31 @@
+---
+source: quil-rs/src/program/graph.rs
+expression: dot_format
+---
+digraph {
+  entry -> "block_0_start";
+  entry [label="Entry Point"];
+  subgraph cluster_0 {
+    label="block_0";
+    node [style="filled"];
+    "block_0_start" [shape=circle, label="start"];
+    "block_0_start" -> "block_0_0" [label="ordering"];
+    "block_0_start" -> "block_0_1" [label="ordering
+timing"];
+    "block_0_start" -> "block_0_3" [label="ordering
+timing"];
+    "block_0_0" [shape=rectangle, label="[0] LOAD params2[0] params1 integers[0]"];
+    "block_0_0" -> "block_0_1" [label="await write"];
+    "block_0_1" [shape=rectangle, label="[1] SHIFT-PHASE 0 \"rf\" params2[0]"];
+    "block_0_1" -> "block_0_2" [label="await read"];
+    "block_0_1" -> "block_0_end" [label="ordering
+timing"];
+    "block_0_2" [shape=rectangle, label="[2] LOAD params2[0] params1 integers[1]"];
+    "block_0_2" -> "block_0_3" [label="await write"];
+    "block_0_3" [shape=rectangle, label="[3] SHIFT-PHASE 1 \"rf\" params2[0]"];
+    "block_0_3" -> "block_0_end" [label="ordering
+timing"];
+    "block_0_end" [shape=circle, label="end"];
+  }
+}
+

--- a/quil-rs/src/program/snapshots/quil_rs__program__graph__tests__write_capture_read.snap
+++ b/quil-rs/src/program/snapshots/quil_rs__program__graph__tests__write_capture_read.snap
@@ -1,0 +1,22 @@
+---
+source: quil-rs/src/program/graph.rs
+expression: dot_format
+---
+digraph {
+  entry -> "block_0_start";
+  entry [label="Entry Point"];
+  subgraph cluster_0 {
+    label="block_0";
+    node [style="filled"];
+    "block_0_start" [shape=circle, label="start"];
+    "block_0_start" -> "block_0_0" [label="ordering"];
+    "block_0_0" [shape=rectangle, label="[0] LOAD bits[0] bits2 integers[0]"];
+    "block_0_0" -> "block_0_1" [label="await write"];
+    "block_0_1" [shape=rectangle, label="[1] NONBLOCKING CAPTURE 0 \"Transmon-0_readout_rx\" flat(detuning: 0, duration: 2.0000000000000003e-6, iq: 1, phase: 0.8745492960861506, scale: 1) bits[0]"];
+    "block_0_1" -> "block_0_2" [label="await capture"];
+    "block_0_2" [shape=rectangle, label="[2] LOAD bits3[0] bits integers[0]"];
+    "block_0_2" -> "block_0_end" [label="ordering"];
+    "block_0_end" [shape=circle, label="end"];
+  }
+}
+

--- a/quil-rs/src/program/snapshots/quil_rs__program__graph__tests__write_write_read.snap
+++ b/quil-rs/src/program/snapshots/quil_rs__program__graph__tests__write_write_read.snap
@@ -1,5 +1,5 @@
 ---
-source: quil-rs/src/program/graphviz_dot.rs
+source: quil-rs/src/program/graph.rs
 expression: dot_format
 ---
 digraph {
@@ -10,14 +10,12 @@ digraph {
     node [style="filled"];
     "block_0_start" [shape=circle, label="start"];
     "block_0_start" -> "block_0_0" [label="ordering"];
-    "block_0_0" [shape=rectangle, label="[0] MOVE ro[0] 1"];
+    "block_0_0" [shape=rectangle, label="[0] LOAD bits[0] bits2 integers[0]"];
     "block_0_0" -> "block_0_1" [label="await write"];
-    "block_0_1" [shape=rectangle, label="[1] MOVE ro[1] 0"];
+    "block_0_1" [shape=rectangle, label="[1] LOAD bits[0] bits3 integers[0]"];
     "block_0_1" -> "block_0_2" [label="await write"];
-    "block_0_2" [shape=rectangle, label="[2] ADD ro[0] 5"];
-    "block_0_2" -> "block_0_3" [label="await write"];
-    "block_0_3" [shape=rectangle, label="[3] SUB ro[1] ro[0]"];
-    "block_0_3" -> "block_0_end" [label="ordering"];
+    "block_0_2" [shape=rectangle, label="[2] LOAD bits4[0] bits integers[0]"];
+    "block_0_2" -> "block_0_end" [label="ordering"];
     "block_0_end" [shape=circle, label="end"];
   }
 }

--- a/quil-rs/src/program/snapshots/quil_rs__program__graphviz_dot__tests__graph__active_reset_single_frame.snap
+++ b/quil-rs/src/program/snapshots/quil_rs__program__graphviz_dot__tests__graph__active_reset_single_frame.snap
@@ -1,5 +1,5 @@
 ---
-source: src/program/graphviz_dot.rs
+source: quil-rs/src/program/graphviz_dot.rs
 expression: dot_format
 ---
 digraph {
@@ -13,13 +13,11 @@ digraph {
 timing"];
     "measure_start" -> "measure_1" [label="ordering
 timing"];
-    "measure_start" -> "measure_end" [label="ordering"];
     "measure_0" [shape=rectangle, label="[0] NONBLOCKING PULSE 0 \"ro_tx\" test(duration: 1000000)"];
     "measure_0" -> "measure_end" [label="ordering
 timing"];
     "measure_1" [shape=rectangle, label="[1] NONBLOCKING CAPTURE 0 \"ro_rx\" test(duration: 1000000) ro[0]"];
-    "measure_1" -> "measure_end" [label="await capture
-ordering
+    "measure_1" -> "measure_end" [label="ordering
 timing"];
     "measure_end" [shape=circle, label="end"];
   }

--- a/quil-rs/src/program/snapshots/quil_rs__program__graphviz_dot__tests__graph__different_frames_nonblocking.snap
+++ b/quil-rs/src/program/snapshots/quil_rs__program__graphviz_dot__tests__graph__different_frames_nonblocking.snap
@@ -1,5 +1,5 @@
 ---
-source: src/program/graphviz_dot.rs
+source: quil-rs/src/program/graphviz_dot.rs
 expression: dot_format
 ---
 digraph {
@@ -15,7 +15,6 @@ timing"];
 timing"];
     "block_0_start" -> "block_0_2" [label="ordering
 timing"];
-    "block_0_start" -> "block_0_end" [label="ordering"];
     "block_0_0" [shape=rectangle, label="[0] NONBLOCKING PULSE 0 \"rf\" test(duration: 1000000)"];
     "block_0_0" -> "block_0_end" [label="ordering
 timing"];

--- a/quil-rs/src/program/snapshots/quil_rs__program__graphviz_dot__tests__graph__parametric_pulse.snap
+++ b/quil-rs/src/program/snapshots/quil_rs__program__graphviz_dot__tests__graph__parametric_pulse.snap
@@ -1,5 +1,5 @@
 ---
-source: src/program/graphviz_dot.rs
+source: quil-rs/src/program/graphviz_dot.rs
 expression: dot_format
 ---
 digraph {
@@ -18,13 +18,10 @@ timing"];
     "block_0_0" [shape=rectangle, label="[0] PULSE 0 \"rf\" test(a: param[0])"];
     "block_0_0" -> "block_0_1" [label="ordering
 timing"];
-    "block_0_0" -> "block_0_end" [label="await read
-ordering
+    "block_0_0" -> "block_0_end" [label="ordering
 timing"];
     "block_0_1" [shape=rectangle, label="[1] CAPTURE 0 \"ro_rx\" test(a: param[0]) ro[0]"];
-    "block_0_1" -> "block_0_end" [label="await capture
-await read
-ordering
+    "block_0_1" -> "block_0_end" [label="ordering
 timing"];
     "block_0_end" [shape=circle, label="end"];
   }

--- a/quil-rs/src/program/snapshots/quil_rs__program__graphviz_dot__tests__graph__parametric_pulses_using_capture_results.snap
+++ b/quil-rs/src/program/snapshots/quil_rs__program__graphviz_dot__tests__graph__parametric_pulses_using_capture_results.snap
@@ -1,5 +1,5 @@
 ---
-source: src/program/graphviz_dot.rs
+source: quil-rs/src/program/graphviz_dot.rs
 expression: dot_format
 ---
 digraph {
@@ -25,8 +25,7 @@ ordering
 timing"];
     "block_0_0" -> "block_0_3" [label="ordering
 timing"];
-    "block_0_0" -> "block_0_end" [label="await read
-ordering
+    "block_0_0" -> "block_0_end" [label="ordering
 timing"];
     "block_0_1" [shape=rectangle, label="[1] NONBLOCKING PULSE 0 \"rf\" test(a: ro[0])"];
     "block_0_1" -> "block_0_3" [label="await read
@@ -42,16 +41,13 @@ timing"];
     "block_0_3" -> "block_0_4" [label="await capture
 ordering
 timing"];
-    "block_0_3" -> "block_0_end" [label="await read
-ordering
+    "block_0_3" -> "block_0_end" [label="ordering
 timing"];
     "block_0_4" [shape=rectangle, label="[4] NONBLOCKING PULSE 0 \"rf\" test(a: ro[0])"];
-    "block_0_4" -> "block_0_end" [label="await read
-ordering
+    "block_0_4" -> "block_0_end" [label="ordering
 timing"];
     "block_0_5" [shape=rectangle, label="[5] NONBLOCKING PULSE 1 \"rf\" test(a: ro[0])"];
-    "block_0_5" -> "block_0_end" [label="await read
-ordering
+    "block_0_5" -> "block_0_end" [label="ordering
 timing"];
     "block_0_end" [shape=circle, label="end"];
   }

--- a/quil-rs/src/program/snapshots/quil_rs__program__graphviz_dot__tests__graph__pulse_after_capture.snap
+++ b/quil-rs/src/program/snapshots/quil_rs__program__graphviz_dot__tests__graph__pulse_after_capture.snap
@@ -1,5 +1,5 @@
 ---
-source: src/program/graphviz_dot.rs
+source: quil-rs/src/program/graphviz_dot.rs
 expression: dot_format
 ---
 digraph {
@@ -18,8 +18,7 @@ timing"];
     "block_0_0" [shape=rectangle, label="[0] CAPTURE 0 \"ro_rx\" test ro[0]"];
     "block_0_0" -> "block_0_1" [label="ordering
 timing"];
-    "block_0_0" -> "block_0_end" [label="await capture
-ordering
+    "block_0_0" -> "block_0_end" [label="ordering
 timing"];
     "block_0_1" [shape=rectangle, label="[1] PULSE 0 \"rf\" test"];
     "block_0_1" -> "block_0_end" [label="ordering

--- a/quil-rs/src/program/snapshots/quil_rs__program__graphviz_dot__tests__graph__simple_capture.snap
+++ b/quil-rs/src/program/snapshots/quil_rs__program__graphviz_dot__tests__graph__simple_capture.snap
@@ -1,5 +1,5 @@
 ---
-source: src/program/graphviz_dot.rs
+source: quil-rs/src/program/graphviz_dot.rs
 expression: dot_format
 ---
 digraph {
@@ -14,8 +14,7 @@ timing"];
     "block_0_start" -> "block_0_end" [label="ordering
 timing"];
     "block_0_0" [shape=rectangle, label="[0] CAPTURE 0 \"ro_rx\" test ro[0]"];
-    "block_0_0" -> "block_0_end" [label="await capture
-ordering
+    "block_0_0" -> "block_0_end" [label="ordering
 timing"];
     "block_0_end" [shape=circle, label="end"];
   }

--- a/quil-rs/src/program/snapshots/quil_rs__program__graphviz_dot__tests__graph__simple_memory_access.snap
+++ b/quil-rs/src/program/snapshots/quil_rs__program__graphviz_dot__tests__graph__simple_memory_access.snap
@@ -1,5 +1,5 @@
 ---
-source: src/program/graphviz_dot.rs
+source: quil-rs/src/program/graphviz_dot.rs
 expression: dot_format
 ---
 digraph {
@@ -10,16 +10,13 @@ digraph {
     node [style="filled"];
     "block_0_start" [shape=circle, label="start"];
     "block_0_start" -> "block_0_0" [label="ordering"];
+    "block_0_start" -> "block_0_1" [label="ordering"];
     "block_0_0" [shape=rectangle, label="[0] MOVE a[0] 1"];
-    "block_0_0" -> "block_0_1" [label="ordering"];
     "block_0_0" -> "block_0_2" [label="await write"];
     "block_0_1" [shape=rectangle, label="[1] MOVE b[0] 2"];
-    "block_0_1" -> "block_0_2" [label="await write
-ordering"];
+    "block_0_1" -> "block_0_2" [label="await write"];
     "block_0_2" [shape=rectangle, label="[2] ADD a[0] b[0]"];
-    "block_0_2" -> "block_0_end" [label="await read
-await write
-ordering"];
+    "block_0_2" -> "block_0_end" [label="ordering"];
     "block_0_end" [shape=circle, label="end"];
   }
 }

--- a/scripts/sync_versions.sh
+++ b/scripts/sync_versions.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 # This script gets the current version of quil-rs from its manifest, and uses it to update the dependency specification
-# of quil-rs in quil-py's manifset.
+# of quil-rs in quil-py's manifest.
 
 # Get current version of quil-rs
 PACKAGE_VERSION=$(cargo metadata --format-version 1 --no-deps | grep -o '"name":"quil-rs","version":"[^"]*' | cut -d '"' -f 8)


### PR DESCRIPTION
The ultimate goal of this PR is to simplify the `InstructionBlock::graph` and thereby improve the ability of a hardware scheduler to schedule a Quil program by reducing the number of edges between classical instructions and block start/end.

Two types of edges in the `InstructionBlock::graph` are deemed extraneous in this work:

1. An edge from two consecutive classical instructions that read from / write to different memory regions. Rather than insist on classical instruction execute in the particular order they are written in a Quil program, _only_ represent ordering of classical Quil instructions based upon the memory regions they read and write to (this is already done with `MemoryAccessQueue`).
2. Edges from BlockStart, if the node has other incoming edges, or to BlockEnd, if the node has other outgoing edges. _Note that while this could apply equally to `InstructionRole::RfControl`, this change set deliberately only impacts edges to and from classical instructions._

```quil
DECLARE params1 REAL[10]
DECLARE params2 REAL[10]
DECLARE params3 REAL[10]
DECLARE params4 REAL[10]
DECLARE integer1 INTEGER[10]

LOAD params1[0] params2 integers[0] # LOAD_1 in graphs below
SHIFT-PHASE 0 "rf" params1[0]
LOAD params3[0] params4 integers[0] # LOAD_2 in graphs below
```

Old representation of `InstructionBlock::graph`.

```mermaid
flowchart TD
    BlockStart --> LOAD_1
    BlockStart --> SHIFT-PHASE
    LOAD_1 --> SHIFT-PHASE
    LOAD_1 --> LOAD_2
    LOAD_1 --> BlockEnd
    LOAD_2 --> BlockEnd
    SHIFT-PHASE --> BlockEnd
```
_In the original algorithm, there is an edge from LOAD_1 to BlockEnd because there are pending reads on `params1` and `integers`._

New representation of `InstructionBlock::graph`.

```mermaid
flowchart TD
    BlockStart --> LOAD_1
    BlockStart --> LOAD_2
    LOAD_1 --> SHIFT-PHASE
    LOAD_2 --> BlockEnd
    SHIFT-PHASE --> BlockEnd
```

There are three invariants of the `InstructionBlock::graph` that remain unchanged:

1. There is always a path connecting the BlockStart to any classical node in the graph.
1. There is always a path connecting any classical node in the graph to the BlockEnd.
1. These invariants pertain to the BlockStart and BlockEnd as well. In other words, there is always a connecting path from the BlockStart to the BlockEnd regardless as to whether there are any instructions in the block. 
