### PR TITLE
ci: Use trusted publishing for PyPI

### DIFF
--- a/.github/workflows/publish-quil-py.yml
+++ b/.github/workflows/publish-quil-py.yml
@@ -162,12 +162,11 @@ jobs:
     # can be published.
     needs: [ macos, linux, windows, sdist ]
     if: always() && needs.sdist.result == 'success'
+    permissions:
+      id-token: write
     steps:
       - uses: actions/download-artifact@v3
       - name: Publish to PyPi
-        env:
-          MATURIN_USERNAME: ${{ secrets.PYPI_USERNAME }}
-          MATURIN_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         uses: messense/maturin-action@v1
         with:
           command: upload 

--- a/quil-rs/src/instruction/calibration.rs
+++ b/quil-rs/src/instruction/calibration.rs
@@ -67,6 +67,36 @@ pub struct MeasureCalibrationDefinition {
     pub instructions: Vec<Instruction>,
 }
 
+impl MeasureCalibrationDefinition {
+    pub fn new(qubit: Option<Qubit>, parameter: String, instructions: Vec<Instruction>) -> Self {
+        Self {
+            qubit,
+            parameter,
+            instructions,
+        }
+    }
+}
+
+impl Quil for MeasureCalibrationDefinition {
+    fn write(
+        &self,
+        f: &mut impl std::fmt::Write,
+        fall_back_to_debug: bool,
+    ) -> crate::quil::ToQuilResult<()> {
+        write!(f, "DEFCAL MEASURE")?;
+        if let Some(qubit) = &self.qubit {
+            write!(f, " ")?;
+            qubit.write(f, fall_back_to_debug)?;
+        }
+
+        writeln!(f, " {}:", self.parameter,)?;
+
+        write_instruction_block(f, fall_back_to_debug, &self.instructions)?;
+        writeln!(f)?;
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod test_measure_calibration_definition {
     use super::MeasureCalibrationDefinition;
@@ -111,35 +141,5 @@ mod test_measure_calibration_definition {
         }, {
             assert_snapshot!(measure_cal_def.to_quil_or_debug())
         })
-    }
-}
-
-impl MeasureCalibrationDefinition {
-    pub fn new(qubit: Option<Qubit>, parameter: String, instructions: Vec<Instruction>) -> Self {
-        Self {
-            qubit,
-            parameter,
-            instructions,
-        }
-    }
-}
-
-impl Quil for MeasureCalibrationDefinition {
-    fn write(
-        &self,
-        f: &mut impl std::fmt::Write,
-        fall_back_to_debug: bool,
-    ) -> crate::quil::ToQuilResult<()> {
-        write!(f, "DEFCAL MEASURE")?;
-        if let Some(qubit) = &self.qubit {
-            write!(f, " ")?;
-            qubit.write(f, fall_back_to_debug)?;
-        }
-
-        writeln!(f, " {}:", self.parameter,)?;
-
-        write_instruction_block(f, fall_back_to_debug, &self.instructions)?;
-        writeln!(f)?;
-        Ok(())
     }
 }

--- a/quil-rs/src/parser/mod.rs
+++ b/quil-rs/src/parser/mod.rs
@@ -31,7 +31,7 @@ mod token;
 
 pub(crate) use error::{ErrorInput, InternalParseError};
 pub use error::{ParseError, ParserErrorKind};
-pub use lexer::{LexError, LexErrorKind};
+pub use lexer::LexError;
 pub use token::{Token, TokenWithLocation};
 
 type ParserInput<'a> = &'a [TokenWithLocation<'a>];


### PR DESCRIPTION
closes #326

This repo has been setup as a trusted publisher for `quil` in PyPI. I've modified the workflow per the [maturin documentation](https://www.maturin.rs/distribution.html?highlight=trusted%20p#using-pypis-trusted-publishing).