### PR TITLE
fix: `is_quil_t()` now correctly returns false for WAIT instructions

### DIFF
--- a/quil-rs/src/instruction/mod.rs
+++ b/quil-rs/src/instruction/mod.rs
@@ -661,7 +661,6 @@ impl Instruction {
             | Instruction::ShiftFrequency(_)
             | Instruction::ShiftPhase(_)
             | Instruction::SwapPhases(_)
-            | Instruction::Wait
             | Instruction::WaveformDefinition(_) => true,
             Instruction::Arithmetic(_)
             | Instruction::BinaryLogic(_)
@@ -685,6 +684,7 @@ impl Instruction {
             | Instruction::Pragma(_)
             | Instruction::Reset(_)
             | Instruction::Store(_)
+            | Instruction::Wait
             | Instruction::UnaryLogic(_) => false,
         }
     }


### PR DESCRIPTION
closes #330 