### PR TITLE
docs: Provide documentation link to pyproject.toml

### DIFF
--- a/quil-py/pyproject.toml
+++ b/quil-py/pyproject.toml
@@ -2,6 +2,7 @@
 name = "quil"
 requires-python = ">=3.8"
 description = "A Python package for building and parsing Quil programs."
+documentation = "https://rigetti.github.io/quil-rs/quil.html"
 readme = "README-py.md"
 license = { text = "Apache-2.0" }
 authors = [{ name = "Rigetti Computing", email = "softapps@rigetti.com" }]


### PR DESCRIPTION
Adding a documentation link to pyproject.toml makes it so that repositories like PyPI can link to them on packages page.