### PR TITLE
feat(quil-cli): Add CLI for interacting with quil-rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,15 +221,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
-name = "cli"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "clap",
- "quil-rs",
-]
-
-[[package]]
 name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1068,6 +1059,15 @@ name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quil-cli"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "quil-rs",
+]
 
 [[package]]
 name = "quil-py"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,16 +19,15 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.3.2"
+version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
+checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
 dependencies = [
  "anstyle",
  "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
- "is-terminal",
  "utf8parse",
 ]
 
@@ -58,13 +57,19 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "1.0.1"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
+checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
 dependencies = [
  "anstyle",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "anyhow"
+version = "1.0.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
 
 [[package]]
 name = "approx"
@@ -177,20 +182,19 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.3.19"
+version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd304a20bff958a57f04c4e96a2e7594cc4490a0e809cbd48bb6437edaa452d"
+checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
 dependencies = [
  "clap_builder",
  "clap_derive",
- "once_cell",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.3.19"
+version = "4.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01c6a3f08f1fe5662a35cfe393aec09c4df95f60ee93b7556505260f75eee9e1"
+checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
 dependencies = [
  "anstream",
  "anstyle",
@@ -200,11 +204,11 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.3.12"
+version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54a9bb5758fc5dfe728d1019941681eccaf0cf8a4189b692a0ee2f2ecf90a050"
+checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2 1.0.78",
  "quote 1.0.35",
  "syn 2.0.48",
@@ -212,9 +216,18 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.5.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
+checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
+
+[[package]]
+name = "cli"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "quil-rs",
+]
 
 [[package]]
 name = "colorchoice"
@@ -511,6 +524,12 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -1039,7 +1058,7 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7774b5a8282bd4f25f803b1f0d945120be959a36c72e08e7cd031c792fdfd424"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2 1.0.78",
  "quote 1.0.35",
  "syn 2.0.48",
@@ -1053,7 +1072,7 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quil-py"
-version = "0.6.6"
+version = "0.7.1"
 dependencies = [
  "ndarray",
  "numpy",
@@ -1066,7 +1085,7 @@ dependencies = [
 
 [[package]]
 name = "quil-rs"
-version = "0.22.6"
+version = "0.23.0"
 dependencies = [
  "approx",
  "clap",
@@ -1402,9 +1421,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
 
 [[package]]
 name = "strum"
@@ -1421,7 +1440,7 @@ version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a3417fc93d76740d974a01654a09777cb500428cc874ca9f45edfe0c4d4cd18"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2 1.0.78",
  "quote 1.0.35",
  "rustversion",
@@ -1685,6 +1704,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.4",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1715,6 +1743,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-targets"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.4",
+ "windows_aarch64_msvc 0.52.4",
+ "windows_i686_gnu 0.52.4",
+ "windows_i686_msvc 0.52.4",
+ "windows_x86_64_gnu 0.52.4",
+ "windows_x86_64_gnullvm 0.52.4",
+ "windows_x86_64_msvc 0.52.4",
+]
+
+[[package]]
 name = "windows_aarch64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1725,6 +1768,12 @@ name = "windows_aarch64_gnullvm"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -1739,6 +1788,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1749,6 +1804,12 @@ name = "windows_i686_gnu"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1763,6 +1824,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1773,6 +1840,12 @@ name = "windows_x86_64_gnu"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1787,6 +1860,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1797,6 +1876,12 @@ name = "windows_x86_64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
 
 [[package]]
 name = "yaml-rust"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -555,15 +555,14 @@ checksum = "1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8"
 
 [[package]]
 name = "insta"
-version = "1.31.0"
+version = "1.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0770b0a3d4c70567f0d58331f3088b0e4c4f56c9b8d764efe654b4a5d46de3a"
+checksum = "1718b3f2b85bb5054baf8ce406e36401f27c3169205f4175504c4b1d98252d3f"
 dependencies = [
  "console",
  "lazy_static",
  "linked-hash-map",
  "similar",
- "yaml-rust",
 ]
 
 [[package]]
@@ -1882,12 +1881,3 @@ name = "windows_x86_64_msvc"
 version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
-
-[[package]]
-name = "yaml-rust"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
-dependencies = [
- "linked-hash-map",
-]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["quil-rs", "quil-py"]
+members = ["quil-rs", "quil-py", "quil-cli"]
 resolver = "2"
 
 [profile.release]

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ It serves three purposes:
 
 It should be considered unstable until the release of v1.0.
 
-
 ## Testing
 
 When testing this crate, you should run with the `--all-features` flag to ensure all tests are executed.

--- a/deny.toml
+++ b/deny.toml
@@ -85,6 +85,7 @@ skip-tree = [
   { name = "regex-syntax", version = "*" },   # proptest and criterion rely on two versions of this
   { name = "redox_syscall", version = "*" },  # proptest and pyo3 rely on two versions of this
   { name = "itertools", version = "*" },      # proptest relies on an older version of itertools than we use
+  { name = "heck", version = "*" },           # conflicting dependency with pyo3 and clap
 ]
 
 # This section is considered when running `cargo deny check sources`.

--- a/knope.toml
+++ b/knope.toml
@@ -8,6 +8,11 @@ versioned_files = ["quil-py/Cargo.toml", "quil-py/pyproject.toml"]
 changelog = "quil-py/CHANGELOG.md"
 scopes = ["py", "python", "quil-py"]
 
+[packages.quil-cli]
+versioned_files = ["quil-cli/Cargo.toml"]
+changelog = "quil-cli/CHANGELOG.md"
+scopes = ["cli", "quil-cli"]
+
 [[workflows]]
 name = "release"
 

--- a/quil-cli/Cargo.toml
+++ b/quil-cli/Cargo.toml
@@ -2,10 +2,11 @@
 name = "cli"
 version = "0.1.0"
 edition = "2021"
+license = "Apache-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-quil-rs = {path = "../quil-rs"}
+quil-rs = { path = "../quil-rs", version = "0.23.0" }
 clap =  {version = "4.5.4", features = ["derive"]}
 anyhow = "1.0.81"

--- a/quil-cli/Cargo.toml
+++ b/quil-cli/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "cli"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+quil-rs = {path = "../quil-rs"}
+clap =  {version = "4.5.4", features = ["derive"]}
+anyhow = "1.0.81"

--- a/quil-cli/Cargo.toml
+++ b/quil-cli/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "cli"
+name = "quil-cli"
 version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"

--- a/quil-cli/src/main.rs
+++ b/quil-cli/src/main.rs
@@ -11,6 +11,7 @@ struct Cli {
 
 #[derive(Subcommand, Clone, Debug)]
 pub enum Command {
+    /// Parse a Quil program or expression
     Parse {
         #[arg(short = 't', long = "type")]
         input_type: Option<InputType>,
@@ -20,8 +21,10 @@ pub enum Command {
 
 #[derive(ValueEnum, Clone, Debug, Default)]
 pub enum InputType {
+    /// Parse a Quil program (default)
     #[default]
     Program,
+    /// Parse a Quil expression
     Expression,
 }
 

--- a/quil-cli/src/main.rs
+++ b/quil-cli/src/main.rs
@@ -43,10 +43,17 @@ fn main() -> anyhow::Result<()> {
 fn handle_parse(input_type: InputType, input: String) -> anyhow::Result<()> {
     let parsed = match input_type {
         InputType::Program => {
-            Program::from_str(&input).context("Failed to parse program from input string.")?.to_quil().expect("Parsed Program from valid Quil string, should be able to convert it back to valid Quil")
+            Program::from_str(&input)
+                .context("Failed to parse program from input string.")?
+                .to_quil()
+                .context("Parsed Program from valid Quil string, but was unable to convert it back to valid Quil. This is probably a bug in the quil-rs parser.")?
         }
-        InputType::Expression => Expression::from_str(&input)
-            .context("Failed to parse expression from input string.")?.to_quil().expect("Parsed Expression from valid Quil expression, should be able to convert it back to valid Expression"),
+        InputType::Expression => {
+             Expression::from_str(&input)
+                .context("Failed to parse expression from input string.")?
+                .to_quil()
+                .context("Parsed Expression from valid Quil expression, but was unable to convert it back to valid Expression. This is probably a bug in the quil-rs parser.")?
+        }
     };
 
     println!("{parsed}");

--- a/quil-cli/src/main.rs
+++ b/quil-cli/src/main.rs
@@ -1,0 +1,52 @@
+use anyhow::Context;
+use clap::{Parser, Subcommand, ValueEnum};
+use quil_rs::{expression::Expression, quil::Quil, Program};
+use std::str::FromStr;
+
+#[derive(Parser, Debug)]
+struct Cli {
+    #[clap(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand, Clone, Debug)]
+pub enum Command {
+    Parse {
+        #[arg(short = 't', long = "type")]
+        input_type: Option<InputType>,
+        input: String,
+    },
+}
+
+#[derive(ValueEnum, Clone, Debug, Default)]
+pub enum InputType {
+    #[default]
+    Program,
+    Expression,
+}
+
+fn main() -> anyhow::Result<()> {
+    let cli = Cli::parse();
+
+    match cli.command {
+        Command::Parse { input_type, input } => {
+            handle_parse(input_type.unwrap_or_default(), input)?
+        }
+    };
+
+    Ok(())
+}
+
+fn handle_parse(input_type: InputType, input: String) -> anyhow::Result<()> {
+    let parsed = match input_type {
+        InputType::Program => {
+            Program::from_str(&input).context("Failed to parse program from input string.")?.to_quil().expect("Parsed Program from valid Quil string, should be able to convert it back to valid Quil")
+        }
+        InputType::Expression => Expression::from_str(&input)
+            .context("Failed to parse expression from input string.")?.to_quil().expect("Parsed Expression from valid Quil expression, should be able to convert it back to valid Expression"),
+    };
+
+    println!("{parsed}");
+
+    Ok(())
+}

--- a/quil-cli/src/main.rs
+++ b/quil-cli/src/main.rs
@@ -13,8 +13,8 @@ struct Cli {
 pub enum Command {
     /// Parse a Quil program or expression
     Parse {
-        #[arg(short = 't', long = "type")]
-        input_type: Option<InputType>,
+        #[arg(short = 't', long = "type", value_enum, default_value_t)]
+        input_type: InputType,
         input: String,
     },
 }
@@ -32,9 +32,7 @@ fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
 
     match cli.command {
-        Command::Parse { input_type, input } => {
-            handle_parse(input_type.unwrap_or_default(), input)?
-        }
+        Command::Parse { input_type, input } => handle_parse(input_type, input)?,
     };
 
     Ok(())

--- a/quil-rs/Cargo.toml
+++ b/quil-rs/Cargo.toml
@@ -29,7 +29,7 @@ thiserror = "1.0.56"
 [dev-dependencies]
 clap = { version = "4.3.19", features = ["derive", "string"] }
 criterion = { version = "0.5.1", features = ["html_reports"] }
-insta = "1.7.1"
+insta = "1.37.0"
 petgraph = "0.6.2"
 proptest = "1.0.0"
 proptest-derive = "0.3.0"

--- a/quil-rs/src/program/mod.rs
+++ b/quil-rs/src/program/mod.rs
@@ -1002,7 +1002,7 @@ DEFWAVEFORM custom:
 I 0
 ";
         let program = Program::from_str(input).unwrap();
-        let expected_owned = vec![Qubit::Fixed(0), Qubit::Variable("q".to_string())];
+        let expected_owned = [Qubit::Fixed(0), Qubit::Variable("q".to_string())];
         let expected = expected_owned.iter().collect::<HashSet<_>>();
         let actual = program.get_used_qubits();
         assert_eq!(expected, actual.iter().collect());
@@ -1057,7 +1057,7 @@ DEFGATE BAR:
         let mut in_place_sum = lhs.clone();
         in_place_sum += rhs;
 
-        let expected_qubits = vec![
+        let expected_qubits = [
             Qubit::Fixed(0),
             Qubit::Fixed(1),
             Qubit::Fixed(2),

--- a/quil-rs/src/reserved.rs
+++ b/quil-rs/src/reserved.rs
@@ -13,6 +13,7 @@ pub enum ReservedToken {
 }
 
 #[derive(Clone, Debug)]
+#[allow(dead_code)] // clippy 0.1.77 incorrectly identifies this NewType as dead code.
 pub struct NotReservedToken(String);
 
 impl FromStr for ReservedToken {

--- a/quil-rs/src/reserved.rs
+++ b/quil-rs/src/reserved.rs
@@ -12,8 +12,8 @@ pub enum ReservedToken {
     Constant(ReservedConstant),
 }
 
-#[derive(Clone, Debug)]
-#[allow(dead_code)] // clippy 0.1.77 incorrectly identifies this NewType as dead code.
+#[derive(Clone, Debug, thiserror::Error)]
+#[error("{0} is not a reserved token")]
 pub struct NotReservedToken(String);
 
 impl FromStr for ReservedToken {
@@ -27,7 +27,7 @@ impl FromStr for ReservedToken {
         } else if let Ok(constant) = ReservedConstant::from_str(s) {
             Ok(Self::Constant(constant))
         } else {
-            Err(NotReservedToken(format!("{s} is not a reserved token")))
+            Err(NotReservedToken(s.to_string()))
         }
     }
 }


### PR DESCRIPTION
I often find myself wanting to quickly test the behavior of the parser. Right now that requires setting up some boilerplate in either pyQuil or quil-rs to go through the parser. This CLI exposes the functionality more directly, allowing me to bisect issues quicker.

In addition to using the parser, I see this as a useful entry point for the recent program analysis feature. It also enables easier benchmarking with tools like hyperfine. Not that the existing benchmarks aren't sufficient, but it makes benching new programs or expressions a bit more accessible and faster in the iteration phase.

closes #349 