### PR TITLE
fix!: CalibrationSet's and Program's will be considered equal if they contain the same set of calibrations, regardless of order.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -520,9 +520,9 @@ checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
 
 [[package]]
 name = "indexmap"
-version = "2.2.2"
+version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824b2ae422412366ba479e8111fd301f7b5faece8149317bb81925979a53f520"
+checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -928,6 +928,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -984,17 +990,19 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.20.0"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04e8453b658fe480c3e70c8ed4e3d3ec33eb74988bd186561b0cc66b85c3bc4b"
+checksum = "53bdbb96d49157e65d45cc287af5f32ffadd5f4761438b527b055fb0d4bb8233"
 dependencies = [
  "cfg-if",
+ "indexmap",
  "indoc",
  "inventory",
  "libc",
  "memoffset",
  "num-complex",
  "parking_lot",
+ "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
@@ -1003,9 +1011,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.20.0"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96fe70b176a89cff78f2fa7b3c930081e163d5379b4dcdf993e3ae29ca662e5"
+checksum = "deaa5745de3f5231ce10517a1f5dd97d53e5a2fd77aa6b5842292085831d48d7"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -1013,9 +1021,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.20.0"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "214929900fd25e6604661ed9cf349727c8920d47deff196c4e28165a6ef2a96b"
+checksum = "62b42531d03e08d4ef1f6e85a2ed422eb678b8cd62b762e53891c05faf0d4afa"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1023,9 +1031,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.20.0"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dac53072f717aa1bfa4db832b39de8c875b7c7af4f4a6fe93cdbf9264cf8383b"
+checksum = "7305c720fa01b8055ec95e484a6eca7a83c841267f0dd5280f0c8b8551d2c158"
 dependencies = [
  "proc-macro2 1.0.78",
  "pyo3-macros-backend",
@@ -1035,12 +1043,13 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.20.0"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7774b5a8282bd4f25f803b1f0d945120be959a36c72e08e7cd031c792fdfd424"
+checksum = "7c7e9b68bb9c3149c5b0cade5d07f953d6d125eb4337723c4ccdb665f1f96185"
 dependencies = [
  "heck",
  "proc-macro2 1.0.78",
+ "pyo3-build-config",
  "quote 1.0.35",
  "syn 2.0.48",
 ]
@@ -1053,8 +1062,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quil-py"
-version = "0.6.6"
+version = "0.7.1"
 dependencies = [
+ "indexmap",
  "ndarray",
  "numpy",
  "pyo3",
@@ -1066,7 +1076,7 @@ dependencies = [
 
 [[package]]
 name = "quil-rs"
-version = "0.22.6"
+version = "0.23.0"
 dependencies = [
  "approx",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1071,7 +1071,7 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quil-cli"
-version = "0.1.0"
+version = "0.2.0-rc.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,4 @@ codegen-units = 1
 [workspace.dependencies]
 ndarray = { version = "0.15.6", features = ["approx-0_5"] }
 strum = { version = "0.26.0", features = ["derive"] }
+indexmap = "2.2.6"

--- a/quil-py/Cargo.toml
+++ b/quil-py/Cargo.toml
@@ -26,8 +26,9 @@ quil-rs = { path = "../quil-rs", version = "0.23.0" }
 strum.workspace = true
 # pyo3 dependencies should be updated together
 numpy = "0.20.0"
-pyo3 = "0.20.0"
+pyo3 = { version = "0.20.3", features = ["indexmap"] }
 rigetti-pyo3 = "0.3.1"
+indexmap.workspace = true
 
 [build-dependencies]
 pyo3-build-config = "0.20.0"

--- a/quil-py/quil/program/__init__.pyi
+++ b/quil-py/quil/program/__init__.pyi
@@ -322,14 +322,20 @@ class CalibrationSet:
     def is_empty(self) -> bool:
         """Returns ``True`` if the ``CalibrationSet`` contains no data."""
         ...
-    def push_calibration(self, calibration: Calibration):
+    def insert_calibration(self, calibration: Calibration) -> Optional[Calibration]:
         """
-        Add another gate ``Calibration`` (`DEFCAL`) to the set.
+        Insert another ``Calibration`` (`DEFCAL`) to the set.
+
+        If a calibration with the same name already exists, it is overwritten and this
+        function returns the previous calibration. Otherwise, None is returned.
         """
         ...
-    def push_measurement_calibration(self, calibration: MeasureCalibrationDefinition):
+    def insert_measurement_calibration(self, calibration: MeasureCalibrationDefinition) -> Optional[MeasureCalibrationDefinition]:
         """
         Add another ``MeasureCalibrationDefinition`` (`DEFCAL MEASURE`) to the set
+
+        If a calibration with the same name already exists, it is overwritten and this
+        function returns the previous calibration. Otherwise, None is returned.
         """
     def extend(self, other: CalibrationSet):
         """

--- a/quil-py/src/program/calibration.rs
+++ b/quil-py/src/program/calibration.rs
@@ -35,7 +35,12 @@ impl PyCalibrationSet {
         Ok(Self(CalibrationSet {
             calibrations: calibrations
                 .into_iter()
-                .map(|c| (c.as_inner().name.clone(), c.into_inner()))
+                .map(|c| {
+                    (
+                        (c.as_inner().name.clone(), c.as_inner().qubits.clone()),
+                        c.into_inner(),
+                    )
+                })
                 .collect(),
             measure_calibrations: measure_calibrations
                 .into_iter()

--- a/quil-py/src/program/calibration.rs
+++ b/quil-py/src/program/calibration.rs
@@ -62,7 +62,7 @@ impl PyCalibrationSet {
         self.as_inner().measure_calibrations().to_python(py)
     }
 
-    pub fn expan(
+    pub fn expand(
         &self,
         py: Python<'_>,
         instruction: PyInstruction,

--- a/quil-py/src/program/calibration.rs
+++ b/quil-py/src/program/calibration.rs
@@ -35,22 +35,14 @@ impl PyCalibrationSet {
         Ok(Self(CalibrationSet {
             calibrations: calibrations
                 .into_iter()
-                .map(|c| {
-                    (
-                        (c.as_inner().name.clone(), c.as_inner().qubits.clone()),
-                        c.into_inner(),
-                    )
-                })
-                .collect(),
+                .map(|c| c.into_inner())
+                .collect::<Vec<Calibration>>()
+                .into(),
             measure_calibrations: measure_calibrations
                 .into_iter()
-                .map(|c| {
-                    (
-                        (c.as_inner().parameter.clone(), c.as_inner().qubit.clone()),
-                        c.into_inner(),
-                    )
-                })
-                .collect(),
+                .map(|c| c.into_inner())
+                .collect::<Vec<MeasureCalibrationDefinition>>()
+                .into(),
         }))
     }
 

--- a/quil-py/src/program/calibration.rs
+++ b/quil-py/src/program/calibration.rs
@@ -1,6 +1,6 @@
 use quil_rs::{
     instruction::{Calibration, Gate, Instruction, MeasureCalibrationDefinition, Measurement},
-    program::CalibrationSet,
+    program::Calibrations,
 };
 use rigetti_pyo3::{
     impl_as_mut_for_wrapper, impl_repr, py_wrap_type,
@@ -19,7 +19,7 @@ use super::ProgramError;
 
 py_wrap_type! {
     #[derive(Debug, PartialEq)]
-    PyCalibrationSet(CalibrationSet) as "CalibrationSet"
+    PyCalibrationSet(Calibrations) as "CalibrationSet"
 }
 impl_as_mut_for_wrapper!(PyCalibrationSet);
 impl_repr!(PyCalibrationSet);
@@ -32,7 +32,7 @@ impl PyCalibrationSet {
         calibrations: Vec<PyCalibration>,
         measure_calibrations: Vec<PyMeasureCalibrationDefinition>,
     ) -> PyResult<Self> {
-        Ok(Self(CalibrationSet {
+        Ok(Self(Calibrations {
             calibrations: calibrations
                 .into_iter()
                 .map(|c| c.into_inner())
@@ -132,7 +132,7 @@ impl PyCalibrationSet {
 
     pub fn extend(&mut self, py: Python<'_>, other: PyCalibrationSet) -> PyResult<()> {
         self.as_inner_mut()
-            .extend(CalibrationSet::py_try_from(py, &other)?);
+            .extend(Calibrations::py_try_from(py, &other)?);
         Ok(())
     }
 

--- a/quil-py/src/program/mod.rs
+++ b/quil-py/src/program/mod.rs
@@ -8,7 +8,7 @@ use quil_rs::{
     instruction::{Instruction, QubitPlaceholder, TargetPlaceholder, Waveform},
     program::{
         analysis::{ControlFlowGraph, ControlFlowGraphOwned},
-        CalibrationSet, FrameSet, MemoryRegion,
+        Calibrations, FrameSet, MemoryRegion,
     },
     Program,
 };
@@ -109,7 +109,7 @@ impl PyProgram {
         calibrations: PyCalibrationSet,
     ) -> PyResult<()> {
         let program = self.as_inner_mut();
-        program.calibrations = CalibrationSet::py_try_from(py, &calibrations)?;
+        program.calibrations = Calibrations::py_try_from(py, &calibrations)?;
         Ok(())
     }
 

--- a/quil-rs/Cargo.toml
+++ b/quil-rs/Cargo.toml
@@ -12,7 +12,6 @@ categories = ["parser-implementations", "science", "compilers", "emulators"]
 [dependencies]
 approx = { version = "0.5.1", features = ["num-complex"] }
 dot-writer = { version = "0.1.2", optional = true }
-indexmap = "2.2.2"
 itertools = "0.12.1"
 lexical = "6.1.1"
 ndarray.workspace = true
@@ -25,6 +24,7 @@ regex = "1.7.1"
 serde = { version = "1.0.125", features = ["derive"] }
 strum.workspace = true
 thiserror = "1.0.56"
+indexmap.workspace = true
 
 [dev-dependencies]
 clap = { version = "4.3.19", features = ["derive", "string"] }

--- a/quil-rs/src/instruction/calibration.rs
+++ b/quil-rs/src/instruction/calibration.rs
@@ -10,7 +10,9 @@ use crate::{
 use super::write_qubit_parameters;
 
 pub trait CalibrationSignature {
-    type Signature<'a>: where Self: 'a;
+    type Signature<'a>
+    where
+        Self: 'a;
 
     fn signature(&self) -> Self::Signature<'_>;
     fn has_signature(&self, signature: &Self::Signature<'_>) -> bool;
@@ -80,9 +82,7 @@ impl CalibrationSignature for Calibration {
 
     fn has_signature(&self, signature: &Self::Signature<'_>) -> bool {
         let (name, parameters, qubits) = signature;
-        self.name == *name
-            && self.parameters == *parameters
-            && self.qubits == *qubits
+        self.name == *name && self.parameters == *parameters && self.qubits == *qubits
     }
 }
 

--- a/quil-rs/src/instruction/calibration.rs
+++ b/quil-rs/src/instruction/calibration.rs
@@ -9,6 +9,12 @@ use crate::{
 
 use super::write_qubit_parameters;
 
+pub trait CalibrationSignature {
+    type Signature: PartialEq;
+
+    fn signature(&self) -> Self::Signature;
+}
+
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct Calibration {
     pub instructions: Vec<Instruction>,
@@ -60,6 +66,18 @@ impl Quil for Calibration {
     }
 }
 
+impl CalibrationSignature for Calibration {
+    type Signature = (String, Vec<Expression>, Vec<Qubit>);
+
+    fn signature(&self) -> Self::Signature {
+        (
+            self.name.clone(),
+            self.parameters.clone(),
+            self.qubits.clone(),
+        )
+    }
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub struct MeasureCalibrationDefinition {
     pub qubit: Option<Qubit>,
@@ -74,6 +92,14 @@ impl MeasureCalibrationDefinition {
             parameter,
             instructions,
         }
+    }
+}
+
+impl CalibrationSignature for MeasureCalibrationDefinition {
+    type Signature = (Option<Qubit>, String);
+
+    fn signature(&self) -> Self::Signature {
+        (self.qubit.clone(), self.parameter.clone())
     }
 }
 

--- a/quil-rs/src/instruction/mod.rs
+++ b/quil-rs/src/instruction/mod.rs
@@ -40,7 +40,7 @@ mod reset;
 mod timing;
 mod waveform;
 
-pub use self::calibration::{Calibration, MeasureCalibrationDefinition};
+pub use self::calibration::{Calibration, CalibrationSignature, MeasureCalibrationDefinition};
 pub use self::circuit::CircuitDefinition;
 pub use self::classical::{
     Arithmetic, ArithmeticOperand, ArithmeticOperator, BinaryLogic, BinaryOperand, BinaryOperands,

--- a/quil-rs/src/program/calibration.rs
+++ b/quil-rs/src/program/calibration.rs
@@ -14,6 +14,7 @@
 
 use std::collections::HashMap;
 
+use indexmap::IndexMap;
 use itertools::FoldWhile::{Continue, Done};
 use itertools::Itertools;
 
@@ -33,8 +34,8 @@ use super::ProgramError;
 /// A collection of Quil calibrations (`DEFCAL` instructions) with utility methods.
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct CalibrationSet {
-    pub calibrations: HashMap<String, Calibration>,
-    pub measure_calibrations: HashMap<(String, Option<Qubit>), MeasureCalibrationDefinition>,
+    pub calibrations: IndexMap<(String, Vec<Qubit>), Calibration>,
+    pub measure_calibrations: IndexMap<(String, Option<Qubit>), MeasureCalibrationDefinition>,
 }
 
 struct MatchedCalibration<'a> {
@@ -386,8 +387,10 @@ impl CalibrationSet {
     /// If a calibration with the same name already exists in the set, it will be replaced, and the
     /// old Calibration is returned. Otherwise, None is returned.
     pub fn insert_calibration(&mut self, calibration: Calibration) -> Option<Calibration> {
-        self.calibrations
-            .insert(calibration.name.clone(), calibration)
+        self.calibrations.insert(
+            (calibration.name.clone(), calibration.qubits.clone()),
+            calibration,
+        )
     }
 
     /// Insert a [`MeasureCalibration`] into the set.

--- a/quil-rs/src/program/calibration.rs
+++ b/quil-rs/src/program/calibration.rs
@@ -27,13 +27,13 @@ use crate::{
     },
 };
 
-use super::{ProgramCalibrationSet, ProgramError};
+use super::{CalibrationSet, ProgramError};
 
 /// A collection of Quil calibrations (`DEFCAL` instructions) with utility methods.
 #[derive(Clone, Debug, Default, PartialEq)]
-pub struct CalibrationSet {
-    pub calibrations: ProgramCalibrationSet<Calibration>,
-    pub measure_calibrations: ProgramCalibrationSet<MeasureCalibrationDefinition>,
+pub struct Calibrations {
+    pub calibrations: CalibrationSet<Calibration>,
+    pub measure_calibrations: CalibrationSet<MeasureCalibrationDefinition>,
 }
 
 struct MatchedCalibration<'a> {
@@ -57,7 +57,7 @@ impl<'a> MatchedCalibration<'a> {
     }
 }
 
-impl CalibrationSet {
+impl Calibrations {
     /// Return a vector containing a reference to all [`Calibration`]s in the set.
     pub fn calibrations(&self) -> Vec<&Calibration> {
         self.calibrations.iter().collect()
@@ -404,7 +404,7 @@ impl CalibrationSet {
     ///
     /// Calibrations with conflicting [`CalibrationSignature`]s are overwritten by the ones in the
     /// given set.
-    pub fn extend(&mut self, other: CalibrationSet) {
+    pub fn extend(&mut self, other: Calibrations) {
         self.calibrations.extend(other.calibrations);
         self.measure_calibrations.extend(other.measure_calibrations);
     }

--- a/quil-rs/src/program/calibration.rs
+++ b/quil-rs/src/program/calibration.rs
@@ -296,7 +296,7 @@ impl CalibrationSet {
     pub fn get_match_for_gate(&self, gate: &Gate) -> Option<&Calibration> {
         let mut matched_calibration: Option<MatchedCalibration> = None;
 
-        for (_, calibration) in &self.calibrations {
+        for calibration in self.iter_calibrations() {
             // Filter out non-matching calibrations: check rules 1-4
             if calibration.name != gate.name
                 || calibration.modifiers != gate.modifiers

--- a/quil-rs/src/program/calibration.rs
+++ b/quil-rs/src/program/calibration.rs
@@ -60,13 +60,13 @@ impl<'a> MatchedCalibration<'a> {
 impl Calibrations {
     /// Return a vector containing a reference to all [`Calibration`]s in the set.
     pub fn calibrations(&self) -> Vec<&Calibration> {
-        self.calibrations.iter().collect()
+        self.iter_calibrations().collect()
     }
 
     /// Return a vector containing a reference to all [`MeasureCalibrationDefinition`]s
     /// in the set.
     pub fn measure_calibrations(&self) -> Vec<&MeasureCalibrationDefinition> {
-        self.measure_calibrations.iter().collect()
+        self.iter_measure_calibrations().collect()
     }
 
     /// Iterate over all [`Calibration`]s in the set

--- a/quil-rs/src/program/calibration.rs
+++ b/quil-rs/src/program/calibration.rs
@@ -386,7 +386,7 @@ impl Calibrations {
     /// If a calibration with the same [`CalibrationSignature`] already exists in the set, it will
     /// be replaced, and the old calibration is returned.
     pub fn insert_calibration(&mut self, calibration: Calibration) -> Option<Calibration> {
-        self.calibrations.replace_signature(calibration)
+        self.calibrations.replace(calibration)
     }
 
     /// Insert a [`MeasureCalibration`] into the set.
@@ -397,7 +397,7 @@ impl Calibrations {
         &mut self,
         calibration: MeasureCalibrationDefinition,
     ) -> Option<MeasureCalibrationDefinition> {
-        self.measure_calibrations.replace_signature(calibration)
+        self.measure_calibrations.replace(calibration)
     }
 
     /// Append another [`CalibrationSet`] onto this one.

--- a/quil-rs/src/program/calibration_set.rs
+++ b/quil-rs/src/program/calibration_set.rs
@@ -1,0 +1,159 @@
+use crate::instruction::CalibrationSignature;
+
+/// A [`ProgramCalibrationSet`] is a collection of calibration instructions that respect how
+/// calibrations work in a Quil program.
+///
+/// During calibration expansion, Calibrations are matched to instructions using their unique
+/// [`CalibrationSignature`]. This means only one calibration can be matched to a particular
+/// instruction. While the Quil specification doesn't explicitly define this behavior, the
+/// [`ProgramCalibrationSet`] takes the liberty of only allowing one calibration per
+/// [`CalibrationSignature`].
+///
+/// In addition, calibration instructions are global. That is, their order or location in a
+/// program make no semantic difference. This means two program [`ProgramCalibrationSet`]s
+/// should be considered equal if they contain the same set of calibrations, regardless of
+/// order.
+///
+/// As a matter of convenience, the insertion order of calibrations is maintained. This
+/// allows for the same set of calibrations to be deterministically serialized to Quil.
+#[derive(Clone, Debug)]
+pub struct CalibrationSet<T> {
+    // The amount of calibrations in a program tends to be small enough that a Vec is more
+    // performant than a typical set.
+    // Sets also have trait bounds that `Instruction`s don't meet, which hampers utility.
+    data: Vec<T>,
+}
+
+impl<T> Default for CalibrationSet<T>
+where
+    T: CalibrationSignature,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T> IntoIterator for CalibrationSet<T> {
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+    type Item = T;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.data.into_iter()
+    }
+}
+
+impl<T> From<Vec<T>> for CalibrationSet<T>
+where
+    T: CalibrationSignature,
+{
+    fn from(data: Vec<T>) -> Self {
+        let mut set = Self::new();
+        for element in data {
+            set.replace_signature(element);
+        }
+        set
+    }
+}
+
+impl<T> CalibrationSet<T>
+where
+    T: CalibrationSignature,
+{
+    /// Creates an empty [`ProgramCalibrationSet`].
+    pub fn new() -> Self {
+        Self { data: Vec::new() }
+    }
+
+    /// Creates a [`InnerCalibrationSet`] with the specified capacity.
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            data: Vec::with_capacity(capacity),
+        }
+    }
+
+    /// Returns the capacity of the [`ProgramCalibrationSet`].
+    pub fn capacity(&self) -> usize {
+        self.data.capacity()
+    }
+
+    /// Returns the length of the [`ProgramCalibrationSet`].
+    pub fn len(&self) -> usize {
+        self.data.len()
+    }
+
+    /// Returns whether the [`ProgramCalibrationSet`] is empty.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Returns an iterator of references to the values in the set.
+    pub fn iter(&self) -> std::slice::Iter<'_, T> {
+        self.data.iter()
+    }
+
+    /// Adds a value to the set, replacing and returning an existing value with the same
+    /// [`CalibrationSignature`], if it exists.
+    pub fn replace_signature(&mut self, value: T) -> Option<T> {
+        if let Some(index) = self.signature_position(value.signature()) {
+            let replaced = std::mem::replace(&mut self.data[index], value);
+            Some(replaced)
+        } else {
+            self.data.push(value);
+            None
+        }
+    }
+
+    /// Removes a value from the set. Returns whether the value was present in the set.
+    pub fn remove_signature(&mut self, signature: <T as CalibrationSignature>::Signature) -> bool {
+        if let Some(index) = self.signature_position(signature) {
+            self.data.remove(index);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Returns the index of an element whose [`CalibrationSignature`] matches the given value, if one exists.
+    fn signature_position(
+        &self,
+        signature: <T as CalibrationSignature>::Signature,
+    ) -> Option<usize> {
+        self.data
+            .iter()
+            .position(|element| element.signature() == signature)
+    }
+}
+
+impl<T> Extend<T> for CalibrationSet<T>
+where
+    T: CalibrationSignature,
+{
+    fn extend<I>(&mut self, iter: I)
+    where
+        I: IntoIterator<Item = T>,
+    {
+        for value in iter {
+            self.replace_signature(value);
+        }
+    }
+}
+
+impl<T> PartialEq for CalibrationSet<T>
+where
+    T: CalibrationSignature + PartialEq,
+    <T as CalibrationSignature>::Signature: std::hash::Hash + Eq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        let self_map: std::collections::HashMap<T::Signature, &T> = self
+            .data
+            .iter()
+            .map(|element| (element.signature(), element))
+            .collect();
+        let other_map: std::collections::HashMap<T::Signature, &T> = other
+            .data
+            .iter()
+            .map(|element| (element.signature(), element))
+            .collect();
+        self_map == other_map
+    }
+}

--- a/quil-rs/src/program/mod.rs
+++ b/quil-rs/src/program/mod.rs
@@ -29,8 +29,8 @@ use crate::instruction::{
 use crate::parser::{lex, parse_instructions, ParseError};
 use crate::quil::Quil;
 
-pub use self::calibration::CalibrationSet;
-pub use self::calibration_set::ProgramCalibrationSet;
+pub use self::calibration::Calibrations;
+pub use self::calibration_set::CalibrationSet;
 pub use self::error::{disallow_leftover, map_parsed, recover, ParseProgramError, SyntaxError};
 pub use self::frame::FrameSet;
 pub use self::frame::MatchedFrames;
@@ -72,7 +72,7 @@ type Result<T> = std::result::Result<T, ProgramError>;
 /// and frame definitions.
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct Program {
-    pub calibrations: CalibrationSet,
+    pub calibrations: Calibrations,
     pub frames: FrameSet,
     pub memory_regions: BTreeMap<String, MemoryRegion>,
     pub waveforms: BTreeMap<String, Waveform>,
@@ -85,7 +85,7 @@ pub struct Program {
 impl Program {
     pub fn new() -> Self {
         Program {
-            calibrations: CalibrationSet::default(),
+            calibrations: Calibrations::default(),
             frames: FrameSet::new(),
             memory_regions: BTreeMap::new(),
             waveforms: BTreeMap::new(),
@@ -363,7 +363,7 @@ impl Program {
         // Remove calibrations such that the resulting program contains
         // only instructions. Calibrations have already been expanded, so
         // technically there is no need to keep them around anyway.
-        expanded_program.calibrations = CalibrationSet::default();
+        expanded_program.calibrations = Calibrations::default();
 
         let mut frames_used: HashSet<&FrameIdentifier> = HashSet::new();
         let mut waveforms_used: HashSet<&String> = HashSet::new();

--- a/quil-rs/src/program/mod.rs
+++ b/quil-rs/src/program/mod.rs
@@ -136,7 +136,7 @@ impl Program {
 
         match instruction {
             Instruction::CalibrationDefinition(calibration) => {
-                self.calibrations.push_calibration(calibration);
+                self.calibrations.insert_calibration(calibration);
             }
             Instruction::FrameDefinition(FrameDefinition {
                 identifier,
@@ -157,7 +157,8 @@ impl Program {
                     .insert(gate_definition.name.clone(), gate_definition);
             }
             Instruction::MeasureCalibrationDefinition(calibration) => {
-                self.calibrations.push_measurement_calibration(calibration);
+                self.calibrations
+                    .insert_measurement_calibration(calibration);
             }
             Instruction::WaveformDefinition(WaveformDefinition { name, definition }) => {
                 self.waveforms.insert(name, definition);
@@ -336,7 +337,7 @@ impl Program {
         instructions.extend(self.waveforms.into_iter().map(|(name, definition)| {
             Instruction::WaveformDefinition(WaveformDefinition { name, definition })
         }));
-        instructions.extend(self.calibrations.into_instructions());
+        instructions.extend(self.calibrations.to_instructions());
         instructions.extend(
             self.gate_definitions
                 .into_values()

--- a/quil-rs/src/program/mod.rs
+++ b/quil-rs/src/program/mod.rs
@@ -30,6 +30,7 @@ use crate::parser::{lex, parse_instructions, ParseError};
 use crate::quil::Quil;
 
 pub use self::calibration::CalibrationSet;
+pub use self::calibration_set::ProgramCalibrationSet;
 pub use self::error::{disallow_leftover, map_parsed, recover, ParseProgramError, SyntaxError};
 pub use self::frame::FrameSet;
 pub use self::frame::MatchedFrames;
@@ -37,6 +38,7 @@ pub use self::memory::{MemoryAccesses, MemoryRegion};
 
 pub mod analysis;
 mod calibration;
+mod calibration_set;
 mod error;
 pub(crate) mod frame;
 mod memory;

--- a/quil-rs/src/program/snapshots/quil_rs__program__calibration__tests__expansion@Measure-Calibration.snap
+++ b/quil-rs/src/program/snapshots/quil_rs__program__calibration__tests__expansion@Measure-Calibration.snap
@@ -1,10 +1,7 @@
 ---
 source: quil-rs/src/program/calibration.rs
-expression: calibrated_program.to_string()
+expression: calibrated_program.to_quil_or_debug()
 ---
-DEFCAL MEASURE 0 addr:
-	PRAGMA INCORRECT_ORDERING
-
 DEFCAL MEASURE 0 addr:
 	PRAGMA CORRECT
 

--- a/quil-rs/src/program/snapshots/quil_rs__program__calibration__tests__expansion@Precedence-Fixed-Match.snap
+++ b/quil-rs/src/program/snapshots/quil_rs__program__calibration__tests__expansion@Precedence-Fixed-Match.snap
@@ -1,15 +1,12 @@
 ---
 source: quil-rs/src/program/calibration.rs
-expression: calibrated_program.to_string()
+expression: calibrated_program.to_quil_or_debug()
 ---
 DEFCAL MEASURE addr:
 	PRAGMA INCORRECT_PRECEDENCE
 
 DEFCAL MEASURE q addr:
 	PRAGMA INCORRECT_PRECEDENCE
-
-DEFCAL MEASURE 0 addr:
-	PRAGMA INCORRECT_ORDER
 
 DEFCAL MEASURE 0 addr:
 	PRAGMA CORRECT

--- a/quil-rs/src/program/snapshots/quil_rs__program__calibration__tests__expansion@Precedence-No-Qubit-Match.snap
+++ b/quil-rs/src/program/snapshots/quil_rs__program__calibration__tests__expansion@Precedence-No-Qubit-Match.snap
@@ -1,10 +1,7 @@
 ---
 source: quil-rs/src/program/calibration.rs
-expression: calibrated_program.to_string()
+expression: calibrated_program.to_quil_or_debug()
 ---
-DEFCAL MEASURE addr:
-	PRAGMA INCORRECT_PRECEDENCE
-
 DEFCAL MEASURE addr:
 	PRAGMA CORRECT
 


### PR DESCRIPTION
I've reworked `CalibrationSet` to actually be a set, where existence in the set is keyed on the calibrations "signature" (e.g. the fields determine the instructions they expand into). In addition, the set maintains insertion order, but disregards order during equality checks. This is to keep program serialization deterministic, while recognizing that the order of calibrations doesn't matter in the semantic meaning of the program.

This required a custom data structure for a few reasons:

1. We care about calibration equality on two different levels: "signature" and equality of contents. This makes using something like an `IndexSet` impossible. To prevent duplicate signatures in a set, we'd have to defined `Hash` and thus `Eq` in terms of the signature. However, when comparing the equality of two calibration sets, we care both about the signature and the contents of the calibration, which would conflict with the definition of `Eq` needed to support using a set.
2. We can't use a `HashMap`, because program serialization wouldn't be deterministic. `BTreeMap` isn't supported by calibrations because there is no clear way to define `Ord` for them, and `IndexMap` defines equality on the order of contents in the map, which leaves us with the same problem we are trying to solve.

Closes #351 