### PR TITLE
fix: Parsing programs with integers that overflow a u64 will no longer panic; instead, they will raise an error.

### DIFF
--- a/quil-rs/src/parser/lexer/error.rs
+++ b/quil-rs/src/parser/lexer/error.rs
@@ -33,4 +33,6 @@ pub enum LexErrorKind {
     /// Encountered an unexpected EOF
     #[error("unexpected EOF while parsing")]
     UnexpectedEOF,
+    #[error("error parsing an integer: {0}")]
+    ParseInt(#[from] std::num::ParseIntError),
 }

--- a/quil-rs/src/parser/lexer/mod.rs
+++ b/quil-rs/src/parser/lexer/mod.rs
@@ -297,12 +297,11 @@ fn lex_number(input: LexInput) -> InternalLexResult {
     Ok((
         input,
         match integer_parse_result {
-            Ok(_) => {
-                float_string.parse::<u64>()
-                    .map(Token::Integer)
-                    .map_err(|e| InternalLexError::from_kind(input, e.into()))
-                    .map_err(nom::Err::Failure)?
-            }
+            Ok(_) => float_string
+                .parse::<u64>()
+                .map(Token::Integer)
+                .map_err(|e| InternalLexError::from_kind(input, e.into()))
+                .map_err(nom::Err::Failure)?,
             Err(_) => Token::Float(double(float_string)?.1),
         },
     ))

--- a/quil-rs/src/parser/lexer/mod.rs
+++ b/quil-rs/src/parser/lexer/mod.rs
@@ -297,7 +297,18 @@ fn lex_number(input: LexInput) -> InternalLexResult {
     Ok((
         input,
         match integer_parse_result {
-            Ok(_) => Token::Integer(float_string.parse::<u64>().unwrap()),
+            Ok(_) => {
+                let parsed_int = float_string.parse::<u64>();
+                match parsed_int {
+                    Ok(int) => Token::Integer(int),
+                    Err(e) => {
+                        return Err(nom::Err::Failure(InternalLexError::from_kind(
+                            input,
+                            e.into(),
+                        )))
+                    }
+                }
+            }
             Err(_) => Token::Float(double(float_string)?.1),
         },
     ))

--- a/quil-rs/src/parser/lexer/mod.rs
+++ b/quil-rs/src/parser/lexer/mod.rs
@@ -298,16 +298,10 @@ fn lex_number(input: LexInput) -> InternalLexResult {
         input,
         match integer_parse_result {
             Ok(_) => {
-                let parsed_int = float_string.parse::<u64>();
-                match parsed_int {
-                    Ok(int) => Token::Integer(int),
-                    Err(e) => {
-                        return Err(nom::Err::Failure(InternalLexError::from_kind(
-                            input,
-                            e.into(),
-                        )))
-                    }
-                }
+                float_string.parse::<u64>()
+                    .map(Token::Integer)
+                    .map_err(|e| InternalLexError::from_kind(input, e.into()))
+                    .map_err(nom::Err::Failure)?
             }
             Err(_) => Token::Float(double(float_string)?.1),
         },

--- a/quil-rs/src/program/mod.rs
+++ b/quil-rs/src/program/mod.rs
@@ -34,7 +34,7 @@ pub use self::calibration_set::CalibrationSet;
 pub use self::error::{disallow_leftover, map_parsed, recover, ParseProgramError, SyntaxError};
 pub use self::frame::FrameSet;
 pub use self::frame::MatchedFrames;
-pub use self::memory::{MemoryAccesses, MemoryRegion};
+pub use self::memory::{MemoryAccess, MemoryAccesses, MemoryRegion};
 
 pub mod analysis;
 mod calibration;


### PR DESCRIPTION
Closes #371 