### PR TITLE
feat: make all instructions and contents Eq and Hash

### DIFF
--- a/quil-rs/src/instruction/calibration.rs
+++ b/quil-rs/src/instruction/calibration.rs
@@ -18,7 +18,7 @@ pub trait CalibrationSignature {
     fn has_signature(&self, signature: &Self::Signature<'_>) -> bool;
 }
 
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
 pub struct Calibration {
     pub instructions: Vec<Instruction>,
     pub modifiers: Vec<GateModifier>,
@@ -86,7 +86,7 @@ impl CalibrationSignature for Calibration {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct MeasureCalibrationDefinition {
     pub qubit: Option<Qubit>,
     pub parameter: String,

--- a/quil-rs/src/instruction/circuit.rs
+++ b/quil-rs/src/instruction/circuit.rs
@@ -2,7 +2,7 @@ use crate::quil::Quil;
 
 use super::Instruction;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct CircuitDefinition {
     pub name: String,
     pub parameters: Vec<String>,

--- a/quil-rs/src/instruction/classical.rs
+++ b/quil-rs/src/instruction/classical.rs
@@ -2,7 +2,7 @@ use crate::{hash::hash_f64, quil::Quil};
 
 use super::MemoryReference;
 
-#[derive(Clone, Debug, Hash, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct Arithmetic {
     pub operator: ArithmeticOperator,
     pub destination: ArithmeticOperand,
@@ -43,6 +43,8 @@ pub enum ArithmeticOperand {
     LiteralReal(f64),
     MemoryReference(MemoryReference),
 }
+
+impl std::cmp::Eq for ArithmeticOperand {}
 
 impl std::hash::Hash for ArithmeticOperand {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
@@ -191,7 +193,7 @@ impl Quil for Convert {
     }
 }
 
-#[derive(Clone, Debug, Hash, PartialEq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct Move {
     pub destination: MemoryReference,
     pub source: ArithmeticOperand,
@@ -220,7 +222,7 @@ impl Quil for Move {
     }
 }
 
-#[derive(Clone, Debug, Hash, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Exchange {
     pub left: MemoryReference,
     pub right: MemoryReference,
@@ -246,7 +248,7 @@ impl Exchange {
     }
 }
 
-#[derive(Clone, Debug, Hash, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct Comparison {
     pub operator: ComparisonOperator,
     pub operands: (MemoryReference, MemoryReference, ComparisonOperand),
@@ -284,6 +286,8 @@ pub enum ComparisonOperand {
     LiteralReal(f64),
     MemoryReference(MemoryReference),
 }
+
+impl std::cmp::Eq for ComparisonOperand {}
 
 impl Quil for ComparisonOperand {
     fn write(

--- a/quil-rs/src/instruction/control_flow.rs
+++ b/quil-rs/src/instruction/control_flow.rs
@@ -108,7 +108,7 @@ impl PartialEq for TargetPlaceholder {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Jump {
     pub target: Target,
 }
@@ -131,7 +131,7 @@ impl Jump {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct JumpWhen {
     pub target: Target,
     pub condition: MemoryReference,
@@ -156,7 +156,7 @@ impl Quil for JumpWhen {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct JumpUnless {
     pub target: Target,
     pub condition: MemoryReference,

--- a/quil-rs/src/instruction/declaration.rs
+++ b/quil-rs/src/instruction/declaration.rs
@@ -254,7 +254,7 @@ impl Quil for Load {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Store {
     pub destination: String,
     pub offset: MemoryReference,

--- a/quil-rs/src/instruction/frame.rs
+++ b/quil-rs/src/instruction/frame.rs
@@ -48,6 +48,16 @@ impl FrameDefinition {
     }
 }
 
+impl std::hash::Hash for FrameDefinition {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.identifier.hash(state);
+        for (k, v) in &self.attributes {
+            k.hash(state);
+            v.hash(state);
+        }
+    }
+}
+
 impl Quil for FrameDefinition {
     fn write(
         &self,
@@ -104,7 +114,7 @@ impl FromStr for FrameIdentifier {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Capture {
     pub blocking: bool,
     pub frame: FrameIdentifier,
@@ -151,7 +161,7 @@ impl Quil for Capture {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Pulse {
     pub blocking: bool,
     pub frame: FrameIdentifier,

--- a/quil-rs/src/instruction/mod.rs
+++ b/quil-rs/src/instruction/mod.rs
@@ -72,7 +72,7 @@ pub enum ValidationError {
     GateError(#[from] GateError),
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Instruction {
     Arithmetic(Arithmetic),
     BinaryLogic(BinaryLogic),

--- a/quil-rs/src/instruction/waveform.rs
+++ b/quil-rs/src/instruction/waveform.rs
@@ -93,6 +93,16 @@ impl WaveformInvocation {
     }
 }
 
+impl std::hash::Hash for WaveformInvocation {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.name.hash(state);
+        for (k, v) in &self.parameters {
+            k.hash(state);
+            v.hash(state);
+        }
+    }
+}
+
 impl Quil for WaveformInvocation {
     fn write(
         &self,


### PR DESCRIPTION
Make `Instruction` and all of its sub-structs both `Hash` and `Eq`:

- Handle f64 equality as `NaN == NaN` which is defensible in the case of equating instructions
- Handle `IndexMap` equality by relying on iteration order. This is suboptimal in that ordering shouldn't matter for equality checks, but sorting them would be expensive. This is where `BTreeMap` may actually make more sense, but that doesn't need to be addressed here.

TODO

- right now, we just `impl Eq for TypeX` when it contains `f64`, which in effect will just cause a panic when one of those `f64` is `NaN`. this should be better handled and possibly include a `PartialEq` override.