### PR TITLE
chore: remove deprecated `f64` constants to satisfy Clippy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1132,7 +1132,7 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quil-cli"
-version = "0.2.1"
+version = "0.4.0-rc.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1141,7 +1141,7 @@ dependencies = [
 
 [[package]]
 name = "quil-py"
-version = "0.9.1"
+version = "0.11.0-rc.0"
 dependencies = [
  "indexmap",
  "ndarray",
@@ -1155,7 +1155,7 @@ dependencies = [
 
 [[package]]
 name = "quil-rs"
-version = "0.25.1"
+version = "0.27.0-rc.0"
 dependencies = [
  "approx",
  "clap",

--- a/quil-rs/src/waveform/templates.rs
+++ b/quil-rs/src/waveform/templates.rs
@@ -30,7 +30,7 @@ pub fn apply_phase_and_detuning(
 /// To handle accumulated floating point errors in sweeps above typical floating point imprecision
 /// we make epsilon 10x larger than floating point epsilon.
 fn ceiling_with_epsilon(value: f64) -> f64 {
-    let truncated = value - (value * 10.0 * std::f64::EPSILON);
+    let truncated = value - (value * 10.0 * f64::EPSILON);
     truncated.ceil()
 }
 
@@ -297,8 +297,8 @@ mod tests {
 
     #[rstest::rstest]
     #[case(0.0, 0.0)]
-    #[case(0.0-std::f64::EPSILON, 0.0)]
-    #[case(0.0+std::f64::EPSILON, 1.0)]
+    #[case(0.0-f64::EPSILON, 0.0)]
+    #[case(0.0+f64::EPSILON, 1.0)]
     // Based on a past edge case
     #[case(8.800_000_000_000_001e-8 * 1.0e9, 88.0)]
     fn ceiling_with_epsilon(#[case] value: f64, #[case] expected: f64) {


### PR DESCRIPTION
The MSRV Clippy check was failing; looks like `std::f64::EPSILON` is now `f64::EPSILON`.