### PR TITLE
test: allow empty comments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1132,7 +1132,7 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quil-cli"
-version = "0.4.0-rc.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1141,7 +1141,7 @@ dependencies = [
 
 [[package]]
 name = "quil-py"
-version = "0.11.0-rc.0"
+version = "0.11.0"
 dependencies = [
  "indexmap",
  "ndarray",
@@ -1155,7 +1155,7 @@ dependencies = [
 
 [[package]]
 name = "quil-rs"
-version = "0.27.0-rc.0"
+version = "0.27.0"
 dependencies = [
  "approx",
  "clap",

--- a/quil-rs/src/parser/lexer/mod.rs
+++ b/quil-rs/src/parser/lexer/mod.rs
@@ -393,14 +393,18 @@ mod tests {
 
     #[test]
     fn comment() {
-        let input = LocatedSpan::new("# hello\n#world");
+        let input = LocatedSpan::new("# hello\n#world\n#\n#");
         let tokens = lex(input).unwrap();
         assert_eq!(
             tokens,
             vec![
                 Token::Comment(" hello".to_owned()),
                 Token::NewLine,
-                Token::Comment("world".to_owned())
+                Token::Comment("world".to_owned()),
+                Token::NewLine,
+                Token::Comment("".to_owned()),
+                Token::NewLine,
+                Token::Comment("".to_owned())
             ]
         )
     }

--- a/quil-rs/src/parser/lexer/mod.rs
+++ b/quil-rs/src/parser/lexer/mod.rs
@@ -17,7 +17,7 @@ mod quoted_strings;
 mod wrapped_parsers;
 
 use nom::{
-    bytes::complete::{is_a, is_not, take_while, take_while1},
+    bytes::complete::{is_a, take_till, take_while, take_while1},
     character::complete::{digit1, one_of},
     combinator::{all_consuming, map, recognize, value},
     multi::many0,
@@ -183,7 +183,7 @@ fn lex_data_type(input: LexInput) -> InternalLexResult {
 
 fn lex_comment(input: LexInput) -> InternalLexResult {
     let (input, _) = tag("#")(input)?;
-    let (input, content) = is_not("\n")(input)?;
+    let (input, content) = take_till(|c| c == '\n')(input)?;
     Ok((input, Token::Comment(content.to_string())))
 }
 


### PR DESCRIPTION
Currently we fail to parse empty comments (`"#\n"`), because we use `is_not` (which requires at least one match) instead of `take_till` (which doesn't).  This PR changes that.