### PR TITLE
feat: allow using instruction handler when simplifying program

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1132,7 +1132,7 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quil-cli"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1141,7 +1141,7 @@ dependencies = [
 
 [[package]]
 name = "quil-py"
-version = "0.11.0"
+version = "0.11.2"
 dependencies = [
  "indexmap",
  "ndarray",
@@ -1155,7 +1155,7 @@ dependencies = [
 
 [[package]]
 name = "quil-rs"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "approx",
  "clap",

--- a/quil-rs/src/instruction/mod.rs
+++ b/quil-rs/src/instruction/mod.rs
@@ -21,6 +21,7 @@ use crate::expression::Expression;
 use crate::parser::lex;
 use crate::parser::parse_instructions;
 use crate::program::frame::{FrameMatchCondition, FrameMatchConditions};
+use crate::program::ProgramError;
 use crate::program::{MatchedFrames, MemoryAccesses};
 use crate::quil::{write_join_quil, Quil, ToQuilResult};
 use crate::Program;
@@ -922,6 +923,11 @@ impl InstructionHandler {
             .as_mut()
             .and_then(|f| f(instruction))
             .unwrap_or_else(|| instruction.get_memory_accesses())
+    }
+
+    /// Like [`Program::into_simplified`], but using custom instruction handling.
+    pub fn simplify_program(&mut self, program: &Program) -> Result<Program, ProgramError> {
+        program.simplify_with_handler(self)
     }
 }
 

--- a/quil-rs/src/program/mod.rs
+++ b/quil-rs/src/program/mod.rs
@@ -21,10 +21,7 @@ use ndarray::Array2;
 use nom_locate::LocatedSpan;
 
 use crate::instruction::{
-    Arithmetic, ArithmeticOperand, ArithmeticOperator, Declaration, FrameDefinition,
-    FrameIdentifier, GateDefinition, GateError, Instruction, Jump, JumpUnless, Label, Matrix,
-    MemoryReference, Move, Qubit, QubitPlaceholder, ScalarType, Target, TargetPlaceholder, Vector,
-    Waveform, WaveformDefinition,
+    Arithmetic, ArithmeticOperand, ArithmeticOperator, Declaration, FrameDefinition, FrameIdentifier, GateDefinition, GateError, Instruction, InstructionHandler, Jump, JumpUnless, Label, Matrix, MemoryReference, Move, Qubit, QubitPlaceholder, ScalarType, Target, TargetPlaceholder, Vector, Waveform, WaveformDefinition
 };
 use crate::parser::{lex, parse_instructions, ParseError};
 use crate::quil::Quil;
@@ -349,16 +346,7 @@ impl Program {
         instructions
     }
 
-    /// Simplify this program into a new [`Program`] which contains only instructions
-    /// and definitions which are executed; effectively, perform dead code removal.
-    ///
-    /// Removes:
-    /// - All calibrations, following calibration expansion
-    /// - Frame definitions which are not used by any instruction such as `PULSE` or `CAPTURE`
-    /// - Waveform definitions which are not used by any instruction
-    ///
-    /// When a valid program is simplified, it remains valid.
-    pub fn into_simplified(&self) -> Result<Self> {
+    pub(crate) fn simplify_with_handler(&self, instruction_handler: &mut InstructionHandler) -> Result<Self> {
         let mut expanded_program = self.expand_calibrations()?;
         // Remove calibrations such that the resulting program contains
         // only instructions. Calibrations have already been expanded, so
@@ -369,7 +357,7 @@ impl Program {
         let mut waveforms_used: HashSet<&String> = HashSet::new();
 
         for instruction in &expanded_program.instructions {
-            if let Some(matched_frames) = expanded_program.get_frames_for_instruction(instruction) {
+            if let Some(matched_frames) = instruction_handler.matching_frames(instruction, &expanded_program) {
                 frames_used.extend(matched_frames.used())
             }
 
@@ -384,6 +372,24 @@ impl Program {
             .retain(|name, _definition| waveforms_used.contains(name));
 
         Ok(expanded_program)
+    }
+
+    /// Simplify this program into a new [`Program`] which contains only instructions
+    /// and definitions which are executed; effectively, perform dead code removal.
+    ///
+    /// Removes:
+    /// - All calibrations, following calibration expansion
+    /// - Frame definitions which are not used by any instruction such as `PULSE` or `CAPTURE`
+    /// - Waveform definitions which are not used by any instruction
+    ///
+    /// When a valid program is simplified, it remains valid.
+    ///
+    /// # Note
+    ///
+    /// If you need custom instruction handling during simplification, using
+    /// [`InstructionHandler::simplify_program`] instead.
+    pub fn into_simplified(&self) -> Result<Self> {
+        self.simplify_with_handler(&mut InstructionHandler::default())
     }
 
     /// Return a copy of the [`Program`] wrapped in a loop that repeats `iterations` times.

--- a/quil-rs/src/program/mod.rs
+++ b/quil-rs/src/program/mod.rs
@@ -21,7 +21,10 @@ use ndarray::Array2;
 use nom_locate::LocatedSpan;
 
 use crate::instruction::{
-    Arithmetic, ArithmeticOperand, ArithmeticOperator, Declaration, FrameDefinition, FrameIdentifier, GateDefinition, GateError, Instruction, InstructionHandler, Jump, JumpUnless, Label, Matrix, MemoryReference, Move, Qubit, QubitPlaceholder, ScalarType, Target, TargetPlaceholder, Vector, Waveform, WaveformDefinition
+    Arithmetic, ArithmeticOperand, ArithmeticOperator, Declaration, FrameDefinition,
+    FrameIdentifier, GateDefinition, GateError, Instruction, InstructionHandler, Jump, JumpUnless,
+    Label, Matrix, MemoryReference, Move, Qubit, QubitPlaceholder, ScalarType, Target,
+    TargetPlaceholder, Vector, Waveform, WaveformDefinition,
 };
 use crate::parser::{lex, parse_instructions, ParseError};
 use crate::quil::Quil;
@@ -346,7 +349,10 @@ impl Program {
         instructions
     }
 
-    pub(crate) fn simplify_with_handler(&self, instruction_handler: &mut InstructionHandler) -> Result<Self> {
+    pub(crate) fn simplify_with_handler(
+        &self,
+        instruction_handler: &mut InstructionHandler,
+    ) -> Result<Self> {
         let mut expanded_program = self.expand_calibrations()?;
         // Remove calibrations such that the resulting program contains
         // only instructions. Calibrations have already been expanded, so
@@ -357,7 +363,9 @@ impl Program {
         let mut waveforms_used: HashSet<&String> = HashSet::new();
 
         for instruction in &expanded_program.instructions {
-            if let Some(matched_frames) = instruction_handler.matching_frames(instruction, &expanded_program) {
+            if let Some(matched_frames) =
+                instruction_handler.matching_frames(instruction, &expanded_program)
+            {
                 frames_used.extend(matched_frames.used())
             }
 


### PR DESCRIPTION
Users of `quil-rs` can use `InstructionHandler` to override how instructions are associated with frames, but this is not considered by `Program::into_simplified`. This PR adds a method, `InstructionHandler::simplify_program`, that uses the frame matching of `InstructionHandler` to determine which frames to retain in the program.