### PR TITLE
fix: update knope action to v2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
         fetch-depth: 0
         token: ${{ secrets.PAT }}
     - name: Install Knope
-      uses: knope-dev/action@v1
+      uses: knope-dev/action@v2
       with:
         version: 0.16.0 # Test before updating, breaking changes likely: https://github.com/knope-dev/action#install-latest-version
     - run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1132,7 +1132,7 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quil-cli"
-version = "0.5.0"
+version = "0.5.1-rc.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1141,7 +1141,7 @@ dependencies = [
 
 [[package]]
 name = "quil-py"
-version = "0.12.0"
+version = "0.12.1-rc.0"
 dependencies = [
  "indexmap",
  "ndarray",
@@ -1155,7 +1155,7 @@ dependencies = [
 
 [[package]]
 name = "quil-rs"
-version = "0.28.0"
+version = "0.28.1-rc.0"
 dependencies = [
  "approx",
  "clap",


### PR DESCRIPTION
knope action v1 cannot install versions newer than 0.10