### PR TITLE
fix!: correctly compute duration for `erfsquare` waveform templates

### DIFF
--- a/quil-py/tests_py/program/test_program.py
+++ b/quil-py/tests_py/program/test_program.py
@@ -134,8 +134,8 @@ DEFCAL CZ q0 q1:
     FENCE q0 q1
     SET-PHASE q0 "flux_tx_cz" 0.0
     SET-PHASE q1 "flux_tx_iswap" 0.0
-    NONBLOCKING PULSE q0 "flux_tx_cz" erf_square(duration: 6.000000000000001e-08)
-    NONBLOCKING PULSE q1 "flux_tx_iswap" erf_square(duration: 6.000000000000001e-08)
+    NONBLOCKING PULSE q0 "flux_tx_cz" erf_square(duration: 6.000000000000001e-08, pad_left: 0.1e-08, pad_right: 0.1e-08)
+    NONBLOCKING PULSE q1 "flux_tx_iswap" erf_square(duration: 6.000000000000001e-08, pad_left: 0.1e-08, pad_right: 0.1e-08)
     SHIFT-PHASE q0 "flux_tx_cz" 1.0
     SHIFT-PHASE q1 "flux_tx_iswap" 1.0
     FENCE q0 q1

--- a/quil-rs/src/program/analysis/control_flow_graph.rs
+++ b/quil-rs/src/program/analysis/control_flow_graph.rs
@@ -745,8 +745,8 @@ DEFCAL CZ q0 q1:
     FENCE q0 q1
     SET-PHASE q0 "flux_tx_cz" 0.0
     SET-PHASE q1 "flux_tx_iswap" 0.0
-    NONBLOCKING PULSE q0 "flux_tx_cz" erf_square(duration: 6.000000000000001e-08)
-    NONBLOCKING PULSE q1 "flux_tx_iswap" erf_square(duration: 6.000000000000001e-08)
+    NONBLOCKING PULSE q0 "flux_tx_cz" erf_square(duration: 6.000000000000001e-08, pad_left: 0, pad_right: 0)
+    NONBLOCKING PULSE q1 "flux_tx_iswap" erf_square(duration: 6.000000000000001e-08, pad_left: 0, pad_right: 0)
     SHIFT-PHASE q0 "flux_tx_cz" 1.0
     SHIFT-PHASE q1 "flux_tx_iswap" 1.0
     FENCE q0 q1

--- a/quil-rs/src/program/scheduling/schedule.rs
+++ b/quil-rs/src/program/scheduling/schedule.rs
@@ -249,14 +249,18 @@ impl<'p> ScheduledBasicBlock<'p> {
             common_sample_rate
                 .map(|sample_rate| sample_count as f64 / sample_rate)
                 .map(Seconds)
-        } else if name == "erfsquare" {
+        } else if name == "erfsquare" || name == "erf_square" {
             // It's not clear how demanding to be of the waveforms here.  This is the simplest thing
             // that could posibly work – compute the duration differently for "erfsquare", don't
             // require constant values for any of the other fields, don't check which fields are
             // present.  However, we could do more stringent parsing and work with an `impl
             // WaveformTemplate` instead.  This would provide stronger guarantees, but less
             // flexibility.
-            Some(parameter("duration")? + parameter("padleft")? + parameter("padright")?)
+            Some(
+                parameter("duration")?
+                    + parameter("padleft").or_else(|| parameter("pad_left"))?
+                    + parameter("padright").or_else(|| parameter("pad_right"))?,
+            )
         } else {
             parameter("duration")
         }

--- a/quil-rs/src/program/scheduling/schedule.rs
+++ b/quil-rs/src/program/scheduling/schedule.rs
@@ -404,6 +404,16 @@ PULSE 0 "a" flat(duration: 1.0)
     #[case(
         r#"DEFFRAME 0 "a":
     SAMPLE-RATE: 1e9
+PULSE 0 "a" erfsquare(duration: 1.0, padleft: 0.2, padright: 0.3)
+PULSE 0 "a" erfsquare(duration: 0.1, padleft: 0.7, padright: 0.7)
+PULSE 0 "a" erfsquare(duration: 0.5, padleft: 0.6, padright: 0.4)
+FENCE
+"#,
+        Ok(vec![0.0, 1.5, 3.0, 4.5])
+    )]
+    #[case(
+        r#"DEFFRAME 0 "a":
+    SAMPLE-RATE: 1e9
 DEFFRAME 0 "b":
     SAMPLE-RATE: 1e9
 NONBLOCKING PULSE 0 "a" flat(duration: 1.0)


### PR DESCRIPTION
`ScheduledBasicBlock::get_waveform_duration_seconds` previously assumed that the duration of all built-in waveforms is equal to their duration parameter.  This isn't true for `erfsquare`, though; the `duration` parameter just specifies the duration of the active pulse, and the `padleft` and `padright` parameters specify silent padding on either side which contribute to the total duration.

This PR updates the computation of the duration to include the padding.  This is a breaking change, because now scheduling a program with an `erfsquare` waveform requires that the `erfsquare` waveform have these extra parameters and that they be constants.  Indeed, some of our very own tests were broken by this.

There is also some inconsistency in names, which this PR papers over by accepting both:

* The Quil spec calls the waveform `erfsquare`, but our test cases call it `erf_square`
* The Quil spec calls the padding parameters `padleft` and `padright`, but our `ErfSquare` type calls them `pad_left` and `pad_right`.

As implemented, any mix of the underscoreless and underscoreful names can be used.

Closes #405.