### PR TITLE
fix!: tokenize keywords and identifiers correctly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1139,7 +1139,7 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quil-cli"
-version = "0.6.2"
+version = "0.6.3-rc.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1148,7 +1148,7 @@ dependencies = [
 
 [[package]]
 name = "quil-py"
-version = "0.13.3-rc.0"
+version = "0.13.3-rc.1"
 dependencies = [
  "indexmap",
  "ndarray",
@@ -1163,7 +1163,7 @@ dependencies = [
 
 [[package]]
 name = "quil-rs"
-version = "0.29.2"
+version = "0.29.3-rc.0"
 dependencies = [
  "approx",
  "clap",

--- a/quil-rs/proptest-regressions/expression/mod.txt
+++ b/quil-rs/proptest-regressions/expression/mod.txt
@@ -7,3 +7,4 @@
 cc 4c32128d724ed0f840715fae4e194c99262dc153c64be39d2acf45b8903b20f7 # shrinks to value = Complex { re: 0.0, im: -0.13530277317700273 }
 cc 5cc95f2159ad7120bbaf296d3a9fb26fef30f57b61e76b3e0dc99f4759009fdb # shrinks to e = Number(Complex { re: 0.0, im: -2.772221265116396 })
 cc de70a1853ccef983fac85a87761ba08bfb2d54b2d4e880d5d90e7b4a75ecafb5 # shrinks to e = Address(MemoryReference { name: "mut", index: 0 })
+cc 9ad50859b68cb403ce1a67af0feef1f55d25587466878e364ba2810be5910b14 # shrinks to e = Address(MemoryReference { name: "iNf", index: 0 })

--- a/quil-rs/proptest-regressions/expression/mod.txt
+++ b/quil-rs/proptest-regressions/expression/mod.txt
@@ -6,3 +6,4 @@
 # everyone who runs the test benefits from these saved cases.
 cc 4c32128d724ed0f840715fae4e194c99262dc153c64be39d2acf45b8903b20f7 # shrinks to value = Complex { re: 0.0, im: -0.13530277317700273 }
 cc 5cc95f2159ad7120bbaf296d3a9fb26fef30f57b61e76b3e0dc99f4759009fdb # shrinks to e = Number(Complex { re: 0.0, im: -2.772221265116396 })
+cc de70a1853ccef983fac85a87761ba08bfb2d54b2d4e880d5d90e7b4a75ecafb5 # shrinks to e = Address(MemoryReference { name: "mut", index: 0 })

--- a/quil-rs/src/parser/lexer/mod.rs
+++ b/quil-rs/src/parser/lexer/mod.rs
@@ -170,9 +170,12 @@ fn lex_token(input: LexInput) -> InternalLexResult<TokenWithLocation> {
             token_with_location(lex_string),
             // Operator must come before number (or it may be parsed as a prefix)
             token_with_location(lex_operator),
-            token_with_location(lex_number),
             token_with_location(lex_variable),
+            // Identifiers must come before numbers so that `NaN`, `Inf`, and `Infinity` aren't
+            // parsed as floats; Nom, as of version 7.1.1, will parse those strings,
+            // case-insensitively, as floats
             token_with_location(lex_keyword_or_identifier),
+            token_with_location(lex_number),
         ),
     )(input)
 }

--- a/quil-rs/src/parser/lexer/mod.rs
+++ b/quil-rs/src/parser/lexer/mod.rs
@@ -399,7 +399,7 @@ mod tests {
     use nom_locate::LocatedSpan;
     use rstest::*;
 
-    use crate::parser::common::tests::KITCHEN_SINK_QUIL;
+    use crate::parser::{common::tests::KITCHEN_SINK_QUIL, DataType};
 
     use super::{lex, Command, Operator, Token};
 
@@ -568,7 +568,13 @@ mod tests {
                 Token::Identifier("a-2".to_string()),
                 Token::Operator(Operator::Minus),
                 Token::Variable("var".to_string())
-        ])
+        ]),
+        case("BIT", vec![Token::DataType(DataType::Bit)]),
+        case("BITS", vec![Token::Identifier("BITS".to_string())]),
+        case("NaN", vec![Token::Identifier("NaN".to_string())]),
+        case("nan", vec![Token::Identifier("nan".to_string())]),
+        case("NaNa", vec![Token::Identifier("NaNa".to_string())]),
+        case("nana", vec![Token::Identifier("nana".to_string())]),
     )]
     fn it_lexes_identifier(input: &str, expected: Vec<Token>) {
         let input = LocatedSpan::new(input);

--- a/quil-rs/src/parser/lexer/mod.rs
+++ b/quil-rs/src/parser/lexer/mod.rs
@@ -16,6 +16,8 @@ mod error;
 mod quoted_strings;
 mod wrapped_parsers;
 
+use std::str::FromStr;
+
 use nom::{
     bytes::complete::{is_a, take_till, take_while, take_while1},
     character::complete::{digit1, one_of},
@@ -28,7 +30,7 @@ use nom::{
 use nom_locate::LocatedSpan;
 use wrapped_parsers::{alt, tag};
 
-pub use super::token::{Token, TokenWithLocation};
+pub use super::token::{KeywordToken, Token, TokenWithLocation};
 use crate::parser::lexer::wrapped_parsers::expecting;
 use crate::parser::token::token_with_location;
 pub(crate) use error::InternalLexError;
@@ -92,7 +94,7 @@ pub enum Command {
     Xor,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, strum::Display)]
+#[derive(Debug, Clone, PartialEq, Eq, strum::Display, strum::EnumString)]
 #[strum(serialize_all = "UPPERCASE")]
 pub enum DataType {
     Bit,
@@ -101,7 +103,7 @@ pub enum DataType {
     Integer,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, strum::Display)]
+#[derive(Debug, Clone, PartialEq, Eq, strum::Display, strum::EnumString)]
 #[strum(serialize_all = "UPPERCASE")]
 pub enum Modifier {
     Controlled,
@@ -163,8 +165,6 @@ fn lex_token(input: LexInput) -> InternalLexResult<TokenWithLocation> {
         "a token",
         (
             token_with_location(lex_comment),
-            token_with_location(lex_data_type),
-            token_with_location(lex_modifier),
             token_with_location(lex_punctuation),
             token_with_location(lex_target),
             token_with_location(lex_string),
@@ -172,21 +172,7 @@ fn lex_token(input: LexInput) -> InternalLexResult<TokenWithLocation> {
             token_with_location(lex_operator),
             token_with_location(lex_number),
             token_with_location(lex_variable),
-            token_with_location(lex_non_blocking),
-            // This should come last because it's sort of a catch all
-            token_with_location(lex_command_or_identifier),
-        ),
-    )(input)
-}
-
-fn lex_data_type(input: LexInput) -> InternalLexResult {
-    alt(
-        "a data type",
-        (
-            value(Token::DataType(DataType::Bit), tag("BIT")),
-            value(Token::DataType(DataType::Integer), tag("INTEGER")),
-            value(Token::DataType(DataType::Octet), tag("OCTET")),
-            value(Token::DataType(DataType::Real), tag("REAL")),
+            token_with_location(lex_keyword_or_identifier),
         ),
     )(input)
 }
@@ -197,62 +183,16 @@ fn lex_comment(input: LexInput) -> InternalLexResult {
     Ok((input, Token::Comment(content.to_string())))
 }
 
-/// If the given identifier string matches a command keyword, return the keyword;
-/// otherwise, return the original identifier as a token.
-fn recognize_command_or_identifier(identifier: String) -> Token {
-    use Command::*;
-
-    match identifier.as_str() {
-        "DEFGATE" => Token::Command(DefGate),
-        "ADD" => Token::Command(Add),
-        "AND" => Token::Command(And),
-        "CALL" => Token::Command(Call),
-        "CONVERT" => Token::Command(Convert),
-        "DIV" => Token::Command(Div),
-        "EQ" => Token::Command(Eq),
-        "EXCHANGE" => Token::Command(Exchange),
-        "GE" => Token::Command(GE),
-        "GT" => Token::Command(GT),
-        "IOR" => Token::Command(Ior),
-        "LE" => Token::Command(LE),
-        "LOAD" => Token::Command(Load),
-        "LT" => Token::Command(LT),
-        "MOVE" => Token::Command(Move),
-        "MUL" => Token::Command(Mul),
-        "NEG" => Token::Command(Neg),
-        "NOT" => Token::Command(Not),
-        "STORE" => Token::Command(Store),
-        "SUB" => Token::Command(Sub),
-        "XOR" => Token::Command(Xor),
-        "DEFCIRCUIT" => Token::Command(DefCircuit),
-        "MEASURE" => Token::Command(Measure),
-        "HALT" => Token::Command(Halt),
-        "WAIT" => Token::Command(Wait),
-        "JUMP-WHEN" => Token::Command(JumpWhen),
-        "JUMP-UNLESS" => Token::Command(JumpUnless),
-        "JUMP" => Token::Command(Jump),
-        "RESET" => Token::Command(Reset),
-        "NOP" => Token::Command(Nop),
-        "INCLUDE" => Token::Command(Include),
-        "PRAGMA" => Token::Command(Pragma),
-        "DECLARE" => Token::Command(Declare),
-        "CAPTURE" => Token::Command(Capture),
-        "DEFCAL" => Token::Command(DefCal),
-        "DEFFRAME" => Token::Command(DefFrame),
-        "DEFWAVEFORM" => Token::Command(DefWaveform),
-        "DELAY" => Token::Command(Delay),
-        "FENCE" => Token::Command(Fence),
-        "PULSE" => Token::Command(Pulse),
-        "RAW-CAPTURE" => Token::Command(RawCapture),
-        "SET-FREQUENCY" => Token::Command(SetFrequency),
-        "SET-PHASE" => Token::Command(SetPhase),
-        "SET-SCALE" => Token::Command(SetScale),
-        "SWAP-PHASES" => Token::Command(SwapPhases),
-        "SHIFT-FREQUENCY" => Token::Command(ShiftFrequency),
-        "SHIFT-PHASE" => Token::Command(ShiftPhase),
-        "LABEL" => Token::Command(Label),
-        _ => Token::Identifier(identifier),
+fn keyword_or_identifier(identifier: String) -> Token {
+    fn parse<T: FromStr>(token: impl Fn(T) -> Token, identifier: &str) -> Result<Token, T::Err> {
+        T::from_str(identifier).map(token)
     }
+
+    parse(KeywordToken::into, &identifier)
+        .or_else(|_| parse(Token::Command, &identifier))
+        .or_else(|_| parse(Token::DataType, &identifier))
+        .or_else(|_| parse(Token::Modifier, &identifier))
+        .unwrap_or(Token::Identifier(identifier))
 }
 
 fn is_valid_identifier_leading_character(chr: char) -> bool {
@@ -286,9 +226,9 @@ fn lex_identifier_raw(input: LexInput) -> InternalLexResult<String> {
     )(input)
 }
 
-fn lex_command_or_identifier(input: LexInput) -> InternalLexResult {
+fn lex_keyword_or_identifier(input: LexInput) -> InternalLexResult {
     let (input, identifier) = lex_identifier_raw(input)?;
-    let token = recognize_command_or_identifier(identifier);
+    let token = keyword_or_identifier(identifier);
     Ok((input, token))
 }
 
@@ -296,10 +236,6 @@ fn lex_target(input: LexInput) -> InternalLexResult {
     let (input, _) = tag("@")(input)?;
     let (input, label) = lex_identifier_raw(input)?;
     Ok((input, Token::Target(label)))
-}
-
-fn lex_non_blocking(input: LexInput) -> InternalLexResult {
-    value(Token::NonBlocking, tag("NONBLOCKING"))(input)
 }
 
 fn lex_number(input: LexInput) -> InternalLexResult {
@@ -316,24 +252,6 @@ fn lex_number(input: LexInput) -> InternalLexResult {
             Err(_) => Token::Float(double(float_string)?.1),
         },
     ))
-}
-
-fn lex_modifier(input: LexInput) -> InternalLexResult {
-    alt(
-        "a modifier token",
-        (
-            value(Token::As, tag("AS")),
-            value(Token::Matrix, tag("MATRIX")),
-            value(Token::Modifier(Modifier::Controlled), tag("CONTROLLED")),
-            value(Token::Modifier(Modifier::Dagger), tag("DAGGER")),
-            value(Token::Modifier(Modifier::Forked), tag("FORKED")),
-            value(Token::Mutable, tag("mut")),
-            value(Token::Offset, tag("OFFSET")),
-            value(Token::PauliSum, tag("PAULI-SUM")),
-            value(Token::Permutation, tag("PERMUTATION")),
-            value(Token::Sharing, tag("SHARING")),
-        ),
-    )(input)
 }
 
 fn lex_operator(input: LexInput) -> InternalLexResult {

--- a/quil-rs/src/parser/lexer/mod.rs
+++ b/quil-rs/src/parser/lexer/mod.rs
@@ -486,9 +486,9 @@ mod tests {
         case("a", vec![Token::Identifier("a".to_string())]),
         case("_a-2_b-2_", vec![Token::Identifier("_a-2_b-2_".to_string())]),
         case("a-2-%var", vec![
-                Token::Identifier("a-2".to_string()),
-                Token::Operator(Operator::Minus),
-                Token::Variable("var".to_string())
+            Token::Identifier("a-2".to_string()),
+            Token::Operator(Operator::Minus),
+            Token::Variable("var".to_string())
         ]),
         case("BIT", vec![Token::DataType(DataType::Bit)]),
         case("BITS", vec![Token::Identifier("BITS".to_string())]),
@@ -496,6 +496,19 @@ mod tests {
         case("nan", vec![Token::Identifier("nan".to_string())]),
         case("NaNa", vec![Token::Identifier("NaNa".to_string())]),
         case("nana", vec![Token::Identifier("nana".to_string())]),
+        case("INF", vec![Token::Identifier("INF".to_string())]),
+        case("Infinity", vec![Token::Identifier("Infinity".to_string())]),
+        case("Inferior", vec![Token::Identifier("Inferior".to_string())]),
+        case("-NaN", vec![Token::Operator(Operator::Minus), Token::Identifier("NaN".to_string())]),
+        case("-inf", vec![Token::Operator(Operator::Minus), Token::Identifier("inf".to_string())]),
+        case("-Infinity", vec![
+            Token::Operator(Operator::Minus),
+            Token::Identifier("Infinity".to_string())
+        ]),
+        case("-inferior", vec![
+            Token::Operator(Operator::Minus),
+            Token::Identifier("inferior".to_string())
+        ]),
     )]
     fn it_lexes_identifier(input: &str, expected: Vec<Token>) {
         let input = LocatedSpan::new(input);

--- a/quil-rs/src/parser/lexer/mod.rs
+++ b/quil-rs/src/parser/lexer/mod.rs
@@ -17,7 +17,7 @@ mod quoted_strings;
 mod wrapped_parsers;
 
 use nom::{
-    bytes::complete::{is_a, tag_no_case, take_till, take_while, take_while1},
+    bytes::complete::{is_a, take_till, take_while, take_while1},
     character::complete::{digit1, one_of},
     combinator::{all_consuming, map, recognize, value},
     multi::many0,
@@ -327,7 +327,7 @@ fn lex_modifier(input: LexInput) -> InternalLexResult {
             value(Token::Modifier(Modifier::Controlled), tag("CONTROLLED")),
             value(Token::Modifier(Modifier::Dagger), tag("DAGGER")),
             value(Token::Modifier(Modifier::Forked), tag("FORKED")),
-            value(Token::Mutable, tag_no_case("MUT")),
+            value(Token::Mutable, tag("mut")),
             value(Token::Offset, tag("OFFSET")),
             value(Token::PauliSum, tag("PAULI-SUM")),
             value(Token::Permutation, tag("PERMUTATION")),

--- a/quil-rs/src/parser/mod.rs
+++ b/quil-rs/src/parser/mod.rs
@@ -31,7 +31,7 @@ mod token;
 
 pub(crate) use error::{ErrorInput, InternalParseError};
 pub use error::{ParseError, ParserErrorKind};
-pub use lexer::LexError;
+pub use lexer::{DataType, LexError};
 pub use token::{Token, TokenWithLocation};
 
 pub(crate) type ParserInput<'a> = &'a [TokenWithLocation<'a>];

--- a/quil-rs/src/parser/mod.rs
+++ b/quil-rs/src/parser/mod.rs
@@ -31,8 +31,8 @@ mod token;
 
 pub(crate) use error::{ErrorInput, InternalParseError};
 pub use error::{ParseError, ParserErrorKind};
-pub use lexer::{DataType, LexError};
-pub use token::{Token, TokenWithLocation};
+pub use lexer::{Command, DataType, LexError, Modifier};
+pub use token::{KeywordToken, Token, TokenWithLocation};
 
 pub(crate) type ParserInput<'a> = &'a [TokenWithLocation<'a>];
 type InternalParserResult<'a, R, E = InternalParseError<'a>> = IResult<ParserInput<'a>, R, E>;

--- a/quil-rs/src/parser/token.rs
+++ b/quil-rs/src/parser/token.rs
@@ -67,6 +67,9 @@ where
     }
 }
 
+// When adding tokens that are keywords, you also need to update
+// [`crate::reserved::ReservedKeyword`], and similarly for gates ([`crate::reserved::ReservedGate`])
+// and constants ([`crate::reserved::ReservedConstant`]).
 #[derive(Clone, PartialEq)]
 pub enum Token {
     As,
@@ -118,7 +121,7 @@ impl fmt::Display for Token {
             Token::NonBlocking => write!(f, "NONBLOCKING"),
             Token::Matrix => write!(f, "MATRIX"),
             Token::Modifier(m) => write!(f, "{m}"),
-            Token::Mutable => write!(f, "MUT"),
+            Token::Mutable => write!(f, "mut"),
             Token::NewLine => write!(f, "NEWLINE"),
             Token::Operator(op) => write!(f, "{op}"),
             Token::Offset => write!(f, "OFFSET"),

--- a/quil-rs/src/parser/token.rs
+++ b/quil-rs/src/parser/token.rs
@@ -67,8 +67,8 @@ where
     }
 }
 
-/// The subset of [`Token`]s which (a) do not contain more specific data and (b) are keywords.  Used
-/// to ensure that keyword-checking remains in sync with the definition of [`Token`].
+/// The subset of [`Token`]s which (a) do not have arguments and (b) are keywords.  Used to ensure
+/// that keyword-checking remains in sync with the definition of [`Token`].
 #[derive(Debug, Copy, Clone, PartialEq, Eq, strum::Display, strum::EnumString)]
 #[strum(serialize_all = "SCREAMING-KEBAB-CASE")]
 pub enum KeywordToken {
@@ -104,7 +104,8 @@ impl TryFrom<Token> for KeywordToken {
 
     fn try_from(token: Token) -> Result<Self, Self::Error> {
         // This match is explicit so that if you add a new [`Token`] constructor you have to decide
-        // if it's a keyword.  Please do not add a top-level wildcard match here.
+        // if it's a keyword.
+        #[deny(clippy::wildcard_enum_match_arm, clippy::wildcard_in_or_patterns)]
         match token {
             Token::As => Ok(KeywordToken::As),
             Token::Matrix => Ok(KeywordToken::Matrix),

--- a/quil-rs/src/reserved.rs
+++ b/quil-rs/src/reserved.rs
@@ -77,6 +77,8 @@ pub enum ReservedKeyword {
     Measure,
     Move,
     Mul,
+    #[strum(serialize = "mut")]
+    Mutable,
     Neg,
     Nop,
     Not,

--- a/quil-rs/src/reserved.rs
+++ b/quil-rs/src/reserved.rs
@@ -4,10 +4,15 @@ use std::{fmt::Display, str::FromStr};
 
 use strum;
 
+pub use crate::parser::{Command, DataType, KeywordToken, Modifier};
+
 /// An enum that can represent any reserved token in quil.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ReservedToken {
-    Keyword(ReservedKeyword),
+    Command(Command),
+    DataType(DataType),
+    Modifier(Modifier),
+    OtherKeyword(KeywordToken),
     Gate(ReservedGate),
     Constant(ReservedConstant),
 }
@@ -20,79 +25,34 @@ impl FromStr for ReservedToken {
     type Err = NotReservedToken;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if let Ok(keyword) = ReservedKeyword::from_str(s) {
-            Ok(Self::Keyword(keyword))
-        } else if let Ok(gate) = ReservedGate::from_str(s) {
-            Ok(Self::Gate(gate))
-        } else if let Ok(constant) = ReservedConstant::from_str(s) {
-            Ok(Self::Constant(constant))
-        } else {
-            Err(NotReservedToken(s.to_string()))
+        fn parse<T: FromStr>(
+            reserved: impl Fn(T) -> ReservedToken,
+            s: &str,
+        ) -> Result<ReservedToken, T::Err> {
+            T::from_str(s).map(reserved)
         }
+
+        parse(Self::Command, s)
+            .or_else(|_| parse(Self::DataType, s))
+            .or_else(|_| parse(Self::Modifier, s))
+            .or_else(|_| parse(Self::OtherKeyword, s))
+            .or_else(|_| parse(Self::Gate, s))
+            .or_else(|_| parse(Self::Constant, s))
+            .map_err(|_| NotReservedToken(s.to_string()))
     }
 }
 
 impl Display for ReservedToken {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Keyword(keyword) => write!(f, "{keyword}"),
+            Self::Command(command) => write!(f, "{command}"),
+            Self::DataType(data_type) => write!(f, "{data_type}"),
+            Self::Modifier(modifier) => write!(f, "{modifier}"),
+            Self::OtherKeyword(keyword_token) => write!(f, "{keyword_token}"),
             Self::Gate(gate) => write!(f, "{gate}"),
             Self::Constant(constant) => write!(f, "{constant}"),
         }
     }
-}
-
-/// Any reserved keyword that isn't specifically a gate identifier or constant
-#[derive(Clone, Copy, Debug, PartialEq, Eq, strum::Display, strum::EnumString)]
-#[strum(serialize_all = "UPPERCASE")]
-pub enum ReservedKeyword {
-    Add,
-    And,
-    As,
-    Controlled,
-    Convert,
-    Dagger,
-    Declare,
-    DefCircuit,
-    DefGate,
-    Div,
-    Eq,
-    Exchange,
-    Forked,
-    Ge,
-    Gt,
-    Halt,
-    Include,
-    Ior,
-    Jump,
-    #[strum(serialize = "JUMP-UNLESS")]
-    JumpUnless,
-    #[strum(serialize = "JUMP-WHEN")]
-    JumpWhen,
-    Label,
-    Le,
-    Load,
-    Lt,
-    Matrix,
-    Measure,
-    Move,
-    Mul,
-    #[strum(serialize = "mut")]
-    Mutable,
-    Neg,
-    Nop,
-    Not,
-    Offset,
-    #[strum(serialize = "PAULI-SUM")]
-    PauliSum,
-    Permutation,
-    Pragma,
-    Reset,
-    Sharing,
-    Store,
-    Sub,
-    Wait,
-    Xor,
 }
 
 /// Every reserved Gate identifier


### PR DESCRIPTION
Fix the tokenization of identifiers and keywords so that keywords are not parsed within word boundaries.  Previously, `BITS` would be parsed as the data type `BIT` followed by the identifier `S`; now, it is correctly parsed as the single identifier `BITS`.

This also fixes the tokenization of `NaN`, `Inf`, and `Infinity`; previously, these were case-insensitively parsed as floats (with the same incorrect prefix behavior, so `nana` would parse as the float `NaN` followed by the identifier `a`), but now they are correctly parsed as normal identifiers.

Finally, this PR makes the "mut" keyword lowercase-only.

Closes #427