### PR TITLE
fix(py)!: make Calibration and MeasureCalibrationDefinition getter methods into properties

### DIFF
--- a/quil-py/pyproject.toml
+++ b/quil-py/pyproject.toml
@@ -27,7 +27,7 @@ sdist-include = ["README.md"]
 dev = [
     "ruff>=0.3.7",
     "maturin>=1.2.3",
-    "mypy>=1.13.0",
+    "mypy==1.13.0",
     "pytest>=7.2.2",
     "pdoc>=14.1.0",
     "syrupy>=3.0.6"

--- a/quil-py/pyproject.toml
+++ b/quil-py/pyproject.toml
@@ -27,7 +27,7 @@ sdist-include = ["README.md"]
 dev = [
     "ruff>=0.3.7",
     "maturin>=1.2.3",
-    "mypy==1.13.0",
+    "mypy>=1.13.0",
     "pytest>=7.2.2",
     "pdoc>=14.1.0",
     "syrupy>=3.0.6"

--- a/quil-py/quil/instructions/__init__.pyi
+++ b/quil-py/quil/instructions/__init__.pyi
@@ -963,17 +963,21 @@ class Calibration:
         identifier: CalibrationIdentifier,
         instructions: Sequence[Instruction],
     ) -> Self: ...
+    @property
     def name(self) -> str:
-        """Get the name that identifies this calibration."""
+        """The name that identifies this calibration."""
         ...
+    @property
     def parameters(self) -> List[Expression]:
-        """Get the list of parameters that this calibration will expand into."""
+        """The list of parameters that this calibration will expand into."""
         ...
+    @property
     def qubits(self) -> List[Qubit]:
-        """Get the list of qubits that this calibration will expand into."""
+        """The list of qubits that this calibration will expand into."""
         ...
+    @property
     def modifiers(self) -> List[GateModifier]:
-        """Get the list of parameters that this calibration will expand into."""
+        """The list of parameters that this calibration will expand into."""
     @property
     def identifier(self) -> CalibrationIdentifier: ...
     @identifier.setter
@@ -1044,7 +1048,9 @@ class MeasureCalibrationDefinition:
         identifier: MeasureCalibrationIdentifier,
         instructions: Sequence[Instruction],
     ) -> Self: ...
+    @property
     def qubit(self) -> Optional[Qubit]: ...
+    @property
     def parameter(self) -> str: ...
     @property
     def identifier(self) -> MeasureCalibrationIdentifier: ...

--- a/quil-py/src/instruction/calibration.rs
+++ b/quil-py/src/instruction/calibration.rs
@@ -51,10 +51,12 @@ impl PyCalibration {
         ))
     }
 
+    #[getter]
     pub fn name(&self) -> &str {
         &self.as_inner().identifier.name
     }
 
+    #[getter]
     pub fn parameters(&self) -> Vec<PyExpression> {
         self.as_inner()
             .identifier
@@ -65,6 +67,7 @@ impl PyCalibration {
             .collect()
     }
 
+    #[getter]
     pub fn qubits(&self) -> Vec<PyQubit> {
         self.as_inner()
             .identifier
@@ -75,6 +78,7 @@ impl PyCalibration {
             .collect()
     }
 
+    #[getter]
     pub fn modifiers(&self) -> Vec<PyGateModifier> {
         self.as_inner()
             .identifier
@@ -153,10 +157,12 @@ impl PyMeasureCalibrationDefinition {
         )))
     }
 
+    #[getter]
     pub fn qubit(&self) -> Option<PyQubit> {
         self.as_inner().identifier.qubit.clone().map(Into::into)
     }
 
+    #[getter]
     pub fn parameter(&self) -> String {
         self.as_inner().identifier.parameter.clone()
     }

--- a/quil-py/tests_py/instructions/test_gate.py
+++ b/quil-py/tests_py/instructions/test_gate.py
@@ -1,5 +1,16 @@
 from quil.expression import Expression
-from quil.instructions import PauliGate, PauliTerm
+from quil.instructions import (
+    MeasureCalibrationDefinition,
+    MeasureCalibrationIdentifier,
+    PauliGate,
+    PauliTerm,
+    Qubit,
+    Calibration,
+    CalibrationIdentifier,
+    QubitPlaceholder,
+    Instruction,
+    Delay,
+)
 
 
 class TestPauliTerm:
@@ -8,3 +19,29 @@ class TestPauliTerm:
         assert pt.arguments == [(PauliGate.X, "a")]
         pt.arguments = [(PauliGate.Y, "b")]
         assert pt.arguments == [(PauliGate.Y, "b")]
+
+
+def test_calibration_getters():
+    placeholder = Qubit.from_placeholder(QubitPlaceholder())
+
+    calibration = Calibration(
+        CalibrationIdentifier("MYCAL", [], [placeholder], []),
+        [Instruction.from_delay(Delay(Expression.from_number(complex(0.5)), [], [placeholder]))],
+    )
+
+    assert calibration.name == "MYCAL"
+    assert calibration.parameters == []
+    assert calibration.qubits == [placeholder]
+    assert calibration.modifiers == []
+
+
+def test_measure_calibration_getters():
+    placeholder = Qubit.from_placeholder(QubitPlaceholder())
+
+    calibration = MeasureCalibrationDefinition(
+        MeasureCalibrationIdentifier(placeholder, "param"),
+        [],
+    )
+
+    assert calibration.qubit == placeholder
+    assert calibration.instructions == []


### PR DESCRIPTION
See https://github.com/rigetti/quil-rs/issues/420

It was always intended for these to be getters, this fixes the implementation and types.