### PR TITLE
fix(py): github release action configuration for upload and download artifact v4

### DIFF
--- a/.github/workflows/publish-quil-py.yml
+++ b/.github/workflows/publish-quil-py.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: wheels-macos-${{ matrix.python-version }}
           path: dist
 
   linux:
@@ -88,7 +88,7 @@ jobs:
     - name: Upload wheels
       uses: actions/upload-artifact@v4
       with:
-        name: wheels
+        name: wheels-linux-${{ matrix.python-version }}
         path: dist
 
   windows:
@@ -126,7 +126,7 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: wheels-windows-${{ matrix.python-version }}
           path: dist
 
   sdist:
@@ -153,7 +153,7 @@ jobs:
     - name: Upload sdist
       uses: actions/upload-artifact@v4
       with:
-        name: wheels
+        name: wheels-sdist
         path: dist
 
   publish-python-package:
@@ -171,7 +171,10 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: wheels-*
+          merge-multiple: true
       - name: Publish to PyPi
         uses: messense/maturin-action@v1
         with:

--- a/.github/workflows/publish-quil-py.yml
+++ b/.github/workflows/publish-quil-py.yml
@@ -88,7 +88,7 @@ jobs:
     - name: Upload wheels
       uses: actions/upload-artifact@v4
       with:
-        name: wheels-linux-${{ matrix.python-version }}
+        name: wheels-linux-${{ matrix.python-version }}-${{ matrix.target }}
         path: dist
 
   windows:
@@ -126,7 +126,7 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheels-windows-${{ matrix.python-version }}
+          name: wheels-windows-${{ matrix.python-version }}-${{ matrix.target }}
           path: dist
 
   sdist:


### PR DESCRIPTION
Closes #436 

See https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md#multiple-uploads-to-the-same-named-artifact