### PR TITLE
fix: fix simplification so that a/(bc) = (a/b)/c

### DIFF
--- a/quil-rs/src/expression/simplification/by_hand.rs
+++ b/quil-rs/src/expression/simplification/by_hand.rs
@@ -804,7 +804,7 @@ fn simplify_infix(l: &Expression, op: InfixOperator, r: &Expression, limit: u64)
                     simplify_infix(numerator, InfixOperator::Slash, multiplier, limit - 1);
                 let new = simplify_infix(
                     &new_multiplier,
-                    InfixOperator::Star,
+                    InfixOperator::Slash,
                     multiplicand,
                     limit - 1,
                 );

--- a/quil-rs/src/expression/simplification/mod.rs
+++ b/quil-rs/src/expression/simplification/mod.rs
@@ -336,6 +336,12 @@ mod tests {
         "0"
     }
 
+    test_simplify! {
+        mul_inside_div_on_right,
+        "4 / (2 * x)",
+        "2 / x"
+    }
+
     // TODO doesn't fully simplify in a reasonable amount of recursion
     //     test_simplify! {
     //         the_big_one,

--- a/quil-rs/src/instruction/waveform.rs
+++ b/quil-rs/src/instruction/waveform.rs
@@ -41,7 +41,6 @@ impl Quil for WaveformDefinition {
         write_parameter_string(f, &self.definition.parameters)?;
         write!(f, ":\n{INDENT}")?;
         write_join_quil(f, fall_back_to_debug, &self.definition.matrix, ", ", "")
-            .map_err(Into::into)
     }
 }
 


### PR DESCRIPTION
Now, expression simplification will try to simplify `a / (b * c)` to `(a / b) / c`.

Previously, it would try to simplify to `(a / b) * c` instead.

(Expression simplification already correctly simplifies `(x * y) / z` to `x * (y / z)`.)