### PR TITLE
Expression interning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1394,8 +1394,9 @@ checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "rigetti-pyo3"
-version = "0.4.2"
-source = "git+https://github.com/rigetti/rigetti-pyo3.git?branch=interning#adeda74b62494178bc56c995cb6e08487f89f919"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de0fe0ab65837fe10015f26bc91aca339fc4e5678faa2007223663a6df79e949"
 dependencies = [
  "indexmap",
  "internment",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1243,6 +1243,7 @@ dependencies = [
  "nom_locate",
  "num-complex",
  "once_cell",
+ "paste",
  "petgraph",
  "pretty_assertions",
  "proptest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,13 +3,32 @@
 version = 3
 
 [[package]]
-name = "aho-corasick"
-version = "1.0.2"
+name = "ahash"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.2.15",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "anes"
@@ -19,57 +38,59 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.13"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
 dependencies = [
  "anstyle",
  "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
+ "is_terminal_polyfill",
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle"
-version = "1.0.1"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a30da5c5f2d5e72842e00bcb57657162cdabef0931f40e2deb9b4140440cecd"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.1"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.2"
+version = "3.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
+checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
 dependencies = [
  "anstyle",
- "windows-sys 0.52.0",
+ "once_cell",
+ "windows-sys",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.81"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
+checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
 
 [[package]]
 name = "approx"
@@ -83,75 +104,60 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "bit-set"
-version = "0.5.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
  "bit-vec",
 ]
 
 [[package]]
 name = "bit-vec"
-version = "0.6.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
-version = "2.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
 name = "bumpalo"
-version = "3.13.0"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
+checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "bytecount"
-version = "0.6.3"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c676a478f63e9fa2dd5368a42f28bba0d6c560b775f38583c8bbaa7fcd67c9c"
+checksum = "5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce"
 
 [[package]]
 name = "bytemuck"
-version = "1.18.0"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bbb0ad554ad961ddc5da507a12a29b14e4ae5bda06b19f575a3e6079d2e2ae"
+checksum = "b6b1fc10dbac614ebc03540c9dbd60e83887fda27794998c6528f1782047d540"
 
 [[package]]
 name = "byteorder"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
-
-[[package]]
-name = "cc"
-version = "1.0.82"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "305fe645edc1442a0fa8b6726ba61d422798d37a52e12eaecf4b022ebbb88f01"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "cfg-if"
@@ -161,9 +167,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "ciborium"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "effd91f6c78e5a4ace8a5d3c0b6bfaec9e2baaef55f3efc00e45fb2e477ee926"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
 dependencies = [
  "ciborium-io",
  "ciborium-ll",
@@ -172,15 +178,15 @@ dependencies = [
 
 [[package]]
 name = "ciborium-io"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdf919175532b369853f5d5e20b26b43112613fd6fe7aee757e35f7a44642656"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
 
 [[package]]
 name = "ciborium-ll"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defaa24ecc093c77630e6c15e17c51f5e187bf35ee514f4e2d67baaa96dae22b"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
  "half",
@@ -188,9 +194,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.4"
+version = "4.5.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
+checksum = "027bb0d98429ae334a8698531da7077bdf906419543a35a55c2cb1b66437d767"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -198,9 +204,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.2"
+version = "4.5.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
+checksum = "5589e0cba072e0f3d23791efac0fd8627b49c829c196a492e88168e6a669d863"
 dependencies = [
  "anstream",
  "anstyle",
@@ -210,38 +216,38 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.4"
+version = "4.5.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
+checksum = "bf4ced95c6f4a675af3da73304b9ac4ed991640c36374e4b46795c49e17cf1ed"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.99",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.0"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.0"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "console"
-version = "0.15.7"
+version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c926e00cc70edefdc64d3a5ff31cc65bb97a3460097762bd23afb4d8145fccf8"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
 dependencies = [
  "encode_unicode",
- "lazy_static",
  "libc",
- "windows-sys 0.45.0",
+ "once_cell",
+ "windows-sys",
 ]
 
 [[package]]
@@ -281,46 +287,47 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-channel"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-deque"
-version = "0.8.3"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
 dependencies = [
- "cfg-if",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.15"
+version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
- "autocfg",
- "cfg-if",
  "crossbeam-utils",
- "memoffset",
- "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.16"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
+
+[[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
 dependencies = [
  "cfg-if",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -340,54 +347,43 @@ checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "dot-writer"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d1b11bd5e7e98406c6ff39fbc94d6e910a489b978ce7f17c19fce91a1195b7a"
+checksum = "a2f7a508d3f95b7cb559acf2231c7efad02fe04061d3165b12513c2dbcc77af0"
 
 [[package]]
 name = "either"
-version = "1.9.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+checksum = "b7914353092ddf589ad78f25c5c1c21b7f80b0ff8621e7c814c3485b5306da9d"
 
 [[package]]
 name = "encode_unicode"
-version = "0.3.6"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.2"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b30f669a7961ef1631673d2766cc92f52d64f7ef354d4fe0ddfd30ed52f0f4f"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
- "errno-dragonfly",
  "libc",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
+ "windows-sys",
 ]
 
 [[package]]
 name = "fastrand"
-version = "2.0.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fixedbitset"
@@ -402,10 +398,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "futures"
-version = "0.3.28"
+name = "foldhash"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
+checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
+
+[[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -418,9 +420,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.28"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -428,15 +430,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.28"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.28"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -445,44 +447,44 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.28"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.28"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.99",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.28"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
-version = "0.3.28"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-timer"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
-version = "0.3.28"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -498,32 +500,59 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.10"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.13.3+wasi-0.2.2",
+ "windows-targets",
 ]
 
 [[package]]
 name = "glob"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "half"
-version = "1.8.2"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
+checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+]
 
 [[package]]
 name = "hashbrown"
-version = "0.14.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "heck"
@@ -539,54 +568,76 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
+checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
 name = "indexmap"
-version = "2.2.6"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
 name = "indoc"
-version = "2.0.4"
+version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8"
+checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
 
 [[package]]
 name = "insta"
-version = "1.37.0"
+version = "1.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1718b3f2b85bb5054baf8ce406e36401f27c3169205f4175504c4b1d98252d3f"
+checksum = "50259abbaa67d11d2bcafc7ba1d094ed7a0c70e3ce893f0d0997f73558cb3084"
 dependencies = [
  "console",
- "lazy_static",
  "linked-hash-map",
+ "once_cell",
+ "pin-project",
  "similar",
 ]
 
 [[package]]
-name = "inventory"
-version = "0.3.15"
+name = "internment"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f958d3d68f4167080a18141e10381e7634563984a537f2a49a30fd8e53ac5767"
+checksum = "636d4b0f6a39fd684effe2a73f5310df16a3fa7954c26d36833e98f44d1977a2"
+dependencies = [
+ "ahash",
+ "dashmap",
+ "hashbrown 0.15.2",
+ "once_cell",
+]
+
+[[package]]
+name = "inventory"
+version = "0.3.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab08d7cd2c5897f2c949e5383ea7c7db03fb19130ffcfbf7eda795137ae3cb83"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "is-terminal"
-version = "0.4.9"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
+checksum = "e19b23d53f35ce9f56aebc7d1bb4e6ac1e9c0db7ac85c8d1760c04379edced37"
 dependencies = [
  "hermit-abi",
- "rustix",
- "windows-sys 0.48.0",
+ "libc",
+ "windows-sys",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
@@ -608,39 +659,40 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.9"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.64"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "lazy_static"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "lexical"
-version = "7.0.1"
+version = "7.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecd3381ac77c22d4e2607284ac71e44b21c21bd3785ee807d21976d54ee16f9"
+checksum = "70ed980ff02623721dc334b9105150b66d0e1f246a92ab5a2eca0335d54c48f6"
 dependencies = [
  "lexical-core",
 ]
 
 [[package]]
 name = "lexical-core"
-version = "1.0.1"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0885f6cdfe75c96e45bbf1c4e49511f128201391ce3b56e60e29f5a1fadbc1c1"
+checksum = "b765c31809609075565a70b4b71402281283aeda7ecaf4818ac14a7b2ade8958"
 dependencies = [
  "lexical-parse-float",
  "lexical-parse-integer",
@@ -651,9 +703,9 @@ dependencies = [
 
 [[package]]
 name = "lexical-parse-float"
-version = "1.0.1"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "924f7ec090cd4f60bd873f160b0fb69a0c80bb3a98f2e778a1893ae0e5c4b0b9"
+checksum = "de6f9cb01fb0b08060209a057c048fcbab8717b4c1ecd2eac66ebfe39a65b0f2"
 dependencies = [
  "lexical-parse-integer",
  "lexical-util",
@@ -662,9 +714,9 @@ dependencies = [
 
 [[package]]
 name = "lexical-parse-integer"
-version = "1.0.1"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8feab1da84a2ab0ddbbad2fb1830b755f71a9a8d996c7a1f2a553faf72aa3686"
+checksum = "72207aae22fc0a121ba7b6d479e42cbfea549af1479c3f3a4f12c70dd66df12e"
 dependencies = [
  "lexical-util",
  "static_assertions",
@@ -672,18 +724,18 @@ dependencies = [
 
 [[package]]
 name = "lexical-util"
-version = "1.0.2"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "591ce1a12ecd3b26d4121ab360a6a4483a67f05a5372add6acbfd0b65c9285d9"
+checksum = "5a82e24bf537fd24c177ffbbdc6ebcc8d54732c35b50a3f28cc3f4e4c949a0b3"
 dependencies = [
  "static_assertions",
 ]
 
 [[package]]
 name = "lexical-write-float"
-version = "1.0.1"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b0f3f9ddada5942b54e97654d535df37c9340ad66c24b50360a90619779f41"
+checksum = "c5afc668a27f460fb45a81a757b6bf2f43c2d7e30cb5a2dcd3abf294c78d62bd"
 dependencies = [
  "lexical-util",
  "lexical-write-integer",
@@ -692,9 +744,9 @@ dependencies = [
 
 [[package]]
 name = "lexical-write-integer"
-version = "1.0.1"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c6d47254ddb292771dce7697ae2be9619f8e369d01a9ccda15ef2ff50443fc"
+checksum = "629ddff1a914a836fb245616a7888b62903aae58fa771e1d83943035efa0f978"
 dependencies = [
  "lexical-util",
  "static_assertions",
@@ -702,15 +754,15 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.147"
+version = "0.2.170"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
 
 [[package]]
 name = "libm"
-version = "0.2.7"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
+checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
 
 [[package]]
 name = "linked-hash-map"
@@ -720,15 +772,15 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.5"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "lock_api"
-version = "0.4.10"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -736,15 +788,15 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.19"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
+checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
 
 [[package]]
 name = "matrixmultiply"
-version = "0.3.7"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "090126dc04f95dc0d1c1c91f61bdd474b3930ca064c1edc8a849da2c6cbe1e77"
+checksum = "9380b911e3e96d10c1f415da0876389aaf1b56759054eeb0de7df940c456ba1a"
 dependencies = [
  "autocfg",
  "rawpointer",
@@ -752,15 +804,15 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "memoffset"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
 ]
@@ -826,9 +878,9 @@ dependencies = [
 
 [[package]]
 name = "nom_locate"
-version = "4.1.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e299bf5ea7b212e811e71174c5d1a5d065c4c0ad0c8691ecb1f97e3e66025e"
+checksum = "1e3c83c053b0713da60c5b8de47fe8e494fe3ece5267b2f23090a07a053ba8f3"
 dependencies = [
  "bytecount",
  "memchr",
@@ -852,21 +904,19 @@ checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-integer"
-version = "0.1.45"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "autocfg",
  "num-traits",
 ]
 
 [[package]]
 name = "num-rational"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
 dependencies = [
- "autocfg",
  "num-integer",
  "num-traits",
 ]
@@ -879,16 +929,6 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
-dependencies = [
- "hermit-abi",
- "libc",
 ]
 
 [[package]]
@@ -908,21 +948,21 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.18.0"
+version = "1.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
 
 [[package]]
 name = "oorandom"
-version = "11.1.3"
+version = "11.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -930,38 +970,58 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.8"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.48.1",
+ "windows-targets",
 ]
 
 [[package]]
 name = "paste"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "petgraph"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
  "indexmap",
 ]
 
 [[package]]
-name = "pin-project-lite"
-version = "0.2.11"
+name = "pin-project"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c516611246607d0c04186886dbb3a754368ef82c79e9827a802c6d836dd111c"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.99",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "pin-utils"
@@ -971,9 +1031,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "plotters"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2c224ba00d7cadd4d5c660deaf2098e5e80e07846537c51f9cfa4be50c1fd45"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
 dependencies = [
  "num-traits",
  "plotters-backend",
@@ -984,24 +1044,24 @@ dependencies = [
 
 [[package]]
 name = "plotters-backend"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e76628b4d3a7581389a35d5b6e2139607ad7c75b17aed325f210aa91f4a9609"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
 
 [[package]]
 name = "plotters-svg"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38f6d39893cca0701371e3c27294f09797214b86f1fb951b89ade8ec04e2abab"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
 ]
 
 [[package]]
 name = "portable-atomic"
-version = "1.6.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
+checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
 
 [[package]]
 name = "powerfmt"
@@ -1011,15 +1071,18 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.17"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "pretty_assertions"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af7cee1a6c8a5b9208b3cb1061f10c0cb689087b3d8ce85fb9d2dd7a29b6ba66"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
 dependencies = [
  "diff",
  "yansi",
@@ -1027,28 +1090,28 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.78"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "proptest"
-version = "1.2.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e35c06b98bf36aba164cc17cb25f7e232f5c4aeea73baa14b8a9f0d92dbfa65"
+checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
 dependencies = [
  "bit-set",
- "bitflags 1.3.2",
- "byteorder",
+ "bit-vec",
+ "bitflags",
  "lazy_static",
  "num-traits",
  "rand",
  "rand_chacha",
  "rand_xorshift",
- "regex-syntax 0.6.29",
+ "regex-syntax",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -1062,7 +1125,7 @@ checksum = "4ee1c9ac207483d5e7db4940700de86a9aae46ef90c48b57f99fe7edb8345e49"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -1115,7 +1178,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -1128,7 +1191,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-build-config",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -1139,7 +1202,7 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quil-cli"
-version = "0.7.0"
+version = "0.7.2-rc.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1148,9 +1211,10 @@ dependencies = [
 
 [[package]]
 name = "quil-py"
-version = "0.15.2"
+version = "0.15.4-rc.0"
 dependencies = [
  "indexmap",
+ "internment",
  "ndarray",
  "num-complex",
  "numpy",
@@ -1163,7 +1227,7 @@ dependencies = [
 
 [[package]]
 name = "quil-rs"
-version = "0.30.0"
+version = "0.30.2-rc.0"
 dependencies = [
  "approx",
  "clap",
@@ -1171,6 +1235,7 @@ dependencies = [
  "dot-writer",
  "indexmap",
  "insta",
+ "internment",
  "itertools 0.12.1",
  "lexical",
  "ndarray",
@@ -1194,9 +1259,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.35"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+checksum = "c1f1914ce909e1658d9907913b4b91947430c7d9be598b15a1912935b8c04801"
 dependencies = [
  "proc-macro2",
 ]
@@ -1228,7 +1293,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
 ]
 
 [[package]]
@@ -1264,9 +1329,9 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
-version = "1.7.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
 dependencies = [
  "either",
  "rayon-core",
@@ -1274,73 +1339,65 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.11.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
- "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-utils",
- "num_cpus",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.3.5"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+checksum = "0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
 ]
 
 [[package]]
 name = "regex"
-version = "1.9.3"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81bc1d4caf89fac26a70747fe603c130093b53c773888797a6329091246d651a"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata",
- "regex-syntax 0.7.4",
+ "regex-syntax",
 ]
 
 [[package]]
 name = "regex-automata"
-version = "0.3.6"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed1ceff11a1dddaee50c9dc8e4938bd106e9d89ae372f192311e7da498e3b69"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.7.4",
+ "regex-syntax",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.29"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
-
-[[package]]
-name = "regex-syntax"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "relative-path"
-version = "1.8.0"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bf2521270932c3c7bed1a59151222bd7643c79310f2916f01925e1e16255698"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "rigetti-pyo3"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402e7e159c1a8b5fcd0a2bb7c9b6d50b25f9380a0ecb83930c1e907e3a9737db"
+version = "0.4.2"
+source = "git+https://github.com/rigetti/rigetti-pyo3.git?branch=interning#adeda74b62494178bc56c995cb6e08487f89f919"
 dependencies = [
  "indexmap",
+ "internment",
  "num-complex",
  "num-traits",
  "paste",
@@ -1373,7 +1430,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn 2.0.48",
+ "syn 2.0.99",
  "unicode-ident",
 ]
 
@@ -1385,31 +1442,31 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc_version"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
 ]
 
 [[package]]
 name = "rustix"
-version = "0.38.7"
+version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "172891ebdceb05aa0005f533a6cbfca599ddd7d966f6f5d4d9b2e70478e70399"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.3.3",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
 name = "rustversion"
-version = "1.0.14"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
 name = "rusty-fork"
@@ -1425,15 +1482,15 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.15"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "safe_arch"
-version = "0.7.1"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f398075ce1e6a179b46f51bd88d0598b92b00d3551f1a2d4ac49e771b56ac354"
+checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
 dependencies = [
  "bytemuck",
 ]
@@ -1455,37 +1512,38 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
-version = "1.0.18"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "serde"
-version = "1.0.197"
+version = "1.0.218"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
+checksum = "e8dfc9d19bdbf6d17e22319da49161d5d0108e4188e8b680aef6299eed22df60"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.197"
+version = "1.0.218"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
+checksum = "f09503e191f4e797cb8aac08e9a4a4695c5edf6a2e70e376d961ddd5c969f82b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.99",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.104"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "076066c5f1078eac5b722a31827a8832fe108bed65dfa75e233c89f8206e976c"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]
@@ -1505,24 +1563,24 @@ dependencies = [
 
 [[package]]
 name = "similar"
-version = "2.2.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "420acb44afdae038210c99e69aae24109f32f15500aa708e81d46c9f29d55fcf"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "slab"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
 
 [[package]]
 name = "static_assertions"
@@ -1532,9 +1590,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "statrs"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d08e5e1748192713cc281da8b16924fb46be7b0c2431854eadc785823e5696e"
+checksum = "b35a062dbadac17a42e0fc64c27f419b25d6fae98572eb43c8814c9e873d7721"
 dependencies = [
  "approx",
  "lazy_static",
@@ -1545,30 +1603,30 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.26.1"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "723b93e8addf9aa965ebe2d11da6d7540fa2283fcea14b3371ff055f7ba13f5f"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.26.1"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a3417fc93d76740d974a01654a09777cb500428cc874ca9f45edfe0c4d4cd18"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.48",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -1584,9 +1642,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.48"
+version = "2.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
+checksum = "e02e925281e18ffd9d640e234264753c43edc62d64b2d4cf898f1bc5e75f3fc2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1595,48 +1653,49 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.11"
+version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d0e916b1148c8e263850e1ebcbd046f333e0683c724876bb0da63ea4373dc8a"
+checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tempfile"
-version = "3.7.1"
+version = "3.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc02fddf48964c42031a0b3fe0428320ecf3a73c401040fc0096f97794310651"
+checksum = "22e5a0acb1f3f55f65cc4a866c361b2fb2a0ff6366785ae6fbb5f85df07ba230"
 dependencies = [
  "cfg-if",
  "fastrand",
- "redox_syscall",
+ "getrandom 0.3.1",
+ "once_cell",
  "rustix",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.56"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.56"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.99",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.36"
+version = "0.3.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
 dependencies = [
  "deranged",
  "num-conv",
@@ -1663,9 +1722,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "unarray"
@@ -1675,36 +1734,42 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.11"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "unindent"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7de7d73e1754487cb58364ee906a499937a0dfabd86bcb980fa99ec8c8fa2ce"
+checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "utf8parse"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wait-timeout"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "walkdir"
-version = "2.3.3"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
@@ -1717,35 +1782,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.87"
+name = "wasi"
+version = "0.13.3+wasi-0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
+checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
+ "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.87"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.99",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.87"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1753,28 +1828,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.87"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.99",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.87"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "web-sys"
-version = "0.3.64"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1782,245 +1860,128 @@ dependencies = [
 
 [[package]]
 name = "wide"
-version = "0.7.16"
+version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81a1851a719f11d1d2fea40e15c72f6c00de8c142d7ac47c1441cc7e4d0d5bc6"
+checksum = "41b5576b9a81633f3e8df296ce0063042a73507636cbe956c61133dd7034ab22"
 dependencies = [
  "bytemuck",
  "safe_arch",
 ]
 
 [[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
 name = "winapi-util"
-version = "0.1.5"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "winapi",
-]
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
+ "windows-sys",
 ]
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.48.1",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.4",
+ "windows-targets",
 ]
 
 [[package]]
 name = "windows-targets"
-version = "0.42.2"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.0",
- "windows_aarch64_msvc 0.48.0",
- "windows_i686_gnu 0.48.0",
- "windows_i686_msvc 0.48.0",
- "windows_x86_64_gnu 0.48.0",
- "windows_x86_64_gnullvm 0.48.0",
- "windows_x86_64_msvc 0.48.0",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
-dependencies = [
- "windows_aarch64_gnullvm 0.52.4",
- "windows_aarch64_msvc 0.52.4",
- "windows_i686_gnu 0.52.4",
- "windows_i686_msvc 0.52.4",
- "windows_x86_64_gnu 0.52.4",
- "windows_x86_64_gnullvm 0.52.4",
- "windows_x86_64_msvc 0.52.4",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.2"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.48.0"
+name = "windows_i686_gnullvm"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.2"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.2"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.0"
+name = "wit-bindgen-rt"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
+checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "yansi"
-version = "0.5.1"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.99",
+]

--- a/deny.toml
+++ b/deny.toml
@@ -26,6 +26,7 @@ allow = [
   "BSD-3-Clause",
   "MIT",
   "Unicode-DFS-2016",
+  "Zlib",
 ]
 # The confidence threshold for detecting a license from license text.
 # The higher the value, the more closely the license text must be to the

--- a/deny.toml
+++ b/deny.toml
@@ -19,6 +19,7 @@ db-urls = ["https://github.com/rustsec/advisory-db"]
 # More documentation for the licenses section can be found here:
 # https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html
 [licenses]
+unused-allowed-license = "allow"
 allow = [
   "Apache-2.0",
   "Apache-2.0 WITH LLVM-exception",

--- a/deny.toml
+++ b/deny.toml
@@ -27,6 +27,7 @@ allow = [
   "BSD-3-Clause",
   "MIT",
   "Unicode-DFS-2016",
+  "Unicode-3.0",
   "Zlib",
 ]
 # The confidence threshold for detecting a license from license text.

--- a/deny.toml
+++ b/deny.toml
@@ -58,6 +58,7 @@ skip-tree = [
   { name = "redox_syscall", version = "*" },  # proptest and pyo3 rely on two versions of this
   { name = "itertools", version = "*" },      # proptest relies on an older version of itertools than we use
   { name = "heck", version = "*" },           # conflicting dependency with pyo3 and clap
+  { name = "hashbrown", version = "*" },      # conflicting versions between indexmap and (indirectly) dashmap
 ]
 
 # This section is considered when running `cargo deny check sources`.

--- a/quil-py/Cargo.toml
+++ b/quil-py/Cargo.toml
@@ -27,7 +27,7 @@ strum.workspace = true
 # pyo3 dependencies should be updated together
 numpy = "0.20.0"
 pyo3 = { version = "0.20.3", features = ["indexmap"] }
-rigetti-pyo3 = { git = "https://github.com/rigetti/rigetti-pyo3.git", branch = "interning", features = ["indexmap"] }
+rigetti-pyo3 = { version = "0.4.3", features = ["indexmap"] }
 indexmap.workspace = true
 num-complex = "0.4.6"
 internment = { version = "0.8.6", features = ["arc"] }

--- a/quil-py/Cargo.toml
+++ b/quil-py/Cargo.toml
@@ -27,9 +27,10 @@ strum.workspace = true
 # pyo3 dependencies should be updated together
 numpy = "0.20.0"
 pyo3 = { version = "0.20.3", features = ["indexmap"] }
-rigetti-pyo3 = {version = "0.3.4", features = ["indexmap"]}
+rigetti-pyo3 = { git = "https://github.com/rigetti/rigetti-pyo3.git", branch = "interning", features = ["indexmap"] }
 indexmap.workspace = true
 num-complex = "0.4.6"
+internment = { version = "0.8.6", features = ["arc"] }
 
 [build-dependencies]
 pyo3-build-config = "0.20.0"

--- a/quil-py/src/expression.rs
+++ b/quil-py/src/expression.rs
@@ -18,6 +18,8 @@ use rigetti_pyo3::{
     wrap_error, PyTryFrom, PyWrapper, PyWrapperMut, ToPython, ToPythonError,
 };
 
+use internment::ArcIntern;
+
 use crate::{impl_eq, impl_to_quil, instruction::PyMemoryReference};
 
 wrap_error!(RustEvaluationError(quil_rs::expression::EvaluationError));
@@ -110,7 +112,7 @@ py_wrap_data_struct! {
     #[derive(Debug)]
     PyFunctionCallExpression(FunctionCallExpression) as "FunctionCallExpression" {
         function: ExpressionFunction => PyExpressionFunction,
-        expression: Box<Expression> => PyExpression
+        expression: ArcIntern<Expression> => PyExpression
     }
 }
 impl_repr!(PyFunctionCallExpression);
@@ -125,7 +127,7 @@ impl PyFunctionCallExpression {
     ) -> PyResult<Self> {
         Ok(PyFunctionCallExpression(FunctionCallExpression::new(
             ExpressionFunction::py_try_from(py, &function)?,
-            Box::<Expression>::py_try_from(py, &expression)?,
+            ArcIntern::<Expression>::py_try_from(py, &expression)?,
         )))
     }
 }
@@ -134,9 +136,9 @@ py_wrap_data_struct! {
     #[derive(Debug)]
     #[pyo3(subclass)]
     PyInfixExpression(InfixExpression) as "InfixExpression" {
-        left: Box<Expression> => PyExpression,
+        left: ArcIntern<Expression> => PyExpression,
         operator: InfixOperator => PyInfixOperator,
-        right: Box<Expression> => PyExpression
+        right: ArcIntern<Expression> => PyExpression
     }
 }
 impl_repr!(PyInfixExpression);
@@ -151,9 +153,9 @@ impl PyInfixExpression {
         right: PyExpression,
     ) -> PyResult<Self> {
         Ok(PyInfixExpression(InfixExpression::new(
-            Box::<Expression>::py_try_from(py, &left)?,
+            ArcIntern::<Expression>::py_try_from(py, &left)?,
             InfixOperator::py_try_from(py, &operator)?,
-            Box::<Expression>::py_try_from(py, &right)?,
+            ArcIntern::<Expression>::py_try_from(py, &right)?,
         )))
     }
 }
@@ -163,7 +165,7 @@ py_wrap_data_struct! {
     #[pyo3(subclass)]
     PyPrefixExpression(PrefixExpression) as "PrefixExpression" {
         operator: PrefixOperator => PyPrefixOperator,
-        expression: Box<Expression> => PyExpression
+        expression: ArcIntern<Expression> => PyExpression
     }
 }
 
@@ -177,7 +179,7 @@ impl PyPrefixExpression {
     ) -> PyResult<Self> {
         Ok(PyPrefixExpression(PrefixExpression::new(
             PrefixOperator::py_try_from(py, &operator)?,
-            Box::<Expression>::py_try_from(py, &expression)?,
+            ArcIntern::<Expression>::py_try_from(py, &expression)?,
         )))
     }
 }

--- a/quil-rs/Cargo.toml
+++ b/quil-rs/Cargo.toml
@@ -27,6 +27,7 @@ thiserror = "1.0.56"
 indexmap.workspace = true
 statrs = "0.16.0"
 internment = { version = "0.8.6", features = ["arc"] }
+paste = "1.0.15"
 
 [dev-dependencies]
 clap = { version = "4.3.19", features = ["derive", "string"] }

--- a/quil-rs/Cargo.toml
+++ b/quil-rs/Cargo.toml
@@ -26,6 +26,7 @@ strum.workspace = true
 thiserror = "1.0.56"
 indexmap.workspace = true
 statrs = "0.16.0"
+internment = { version = "0.8.6", features = ["arc"] }
 
 [dev-dependencies]
 clap = { version = "4.3.19", features = ["derive", "string"] }

--- a/quil-rs/src/expression/mod.rs
+++ b/quil-rs/src/expression/mod.rs
@@ -32,7 +32,9 @@ use std::{
     fmt,
     hash::{Hash, Hasher},
     num::NonZeroI32,
-    ops::{Add, AddAssign, BitXor, BitXorAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign},
+    ops::{
+        Add, AddAssign, BitXor, BitXorAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign,
+    },
     str::FromStr,
 };
 
@@ -262,6 +264,17 @@ impl_expr_op!(Add, AddAssign, add, add_assign, Plus);
 impl_expr_op!(Sub, SubAssign, sub, sub_assign, Minus);
 impl_expr_op!(Mul, MulAssign, mul, mul_assign, Star);
 impl_expr_op!(Div, DivAssign, div, div_assign, Slash);
+
+impl Neg for Expression {
+    type Output = Self;
+
+    fn neg(self) -> Self {
+        Expression::Prefix(PrefixExpression {
+            operator: PrefixOperator::Minus,
+            expression: ArcIntern::new(self),
+        })
+    }
+}
 
 /// Compute the result of an infix expression where both operands are complex.
 #[inline]

--- a/quil-rs/src/expression/mod.rs
+++ b/quil-rs/src/expression/mod.rs
@@ -216,8 +216,39 @@ macro_rules! impl_expr_op {
                 })
             }
         }
+
+        impl $name<ArcIntern<Expression>> for Expression {
+            type Output = Self;
+            fn $function(self, other: ArcIntern<Expression>) -> Self {
+                Expression::Infix(InfixExpression {
+                    left: ArcIntern::new(self),
+                    operator: InfixOperator::$operator,
+                    right: other,
+                })
+            }
+        }
+
+        impl $name<Expression> for ArcIntern<Expression> {
+            type Output = Expression;
+            fn $function(self, other: Expression) -> Expression {
+                Expression::Infix(InfixExpression {
+                    left: self,
+                    operator: InfixOperator::$operator,
+                    right: ArcIntern::new(other),
+                })
+            }
+        }
+
         impl $name_assign for Expression {
             fn $function_assign(&mut self, other: Self) {
+                // Move out of self to avoid potentially cloning a large value
+                let temp = ::std::mem::replace(self, Self::PiConstant);
+                *self = temp.$function(other);
+            }
+        }
+
+        impl $name_assign<ArcIntern<Expression>> for Expression {
+            fn $function_assign(&mut self, other: ArcIntern<Expression>) {
                 // Move out of self to avoid potentially cloning a large value
                 let temp = ::std::mem::replace(self, Self::PiConstant);
                 *self = temp.$function(other);

--- a/quil-rs/src/expression/mod.rs
+++ b/quil-rs/src/expression/mod.rs
@@ -238,7 +238,7 @@ macro_rules! impl_expr_op {
         impl $name for Expression {
             type Output = Self;
             fn $function(self, other: Self) -> Self {
-                Expression::Infix(InfixExpression {
+                Self::Infix(InfixExpression {
                     left: ArcIntern::new(self),
                     operator: InfixOperator::$operator,
                     right: ArcIntern::new(other),
@@ -249,7 +249,7 @@ macro_rules! impl_expr_op {
         impl $name<ArcIntern<Expression>> for Expression {
             type Output = Self;
             fn $function(self, other: ArcIntern<Expression>) -> Self {
-                Expression::Infix(InfixExpression {
+                Self::Infix(InfixExpression {
                     left: ArcIntern::new(self),
                     operator: InfixOperator::$operator,
                     right: other,

--- a/quil-rs/src/expression/simplification/by_hand.rs
+++ b/quil-rs/src/expression/simplification/by_hand.rs
@@ -54,6 +54,7 @@ struct Simplifier {
     size_cache: HashMap<ArcIntern<Expression>, usize>,
 }
 
+/// Useful for debugging
 fn debug_cache<V, D: std::fmt::Display, W: std::io::Write>(
     cache_name: &str,
     cache: &HashMap<ArcIntern<Expression>, V>,
@@ -78,6 +79,7 @@ impl Simplifier {
         }
     }
 
+    /// Useful for debugging
     #[allow(dead_code)]
     fn debug_caches(&self, w: &mut impl std::io::Write) -> std::io::Result<()> {
         self.debug_simplify_cache(w)?;
@@ -86,6 +88,7 @@ impl Simplifier {
         Ok(())
     }
 
+    /// Useful for debugging
     fn debug_simplify_cache(&self, w: &mut impl std::io::Write) -> std::io::Result<()> {
         use crate::quil::Quil as _;
         debug_cache(
@@ -96,6 +99,7 @@ impl Simplifier {
         )
     }
 
+    /// Useful for debugging
     fn debug_size_cache(&self, w: &mut impl std::io::Write) -> std::io::Result<()> {
         debug_cache("Size", &self.size_cache, |v| *v, w)
     }
@@ -661,20 +665,18 @@ impl Simplifier {
 
             // Mul inside Div on left with cancellation: (a * b) / a = (b * a) / a = b
             (
-                Expression::Infix(InfixExpression {
-                    left: same,
-                    operator: InfixOperator::Star,
-                    right: other,
-                }),
-                InfixOperator::Slash,
-                _,
-            )
-            | (
-                Expression::Infix(InfixExpression {
-                    left: other,
-                    operator: InfixOperator::Star,
-                    right: same,
-                }),
+                Expression::Infix(
+                    InfixExpression {
+                        left: same,
+                        operator: InfixOperator::Star,
+                        right: other,
+                    }
+                    | InfixExpression {
+                        left: other,
+                        operator: InfixOperator::Star,
+                        right: same,
+                    },
+                ),
                 InfixOperator::Slash,
                 _,
             ) if &right == same => other.clone(),

--- a/quil-rs/src/expression/simplification/by_hand.rs
+++ b/quil-rs/src/expression/simplification/by_hand.rs
@@ -48,6 +48,7 @@ impl std::ops::Sub<u64> for Limit {
     }
 }
 
+#[derive(Debug, Clone)]
 struct Simplifier {
     memo_table: HashMap<ArcIntern<Expression>, ArcIntern<Expression>>,
 }
@@ -57,6 +58,23 @@ impl Simplifier {
         Self {
             memo_table: HashMap::new(),
         }
+    }
+
+    #[allow(dead_code)]
+    fn debug_memo_table(&self, w: &mut impl std::io::Write) -> std::io::Result<()> {
+        use crate::quil::Quil as _;
+
+        writeln!(w, "Simplifier memo table:")?;
+        for (k, v) in &self.memo_table {
+            writeln!(
+                w,
+                "    {} => {}",
+                k.to_quil_or_debug(),
+                v.to_quil_or_debug(),
+            )?
+        }
+
+        Ok(())
     }
 
     /// Recursively simplify an [`Expression`] by hand, breaking into cases to make things more

--- a/quil-rs/src/expression/simplification/by_hand.rs
+++ b/quil-rs/src/expression/simplification/by_hand.rs
@@ -1,13 +1,20 @@
-/// Complex machinery for simplifying [`Expression`]s.
+//! Complex machinery for simplifying [`Expression`]s.
+
+use std::{cmp::min_by_key, collections::HashMap};
+
+use internment::ArcIntern;
+
 use crate::expression::{
-    imag, real, Expression, ExpressionFunction, FunctionCallExpression, InfixExpression,
-    InfixOperator, PrefixExpression, PrefixOperator,
+    calculate_function, calculate_infix, interned, real, Expression, ExpressionFunction,
+    FunctionCallExpression, InfixExpression, InfixOperator, PrefixExpression, PrefixOperator,
 };
-use std::cmp::min_by_key;
 
 /// Simplify an [`Expression`].
-pub(super) fn run(expression: &Expression) -> Expression {
-    simplify(expression, LIMIT)
+pub fn run(expression: &Expression) -> Expression {
+    Simplifier::new()
+        .simplify(ArcIntern::new(expression.clone()), LIMIT)
+        .as_ref()
+        .clone()
 }
 
 /// Keep stack sizes under control
@@ -17,74 +24,91 @@ pub(super) fn run(expression: &Expression) -> Expression {
 /// crash with an "I've overflowed my stack" error. Except for exceedingly large expressions
 /// (`the_big_one` test case in `mod.rs`, for example), a larger limit here doesn't seem to be of
 /// practical value in anecdotal testing.
-const LIMIT: u64 = 10;
+const LIMIT: Limit = Limit(10);
 
-/// Recursively simplify an [`Expression`] by hand, breaking into cases to make things more
-/// manageable.
-fn simplify(e: &Expression, limit: u64) -> Expression {
-    if limit == 0 {
-        // bail
-        e.clone()
-    } else {
-        match e {
+/// We use a separate type for the limit so that we can enforce the use of saturating subtraction,
+/// but we don't use [`std::num::Saturating`] so that we can write that in terms of literals.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(transparent)]
+struct Limit(u64);
+
+impl std::cmp::PartialEq<u64> for Limit {
+    #[inline(always)]
+    fn eq(&self, other: &u64) -> bool {
+        self.0 == *other
+    }
+}
+
+impl std::ops::Sub<u64> for Limit {
+    type Output = Self;
+
+    #[inline(always)]
+    fn sub(self, rhs: u64) -> Self::Output {
+        Limit(self.0.saturating_sub(rhs))
+    }
+}
+
+struct Simplifier {
+    memo_table: HashMap<ArcIntern<Expression>, ArcIntern<Expression>>,
+}
+
+impl Simplifier {
+    fn new() -> Self {
+        Self {
+            memo_table: HashMap::new(),
+        }
+    }
+
+    /// Recursively simplify an [`Expression`] by hand, breaking into cases to make things more
+    /// manageable.  Terminates the simplification when `limit` reaches `0`.
+    ///
+    /// The `limit` decreases whenever we take a step deeper within the expression.  The special
+    /// case simplification functions, the ones that do all the work, don't need to decrement the
+    /// limit at the top of the function.
+    ///
+    /// Invariant: Never returns [`Expression::PiConstant`].
+    fn simplify(&mut self, e: ArcIntern<Expression>, limit: Limit) -> ArcIntern<Expression> {
+        if let Some(simplified) = self.memo_table.get(&e) {
+            return simplified.clone();
+        }
+
+        let result = match e.as_ref() {
+            // Even at a limit of 0, replace `pi` with 3.14….  This gets us the extremely useful
+            // invariant that `Expression::PiConstant` can never be returned from `simplify`.
+            Expression::PiConstant => ArcIntern::new(Expression::Number(PI)),
+
+            // We're out of gas; this is as simplified as things get
+            _ if limit == 0 => e.clone(),
+
+            // Atoms don't need to be simplified
             Expression::Address(_) | Expression::Number(_) | Expression::Variable(_) => e.clone(),
+
+            // Simplify recursively
             Expression::FunctionCall(FunctionCallExpression {
                 function,
                 expression,
-            }) => simplify_function_call(*function, expression, limit - 1),
-            Expression::PiConstant => Expression::Number(std::f64::consts::PI.into()),
+            }) => self.simplify_function_call(*function, expression.clone(), limit - 1),
             Expression::Infix(InfixExpression {
                 left,
                 operator,
                 right,
-            }) => simplify_infix(left, *operator, right, limit - 1),
+            }) => self.simplify_infix(left.clone(), *operator, right.clone(), limit - 1),
             Expression::Prefix(PrefixExpression {
                 operator,
                 expression,
-            }) => simplify_prefix(*operator, expression, limit - 1),
-        }
+            }) => self.simplify_prefix(*operator, expression.clone(), limit - 1),
+        };
+
+        self.memo_table.insert(e, result.clone());
+
+        result
     }
 }
 
-const PI: num_complex::Complex64 = real!(std::f64::consts::PI);
 const ZERO: num_complex::Complex64 = real!(0.0);
 const ONE: num_complex::Complex64 = real!(1.0);
 const TWO: num_complex::Complex64 = real!(2.0);
-
-/// Simplify a function call inside an `Expression`, terminating the recursion if `limit` has reached zero.
-fn simplify_function_call(func: ExpressionFunction, expr: &Expression, limit: u64) -> Expression {
-    if limit == 0 {
-        // bail
-        Expression::FunctionCall(FunctionCallExpression {
-            function: func,
-            expression: expr.clone().into(),
-        })
-    } else {
-        // Evaluate numbers and π
-        // Pass through otherwise
-        match (func, simplify(expr, limit - 1)) {
-            (ExpressionFunction::Cis, Expression::Number(x)) => {
-                // num_complex::Complex64::cis only accepts f64
-                Expression::Number(x.cos() + imag!(1.0) * x.sin())
-            }
-            (ExpressionFunction::Cis, Expression::PiConstant) => Expression::Number(-ONE),
-            (ExpressionFunction::Cosine, Expression::Number(x)) => Expression::Number(x.cos()),
-            (ExpressionFunction::Cosine, Expression::PiConstant) => Expression::Number(-ONE),
-            (ExpressionFunction::Exponent, Expression::Number(x)) => Expression::Number(x.exp()),
-            (ExpressionFunction::Exponent, Expression::PiConstant) => Expression::Number(PI.exp()),
-            (ExpressionFunction::Sine, Expression::Number(x)) => Expression::Number(x.sin()),
-            (ExpressionFunction::Sine, Expression::PiConstant) => Expression::Number(PI.sin()),
-            (ExpressionFunction::SquareRoot, Expression::Number(x)) => Expression::Number(x.sqrt()),
-            (ExpressionFunction::SquareRoot, Expression::PiConstant) => {
-                Expression::Number(PI.sqrt())
-            }
-            (function, expression) => Expression::FunctionCall(FunctionCallExpression {
-                function,
-                expression: expression.into(),
-            }),
-        }
-    }
-}
+const PI: num_complex::Complex64 = real!(std::f64::consts::PI);
 
 #[inline]
 fn is_zero(x: num_complex::Complex64) -> bool {
@@ -97,8 +121,8 @@ fn is_one(x: num_complex::Complex64) -> bool {
 }
 
 /// Helper: in simplification, we'll bias towards smaller expressions
-fn size(expr: &Expression) -> usize {
-    match expr {
+fn size(expr: &ArcIntern<Expression>) -> usize {
+    match expr.as_ref() {
         Expression::Address(_)
         | Expression::Number(_)
         | Expression::PiConstant
@@ -119,189 +143,125 @@ fn size(expr: &Expression) -> usize {
     }
 }
 
-// It's verbose to go alone! Take this.
-macro_rules! infix {
-    ($left:expr, $op:expr, $right:expr) => {
-        Expression::Infix(InfixExpression {
-            left: $left.into(),
-            operator: $op,
-            right: $right.into(),
-        })
-    };
-}
-macro_rules! add {
-    ($left:expr, $right:expr) => {
-        infix!($left, InfixOperator::Plus, $right)
-    };
-}
-macro_rules! sub {
-    ($left:expr, $right:expr) => {
-        infix!($left, InfixOperator::Minus, $right)
-    };
-}
-macro_rules! mul {
-    ($left:expr, $right:expr) => {
-        infix!($left, InfixOperator::Star, $right)
-    };
-}
-macro_rules! div {
-    ($left:expr, $right:expr) => {
-        infix!($left, InfixOperator::Slash, $right)
-    };
-}
-
 /// Check if both arguments are of the form "something * x" for the _same_ x.
-fn mul_matches(left_ax: &Expression, right_ax: &Expression) -> bool {
-    match (left_ax, right_ax) {
+fn mul_matches(left_ax: &ArcIntern<Expression>, right_ax: &ArcIntern<Expression>) -> bool {
+    match (left_ax.as_ref(), right_ax.as_ref()) {
         (
             Expression::Infix(InfixExpression {
-                left: ref ll,
+                left: ll,
                 operator: InfixOperator::Star,
-                right: ref lr,
+                right: lr,
             }),
             Expression::Infix(InfixExpression {
-                left: ref rl,
+                left: rl,
                 operator: InfixOperator::Star,
-                right: ref rr,
+                right: rr,
             }),
         ) => ll == rl || ll == rr || lr == rl || lr == rr,
         _ => false,
     }
 }
 
-/// Simplify an infix expression inside an `Expression`, terminating the recursion if `limit` has reached
-/// zero.
-fn simplify_infix(l: &Expression, op: InfixOperator, r: &Expression, limit: u64) -> Expression {
-    if limit == 0 {
-        // bail
-        Expression::Infix(InfixExpression {
-            left: l.clone().into(),
-            operator: op,
-            right: r.clone().into(),
-        })
-    } else {
+impl Simplifier {
+    /// Simplify a function call inside an `Expression`.
+    fn simplify_function_call(
+        &mut self,
+        function: ExpressionFunction,
+        expression: ArcIntern<Expression>,
+        limit: Limit,
+    ) -> ArcIntern<Expression> {
+        // Evaluate numbers and π, pass through otherwise.  Since [`Self::simplify`] cannot return a
+        // literal π, we only need to worry about the number case
+        let expression = self.simplify(expression, limit);
+
+        if let Expression::Number(x) = expression.as_ref() {
+            interned::number(calculate_function(function, *x))
+        } else {
+            interned::function_call(function, expression)
+        }
+    }
+
+    /// Simplify an infix expression inside an `Expression`
+    fn simplify_infix(
+        &mut self,
+        left: ArcIntern<Expression>,
+        operator: InfixOperator,
+        right: ArcIntern<Expression>,
+        limit: Limit,
+    ) -> ArcIntern<Expression> {
+        let left = self.simplify(left, limit);
+        let right = self.simplify(right, limit);
+
         // There are … many cases here
-        match (simplify(l, limit - 1), op, simplify(r, limit - 1)) {
+        match (left.as_ref(), operator, right.as_ref()) {
             //----------------------------------------------------------------
             // First: only diving one deep, pattern matching on the operation
-            // (Constant folding and cancellations, mostly)
+            // (Constant folding and cancellations)
             //----------------------------------------------------------------
 
-            // Addition and Subtraction
+            // ## Addition and Subtraction ##
 
             // Adding with zero
-            (Expression::Number(x), InfixOperator::Plus, other)
-            | (other, InfixOperator::Plus, Expression::Number(x))
-                if is_zero(x) =>
-            {
-                other
-            }
-            // Adding numbers or π
-            (Expression::Number(x), InfixOperator::Plus, Expression::Number(y)) => {
-                Expression::Number(x + y)
-            }
-            (Expression::Number(x), InfixOperator::Plus, Expression::PiConstant)
-            | (Expression::PiConstant, InfixOperator::Plus, Expression::Number(x)) => {
-                Expression::Number(PI + x)
-            }
-            (Expression::PiConstant, InfixOperator::Plus, Expression::PiConstant) => {
-                Expression::Number(2.0 * PI)
-            }
+            (Expression::Number(x), InfixOperator::Plus, _) if is_zero(*x) => right,
+            (_, InfixOperator::Plus, Expression::Number(x)) if is_zero(*x) => left,
 
             // Subtracting with zero
-            (Expression::Number(x), InfixOperator::Minus, right) if is_zero(x) => {
-                simplify_prefix(PrefixOperator::Minus, &right, limit - 1)
+            (Expression::Number(x), InfixOperator::Minus, _) if is_zero(*x) => {
+                self.simplify(interned::neg(right), limit - 1)
             }
-            (left, InfixOperator::Minus, Expression::Number(y)) if is_zero(y) => left,
-            // Subtracting self
-            (left, InfixOperator::Minus, right) if left == right => Expression::Number(ZERO),
-            // Subtracting numbers or π (π - π already covered)
-            (Expression::Number(x), InfixOperator::Minus, Expression::Number(y)) => {
-                Expression::Number(x - y)
-            }
-            (Expression::Number(x), InfixOperator::Minus, Expression::PiConstant) => {
-                Expression::Number(x - PI)
-            }
-            (Expression::PiConstant, InfixOperator::Minus, Expression::Number(y)) => {
-                Expression::Number(PI - y)
-            }
+            (_, InfixOperator::Minus, Expression::Number(y)) if is_zero(*y) => left,
 
-            // Multiplication and Division
+            // Subtracting two equal items; equality comparison is more efficient on the `ArcIntern`s
+            (_, InfixOperator::Minus, _) if left == right => interned::number(ZERO),
+
+            // ## Multiplication and Division ##
 
             // Multiplication with zero
             (Expression::Number(x), InfixOperator::Star, _)
             | (_, InfixOperator::Star, Expression::Number(x))
-                if is_zero(x) =>
+                if is_zero(*x) =>
             {
-                Expression::Number(ZERO)
+                interned::number(ZERO)
             }
+
             // Multiplication with one
-            (Expression::Number(x), InfixOperator::Star, other)
-            | (other, InfixOperator::Star, Expression::Number(x))
-                if is_one(x) =>
-            {
-                other
-            }
-            // Multiplying with numbers or π
-            (Expression::Number(x), InfixOperator::Star, Expression::Number(y)) => {
-                Expression::Number(x * y)
-            }
-            (Expression::Number(x), InfixOperator::Star, Expression::PiConstant)
-            | (Expression::PiConstant, InfixOperator::Star, Expression::Number(x)) => {
-                Expression::Number(PI * x)
-            }
-            (Expression::PiConstant, InfixOperator::Star, Expression::PiConstant) => {
-                Expression::Number(PI * PI)
-            }
+            (Expression::Number(x), InfixOperator::Star, _) if is_one(*x) => right,
+            (_, InfixOperator::Star, Expression::Number(x)) if is_one(*x) => left,
 
             // Division with zero
-            (Expression::Number(x), InfixOperator::Slash, _) if is_zero(x) => {
-                Expression::Number(ZERO)
+            (Expression::Number(x), InfixOperator::Slash, _) if is_zero(*x) => {
+                interned::number(ZERO)
             }
-            (_, InfixOperator::Slash, Expression::Number(y)) if is_zero(y) => {
-                Expression::Number(real!(f64::NAN))
-            }
-            // Division with one
-            (left, InfixOperator::Slash, Expression::Number(y)) if is_one(y) => left,
-            // Division with self
-            (left, InfixOperator::Slash, right) if left == right => Expression::Number(ONE),
-            // Division with numbers or π (π / π already covered)
-            (Expression::Number(x), InfixOperator::Slash, Expression::Number(y)) => {
-                Expression::Number(x / y)
-            }
-            (Expression::Number(x), InfixOperator::Slash, Expression::PiConstant) => {
-                Expression::Number(x / PI)
-            }
-            (Expression::PiConstant, InfixOperator::Slash, Expression::Number(y)) => {
-                Expression::Number(PI / y)
+            (_, InfixOperator::Slash, Expression::Number(y)) if is_zero(*y) => {
+                interned::number(real!(f64::NAN))
             }
 
-            // Exponentiation
+            // Division by one
+            (_, InfixOperator::Slash, Expression::Number(y)) if is_one(*y) => left,
 
-            // Exponentiation with zero
-            (Expression::Number(x), InfixOperator::Caret, _) if is_zero(x) => {
-                Expression::Number(ZERO)
+            // Division of two equal items; equality comparison is more efficient on the `ArcIntern`s
+            (_, InfixOperator::Slash, _) if left == right => interned::number(ONE),
+
+            // ## Exponentiation ##
+
+            // Exponentiation with zero (0⁰ = 1)
+            (Expression::Number(x), InfixOperator::Caret, _) if is_zero(*x) => {
+                interned::number(ZERO)
             }
-            (_, InfixOperator::Caret, Expression::Number(y)) if is_zero(y) => {
-                Expression::Number(ONE)
+            (_, InfixOperator::Caret, Expression::Number(y)) if is_zero(*y) => {
+                interned::number(ONE)
             }
+
             // Exponentiation with one
-            (Expression::Number(x), InfixOperator::Caret, _) if is_one(x) => {
-                Expression::Number(ONE)
-            }
-            (left, InfixOperator::Caret, Expression::Number(y)) if is_one(y) => left,
-            // Exponentiation with numbers or π
-            (Expression::Number(x), InfixOperator::Caret, Expression::Number(y)) => {
-                Expression::Number(x.powc(y))
-            }
-            (Expression::Number(x), InfixOperator::Caret, Expression::PiConstant) => {
-                Expression::Number(x.powc(PI))
-            }
-            (Expression::PiConstant, InfixOperator::Caret, Expression::Number(y)) => {
-                Expression::Number(PI.powc(y))
-            }
-            (Expression::PiConstant, InfixOperator::Caret, Expression::PiConstant) => {
-                Expression::Number(PI.powc(PI))
+            (Expression::Number(x), InfixOperator::Caret, _) if is_one(*x) => interned::number(ONE),
+            (_, InfixOperator::Caret, Expression::Number(y)) if is_one(*y) => left,
+
+            // ## Two numbers ##
+
+            // Since [`Self::simplify`] cannot return [`Expression::PiConstant`], we only need to
+            // handle true numbers here.
+            (Expression::Number(x), _, Expression::Number(y)) => {
+                interned::number(calculate_infix(*x, operator, *y))
             }
 
             //----------------------------------------------------------------
@@ -311,156 +271,120 @@ fn simplify_infix(l: &Expression, op: InfixOperator, r: &Expression, limit: u64)
             // Addition with negation
             // a + (-b) = (-b) + a = a - b
             (
-                ref other,
+                _,
                 InfixOperator::Plus,
                 Expression::Prefix(PrefixExpression {
                     operator: PrefixOperator::Minus,
-                    ref expression,
+                    expression,
                 }),
-            )
-            | (
+            ) => self.simplify(interned::sub(left, expression.clone()), limit - 1),
+
+            (
                 Expression::Prefix(PrefixExpression {
                     operator: PrefixOperator::Minus,
-                    ref expression,
+                    expression,
                 }),
                 InfixOperator::Plus,
-                ref other,
-            ) => simplify_infix(other, InfixOperator::Minus, expression, limit - 1),
+                _,
+            ) => self.simplify(interned::sub(right, expression.clone()), limit - 1),
 
             // Subtraction with negation
 
             // a - (-b) = a + b
             (
-                ref left,
+                _,
                 InfixOperator::Minus,
                 Expression::Prefix(PrefixExpression {
                     operator: PrefixOperator::Minus,
-                    ref expression,
+                    expression,
                 }),
-            ) => simplify_infix(left, InfixOperator::Plus, expression, limit - 1),
+            ) => self.simplify(interned::add(left, expression.clone()), limit - 1),
 
             // -expression - right = smaller of [(-expression) - right, -(expression + right)]
             (
-                ref left @ Expression::Prefix(PrefixExpression {
+                Expression::Prefix(PrefixExpression {
                     operator: PrefixOperator::Minus,
-                    ref expression,
+                    expression,
                 }),
                 InfixOperator::Minus,
-                ref right,
+                _,
             ) => {
-                let original = sub!(left.clone(), right.clone());
-                let new = simplify_prefix(
-                    PrefixOperator::Minus,
-                    &simplify_infix(expression, InfixOperator::Plus, right, limit - 1),
+                // Recreate the original structure but having simplified the contents
+                let original_structure = interned::sub(left.clone(), right.clone());
+
+                // Factor out the negation
+                let inner_sum = self.simplify(interned::add(expression.clone(), right), limit - 1);
+                let outer_neg = self.simplify(interned::neg(inner_sum), limit - 1);
+
+                min_by_key(original_structure, outer_neg, size)
+            }
+
+            // Multiplication and division with negation
+
+            // Double negative: (-a) ⋇ (-b) = a ⋇ b
+            (
+                Expression::Prefix(PrefixExpression {
+                    operator: PrefixOperator::Minus,
+                    expression: a,
+                }),
+                InfixOperator::Star | InfixOperator::Slash,
+                Expression::Prefix(PrefixExpression {
+                    operator: PrefixOperator::Minus,
+                    expression: b,
+                }),
+            ) => self.simplify(interned::infix(a.clone(), operator, b.clone()), limit - 1),
+
+            // (-a) / a = a / (-a) = -1
+            (
+                _,
+                InfixOperator::Slash,
+                Expression::Prefix(PrefixExpression {
+                    operator: PrefixOperator::Minus,
+                    expression,
+                }),
+            ) if &left == expression => interned::number(-ONE),
+            (
+                Expression::Prefix(PrefixExpression {
+                    operator: PrefixOperator::Minus,
+                    expression,
+                }),
+                InfixOperator::Slash,
+                _,
+            ) if expression == &right => interned::number(-ONE),
+
+            // a ⋇ (-b) = (-a) ⋇ b, pick the shorter
+            (
+                _,
+                InfixOperator::Star | InfixOperator::Slash,
+                Expression::Prefix(PrefixExpression {
+                    operator: PrefixOperator::Minus,
+                    expression,
+                }),
+            ) => {
+                let original = interned::mul(left.clone(), right.clone());
+                let neg_left = self.simplify(interned::neg(left), limit - 1);
+                let new = self.simplify(
+                    interned::infix(neg_left, operator, expression.clone()),
                     limit - 1,
                 );
                 min_by_key(original, new, size)
             }
 
-            // Multiplication with negation
-
-            // Double negative: (-a) * (-b) = a * b
+            // (-a) ⋇ b = a ⋇ (-b), pick the shorter
             (
                 Expression::Prefix(PrefixExpression {
                     operator: PrefixOperator::Minus,
-                    expression: ref a,
+                    expression,
                 }),
-                InfixOperator::Star,
-                Expression::Prefix(PrefixExpression {
-                    operator: PrefixOperator::Minus,
-                    expression: ref b,
-                }),
-            ) => simplify_infix(a, InfixOperator::Star, b, limit - 1),
-
-            // a * (-b) = (-a) * b, pick the shorter
-            (
-                ref left,
-                InfixOperator::Star,
-                ref right @ Expression::Prefix(PrefixExpression {
-                    operator: PrefixOperator::Minus,
-                    ref expression,
-                }),
+                InfixOperator::Star | InfixOperator::Slash,
+                _,
             ) => {
-                let original = mul!(left.clone(), right.clone());
-                let neg_left = simplify_prefix(PrefixOperator::Minus, left, limit - 1);
-                let new = simplify_infix(&neg_left, InfixOperator::Star, expression, limit - 1);
-                min_by_key(original, new, size)
-            }
-            // (-a) * b = a * (-b), pick the shorter
-            (
-                ref left @ Expression::Prefix(PrefixExpression {
-                    operator: PrefixOperator::Minus,
-                    ref expression,
-                }),
-                InfixOperator::Star,
-                ref right,
-            ) => {
-                let original = mul!(left.clone(), right.clone());
-                let neg_right = simplify_prefix(PrefixOperator::Minus, right, limit - 1);
-                let new = simplify_infix(expression, InfixOperator::Star, &neg_right, limit - 1);
-                min_by_key(original, new, size)
-            }
-
-            // Division with negation
-
-            // Double negative: (-a) / (-b) = a / b
-            (
-                Expression::Prefix(PrefixExpression {
-                    operator: PrefixOperator::Minus,
-                    expression: ref a,
-                }),
-                InfixOperator::Slash,
-                Expression::Prefix(PrefixExpression {
-                    operator: PrefixOperator::Minus,
-                    expression: ref b,
-                }),
-            ) => simplify_infix(a, InfixOperator::Slash, b, limit - 1),
-
-            // (-a) / a = a / (-a) = -1
-            (
-                ref other,
-                InfixOperator::Slash,
-                Expression::Prefix(PrefixExpression {
-                    operator: PrefixOperator::Minus,
-                    ref expression,
-                }),
-            )
-            | (
-                Expression::Prefix(PrefixExpression {
-                    operator: PrefixOperator::Minus,
-                    ref expression,
-                }),
-                InfixOperator::Slash,
-                ref other,
-            ) if *other == **expression => Expression::Number(-ONE),
-
-            // a / (-b) = (-a) / b, pick the shorter
-            (
-                ref left,
-                InfixOperator::Slash,
-                ref right @ Expression::Prefix(PrefixExpression {
-                    operator: PrefixOperator::Minus,
-                    ref expression,
-                }),
-            ) => {
-                let original = div!(left.clone(), right.clone());
-                let neg_left = simplify_prefix(PrefixOperator::Minus, left, limit - 1);
-                let new = simplify_infix(&neg_left, InfixOperator::Slash, expression, limit - 1);
-                min_by_key(original, new, size)
-            }
-
-            // (-a) / b = a / (-b), pick the shorter
-            (
-                ref left @ Expression::Prefix(PrefixExpression {
-                    operator: PrefixOperator::Minus,
-                    ref expression,
-                }),
-                InfixOperator::Slash,
-                ref right,
-            ) => {
-                let original = div!(left.clone(), right.clone());
-                let neg_right = simplify_prefix(PrefixOperator::Minus, right, limit - 1);
-                let new = simplify_infix(expression, InfixOperator::Slash, &neg_right, limit - 1);
+                let original = interned::mul(left.clone(), right.clone());
+                let neg_right = self.simplify(interned::neg(right), limit - 1);
+                let new = self.simplify(
+                    interned::infix(expression.clone(), operator, neg_right),
+                    limit - 1,
+                );
                 min_by_key(original, new, size)
             }
 
@@ -474,247 +398,202 @@ fn simplify_infix(l: &Expression, op: InfixOperator, r: &Expression, limit: u64)
             // recursive data type, and `if let` in a match guard isn't stabilized.
             (
                 Expression::Infix(InfixExpression {
-                    left: ref left_ax,
+                    left: left_ax,
                     operator: InfixOperator::Plus,
-                    right: ref left_b,
+                    right: left_b,
                 }),
                 InfixOperator::Plus,
                 Expression::Infix(InfixExpression {
-                    left: ref right_ax,
+                    left: right_ax,
                     operator: InfixOperator::Plus,
-                    right: ref right_b,
+                    right: right_b,
                 }),
             ) if mul_matches(left_ax, right_ax) => {
-                let &Expression::Infix(InfixExpression {
-                    left: ref ll,
+                let Expression::Infix(InfixExpression {
+                    left: ll,
                     operator: InfixOperator::Star,
-                    right: ref lr,
-                }) = &**left_ax
+                    right: lr,
+                }) = left_ax.as_ref()
                 else {
                     unreachable!("This is handled by mul_matches")
                 };
-                let &Expression::Infix(InfixExpression {
-                    left: ref rl,
+                let Expression::Infix(InfixExpression {
+                    left: rl,
                     operator: InfixOperator::Star,
-                    right: ref rr,
-                }) = &**right_ax
+                    right: rr,
+                }) = right_ax.as_ref()
                 else {
                     unreachable!("This is handled by mul_matches")
                 };
-                let (left_a, right_a, x) = if **ll == **rl {
+                let (left_a, right_a, x) = if ll == rl {
                     (lr, rr, ll)
-                } else if **ll == **rr {
+                } else if ll == rr {
                     (lr, rl, ll)
-                } else if **lr == **rl {
+                } else if lr == rl {
                     (ll, rr, lr)
                 } else {
                     (ll, rl, rr)
                 };
-                simplify_infix(
-                    &simplify_infix(
-                        &simplify_infix(left_a, InfixOperator::Plus, right_a, limit - 1),
-                        InfixOperator::Star,
-                        x,
-                        limit - 1,
-                    ),
-                    InfixOperator::Plus,
-                    &simplify_infix(left_b, InfixOperator::Plus, right_b, limit - 1),
-                    limit - 1,
-                )
+
+                let sum_as =
+                    self.simplify(interned::add(left_a.clone(), right_a.clone()), limit - 1);
+                let sum_bs =
+                    self.simplify(interned::add(left_b.clone(), right_b.clone()), limit - 1);
+                let mul_as_x = self.simplify(interned::mul(sum_as, x.clone()), limit - 1);
+                self.simplify(interned::add(mul_as_x, sum_bs), limit - 1)
             }
 
             // (a1 * x) + (a2 * x) = (a1 + a2) * x
             (
                 Expression::Infix(InfixExpression {
-                    left: ref left_a,
+                    left: left_a,
                     operator: InfixOperator::Star,
-                    right: ref left_x,
+                    right: left_x,
                 }),
                 InfixOperator::Plus,
                 Expression::Infix(InfixExpression {
-                    left: ref right_a,
+                    left: right_a,
                     operator: InfixOperator::Star,
-                    right: ref right_x,
+                    right: right_x,
                 }),
-            ) if left_x == right_x => simplify_infix(
-                &simplify_infix(left_a, InfixOperator::Plus, right_a, limit - 1),
-                InfixOperator::Star,
-                left_x,
-                limit - 1,
-            ),
+            ) if left_x == right_x => {
+                let sum_as =
+                    self.simplify(interned::add(left_a.clone(), right_a.clone()), limit - 1);
+                self.simplify(interned::mul(sum_as, left_x.clone()), limit - 1)
+            }
 
-            // (x + b1) + (x + b2) = x + (b1 + b2)
+            // (x + b1) + (x + b2) = 2 * x + (b1 + b2)
             (
                 Expression::Infix(InfixExpression {
-                    left: ref left_x,
+                    left: left_x,
                     operator: InfixOperator::Plus,
-                    right: ref left_b,
+                    right: left_b,
                 }),
                 InfixOperator::Plus,
                 Expression::Infix(InfixExpression {
-                    left: ref right_x,
+                    left: right_x,
                     operator: InfixOperator::Plus,
-                    right: ref right_b,
+                    right: right_b,
                 }),
-            ) if left_x == right_x => simplify_infix(
-                &simplify_infix(
-                    &Expression::Number(TWO),
-                    InfixOperator::Star,
-                    left_x,
+            ) if left_x == right_x => {
+                let two_x = self.simplify(
+                    interned::mul(interned::number(TWO), left_x.clone()),
                     limit - 1,
-                ),
-                InfixOperator::Plus,
-                &simplify_infix(left_b, InfixOperator::Plus, right_b, limit - 1),
-                limit - 1,
-            ),
+                );
+                let sum_bs =
+                    self.simplify(interned::add(left_b.clone(), right_b.clone()), limit - 1);
+                self.simplify(interned::add(two_x, sum_bs), limit - 1)
+            }
 
             //----------------------------------------------------------------
             // Fourth: commutation, association, distribution
             //----------------------------------------------------------------
 
-            // Addition associative, right: a + (b + c) = (a + b) + c, pick the shorter
+            // Right associativity:
+            // - Addition: a + (b + c) = (a + b) + c
+            // - Multiplication: a * (b * c) = (a * b) * c
+            // In both cases, pick the shorter
             (
-                ref a,
-                InfixOperator::Plus,
-                ref right @ Expression::Infix(InfixExpression {
-                    left: ref b,
-                    operator: InfixOperator::Plus,
-                    right: ref c,
+                _,
+                InfixOperator::Plus | InfixOperator::Star,
+                Expression::Infix(InfixExpression {
+                    left: b,
+                    operator: inner_operator,
+                    right: c,
                 }),
-            ) => {
-                let original = add!(a.clone(), right.clone());
-                let new_ab = simplify_infix(a, InfixOperator::Plus, b, limit - 1);
-                let new = simplify_infix(&new_ab, InfixOperator::Plus, c, limit - 1);
+            ) if operator == *inner_operator => {
+                let original = interned::infix(left.clone(), operator, right.clone());
+                let ab = self.simplify(interned::infix(left, operator, b.clone()), limit - 1);
+                let new = self.simplify(interned::infix(ab, operator, c.clone()), limit - 1);
                 min_by_key(original, new, size)
             }
 
-            // Addition associative, left: (a + b) + c = a + (b + c), pick the shorter
+            // Right "associativity" (not really):
+            // - Subtraction (not really): a - (b - c) = (a + c) - b
+            // - Division (not really): a / (b / c) = (a * c) / b
+            // In both cases, pick the shorter
             (
-                ref left @ Expression::Infix(InfixExpression {
-                    left: ref a,
-                    operator: InfixOperator::Plus,
-                    right: ref b,
+                _,
+                InfixOperator::Minus | InfixOperator::Slash,
+                Expression::Infix(InfixExpression {
+                    left: b,
+                    operator: inner_operator,
+                    right: c,
                 }),
-                InfixOperator::Plus,
-                ref c,
-            ) => {
-                let original = add!(left.clone(), c.clone());
-                let bc = simplify_infix(b, InfixOperator::Plus, c, limit - 1);
-                let new = simplify_infix(a, InfixOperator::Plus, &bc, limit - 1);
+            ) if operator == *inner_operator => {
+                let inverse = if operator == InfixOperator::Minus {
+                    InfixOperator::Plus
+                } else {
+                    InfixOperator::Star
+                };
+
+                let original = interned::infix(left.clone(), operator, right.clone());
+                let ac = self.simplify(interned::infix(left, inverse, c.clone()), limit - 1);
+                let new = self.simplify(interned::infix(ac, operator, b.clone()), limit - 1);
                 min_by_key(original, new, size)
             }
 
-            // Multiplication associative, right: a * (b * c) = (a * b) * c, pick the shorter
+            // Left associativity and "associativity":
+            // - Addition: (a + b) + c = a + (b + c)
+            // - Multiplication: (a * b) * c = a * (b * c)
+            // - Subtraction (not really): (a - b) - c = a - (b + c)
+            // - Division (not really): (a / b) / c = a / (b * c)
+            // In all cases, pick the shorter
             (
-                ref a,
-                InfixOperator::Star,
-                ref right @ Expression::Infix(InfixExpression {
-                    left: ref b,
-                    operator: InfixOperator::Star,
-                    right: ref c,
+                Expression::Infix(InfixExpression {
+                    left: a,
+                    operator: inner_operator,
+                    right: b,
                 }),
-            ) => {
-                let original = mul!(a.clone(), right.clone());
-                let ab = simplify_infix(a, InfixOperator::Star, b, limit - 1);
-                let new = simplify_infix(&ab, InfixOperator::Star, c, limit - 1);
-                min_by_key(original, new, size)
-            }
+                InfixOperator::Plus
+                | InfixOperator::Star
+                | InfixOperator::Minus
+                | InfixOperator::Slash,
+                _,
+            ) if operator == *inner_operator => {
+                let rhs_operator = match operator {
+                    InfixOperator::Minus => InfixOperator::Plus,
+                    InfixOperator::Slash => InfixOperator::Star,
+                    _ => operator,
+                };
 
-            // Multiplication associative, left: (a * b) * c = a * (b * c), pick the shorter
-            (
-                ref left @ Expression::Infix(InfixExpression {
-                    left: ref a,
-                    operator: InfixOperator::Star,
-                    right: ref b,
-                }),
-                InfixOperator::Star,
-                ref c,
-            ) => {
-                let original = mul!(left.clone(), c.clone());
-                let bc = simplify_infix(b, InfixOperator::Star, c, limit - 1);
-                let new = simplify_infix(a, InfixOperator::Star, &bc, limit - 1);
-                min_by_key(original, new, size)
-            }
-
-            // Subtraction "associative" (not really), right: a - (b - c) = (a + c) - b
-            (
-                ref a,
-                InfixOperator::Minus,
-                ref right @ Expression::Infix(InfixExpression {
-                    left: ref b,
-                    operator: InfixOperator::Minus,
-                    right: ref c,
-                }),
-            ) => {
-                let original = sub!(a.clone(), right.clone());
-                let ac = simplify_infix(a, InfixOperator::Plus, c, limit - 1);
-                let new = simplify_infix(&ac, InfixOperator::Minus, b, limit - 1);
-                min_by_key(original, new, size)
-            }
-
-            // Division "associative" (not really), right: a / (b / c) = (a * c) / b
-            (
-                ref a,
-                InfixOperator::Slash,
-                ref right @ Expression::Infix(InfixExpression {
-                    left: ref b,
-                    operator: InfixOperator::Slash,
-                    right: ref c,
-                }),
-            ) => {
-                let original = div!(a.clone(), right.clone());
-                let ac = simplify_infix(a, InfixOperator::Star, c, limit - 1);
-                let new = simplify_infix(&ac, InfixOperator::Slash, b, limit - 1);
-                min_by_key(original, new, size)
-            }
-
-            // Division "associative" (not really), left: (a / b) / c = a / (b * c)
-            (
-                ref left @ Expression::Infix(InfixExpression {
-                    left: ref a,
-                    operator: InfixOperator::Slash,
-                    right: ref b,
-                }),
-                InfixOperator::Slash,
-                ref c,
-            ) => {
-                let original = div!(left.clone(), c.clone());
-                let bc = simplify_infix(b, InfixOperator::Star, c, limit - 1);
-                let new = simplify_infix(a, InfixOperator::Slash, &bc, limit - 1);
+                let original = interned::infix(left.clone(), operator, right.clone());
+                let bc = self.simplify(interned::infix(b.clone(), operator, right), limit - 1);
+                let new = self.simplify(interned::infix(a.clone(), rhs_operator, bc), limit - 1);
                 min_by_key(original, new, size)
             }
 
             // Right distribution: a * (b + c) = (a * b) + (a * c)
             (
-                ref a,
+                _,
                 InfixOperator::Star,
-                ref right @ Expression::Infix(InfixExpression {
-                    left: ref b,
+                Expression::Infix(InfixExpression {
+                    left: b,
                     operator: InfixOperator::Plus,
-                    right: ref c,
+                    right: c,
                 }),
             ) => {
-                let original = mul!(a.clone(), right.clone());
-                let ab = simplify_infix(a, InfixOperator::Star, b, limit - 1);
-                let ac = simplify_infix(a, InfixOperator::Star, c, limit - 1);
-                let new = simplify_infix(&ab, InfixOperator::Plus, &ac, limit - 1);
+                let original = interned::mul(left.clone(), right.clone());
+                let ab = self.simplify(interned::mul(left.clone(), b.clone()), limit - 1);
+                let ac = self.simplify(interned::mul(left, c.clone()), limit - 1);
+                let new = self.simplify(interned::add(ab, ac), limit - 1);
                 min_by_key(original, new, size)
             }
 
             // Left distribution: (a + b) * c = (a * c) + (a * b)
             (
-                ref left @ Expression::Infix(InfixExpression {
-                    left: ref a,
+                Expression::Infix(InfixExpression {
+                    left: a,
                     operator: InfixOperator::Plus,
-                    right: ref b,
+                    right: b,
                 }),
                 InfixOperator::Star,
-                ref c,
+                _,
             ) => {
-                let original = mul!(left.clone(), c.clone());
-                let ac = simplify_infix(a, InfixOperator::Star, c, limit - 1);
-                let bc = simplify_infix(b, InfixOperator::Star, c, limit - 1);
-                let new = simplify_infix(&ac, InfixOperator::Plus, &bc, limit - 1);
+                let original = interned::mul(left.clone(), right.clone());
+                let ac = self.simplify(interned::mul(a.clone(), right.clone()), limit - 1);
+                let bc = self.simplify(interned::mul(b.clone(), right), limit - 1);
+                let new = self.simplify(interned::add(ac, bc), limit - 1);
                 min_by_key(original, new, size)
             }
 
@@ -722,147 +601,145 @@ fn simplify_infix(l: &Expression, op: InfixOperator, r: &Expression, limit: u64)
             // Fifth: other parenthesis manipulation
             //----------------------------------------------------------------
 
-            // Mul inside Div on left with cancellation
+            // Mul inside Div on left with cancellation: (a * b) / a = (b * a) / a = b
             (
                 Expression::Infix(InfixExpression {
-                    left: ref same_1,
+                    left: same,
                     operator: InfixOperator::Star,
-                    right: ref other,
+                    right: other,
                 }),
                 InfixOperator::Slash,
-                ref same_2,
+                _,
             )
             | (
                 Expression::Infix(InfixExpression {
-                    left: ref other,
+                    left: other,
                     operator: InfixOperator::Star,
-                    right: ref same_1,
+                    right: same,
                 }),
                 InfixOperator::Slash,
-                ref same_2,
-            ) if **same_1 == *same_2 => simplify(other, limit - 1),
+                _,
+            ) if &right == same => other.clone(),
 
-            // Mul inside Div on right with cancellation
+            // Mul inside Div on right with cancellation: a / (a * b) = a / (b * a) = 1 / b
             (
-                ref same_1,
+                _,
                 InfixOperator::Slash,
                 Expression::Infix(InfixExpression {
-                    left: ref same_2,
+                    left: same,
                     operator: InfixOperator::Star,
-                    right: ref other,
+                    right: other,
                 }),
             )
             | (
-                ref same_1,
+                _,
                 InfixOperator::Slash,
                 Expression::Infix(InfixExpression {
-                    left: ref other,
+                    left: other,
                     operator: InfixOperator::Star,
-                    right: ref same_2,
+                    right: same,
                 }),
-            ) if *same_1 == **same_2 => simplify_infix(
-                &Expression::Number(ONE),
-                InfixOperator::Slash,
-                other,
+            ) if &left == same => self.simplify(
+                interned::div(interned::number(ONE), other.clone()),
                 limit - 1,
             ),
 
-            // Mul inside Div on left
+            // Mul inside Div on left: (a * b) / c = a * (b / c), pick the shorter
             (
-                ref numerator @ Expression::Infix(InfixExpression {
-                    left: ref multiplier,
+                Expression::Infix(InfixExpression {
+                    left: multiplier,
                     operator: InfixOperator::Star,
-                    right: ref multiplicand,
+                    right: multiplicand,
                 }),
                 InfixOperator::Slash,
-                ref denominator,
+                _,
             ) => {
-                let original = div!(numerator.clone(), denominator.clone());
+                let original = interned::div(left.clone(), right.clone());
                 let new_multiplicand =
-                    simplify_infix(multiplicand, InfixOperator::Slash, denominator, limit - 1);
-                let new = simplify_infix(
-                    multiplier,
-                    InfixOperator::Star,
-                    &new_multiplicand,
+                    self.simplify(interned::div(multiplicand.clone(), right), limit - 1);
+                let new = self.simplify(
+                    interned::mul(multiplier.clone(), new_multiplicand),
                     limit - 1,
                 );
                 min_by_key(original, new, size)
             }
 
-            // Mul inside Div on right
+            // Mul inside Div on right: a / (b * c) = (a / b) / c, pick the shorter
             (
-                ref numerator,
+                _,
                 InfixOperator::Slash,
-                ref denominator @ Expression::Infix(InfixExpression {
-                    left: ref multiplier,
+                Expression::Infix(InfixExpression {
+                    left: multiplier,
                     operator: InfixOperator::Star,
-                    right: ref multiplicand,
+                    right: multiplicand,
                 }),
             ) => {
-                let original = div!(numerator.clone(), denominator.clone());
+                let original = interned::div(left.clone(), right.clone());
                 let new_multiplier =
-                    simplify_infix(numerator, InfixOperator::Slash, multiplier, limit - 1);
-                let new = simplify_infix(
-                    &new_multiplier,
-                    InfixOperator::Slash,
-                    multiplicand,
+                    self.simplify(interned::div(left, multiplier.clone()), limit - 1);
+                let new = self.simplify(
+                    interned::div(new_multiplier, multiplicand.clone()),
                     limit - 1,
                 );
                 min_by_key(original, new, size)
             }
 
-            // Div inside Mul with cancellation
+            // Div inside Mul on left with cancellation: (b / a) * a = b
             (
                 Expression::Infix(InfixExpression {
-                    left: ref other,
+                    left: other,
                     operator: InfixOperator::Slash,
-                    right: ref same_1,
+                    right: same,
                 }),
                 InfixOperator::Star,
-                ref same_2,
-            )
-            | (
-                ref same_2,
+                _,
+            ) if same == &right => other.clone(),
+
+            // Div inside Mul on right with cancellation: a * (b / a) = b
+            (
+                _,
                 InfixOperator::Star,
                 Expression::Infix(InfixExpression {
-                    left: ref other,
+                    left: other,
                     operator: InfixOperator::Slash,
-                    right: ref same_1,
+                    right: same,
                 }),
-            ) if **same_1 == *same_2 => simplify(other, limit - 1),
+            ) if &left == same => other.clone(),
 
             //----------------------------------------------------------------
             // Sixth: catch-all if no other patterns match
             //----------------------------------------------------------------
-            (left, operator, right) => Expression::Infix(InfixExpression {
-                left: left.into(),
-                operator,
-                right: right.into(),
-            }),
+            _ => interned::infix(left, operator, right),
         }
     }
-}
 
-/// Simplify a prefix expression inside an `Expression`, terminating the recursion if `limit` has reached zero.
-fn simplify_prefix(op: PrefixOperator, expr: &Expression, limit: u64) -> Expression {
-    if limit == 0 {
-        // bail
-        Expression::Prefix(PrefixExpression {
-            operator: op,
-            expression: expr.clone().into(),
-        })
-    } else {
+    /// Simplify a prefix expression inside an `Expression`
+    fn simplify_prefix(
+        &mut self,
+        operator: PrefixOperator,
+        expr: ArcIntern<Expression>,
+        limit: Limit,
+    ) -> ArcIntern<Expression> {
         // Remove +
-        // Push - into numbers & π
+        // Push - into numbers ([`Self::simplify`] cannot return π)
+        // Remove double negation
         // Pass through otherwise
-        match (op, simplify(expr, limit - 1)) {
-            (PrefixOperator::Plus, expression) => expression,
-            (PrefixOperator::Minus, Expression::Number(x)) => Expression::Number(-x),
-            (PrefixOperator::Minus, Expression::PiConstant) => Expression::Number(-PI),
-            (operator, expression) => Expression::Prefix(PrefixExpression {
-                operator,
-                expression: expression.into(),
-            }),
+
+        let expr = self.simplify(expr, limit);
+
+        match operator {
+            PrefixOperator::Plus => expr,
+
+            PrefixOperator::Minus => match expr.as_ref() {
+                Expression::Number(x) => interned::number(-*x),
+
+                Expression::Prefix(PrefixExpression {
+                    operator: PrefixOperator::Minus,
+                    expression: inner,
+                }) => inner.clone(),
+
+                _ => interned::neg(expr),
+            },
         }
     }
 }

--- a/quil-rs/src/expression/simplification/mod.rs
+++ b/quil-rs/src/expression/simplification/mod.rs
@@ -8,7 +8,7 @@ mod tests {
 
     use std::str::FromStr;
 
-    use crate::expression::Expression;
+    use crate::{expression::Expression, quil::Quil};
 
     macro_rules! test_simplify {
         ($name:ident, $input:expr, $expected:expr) => {
@@ -23,7 +23,26 @@ mod tests {
                     )
                 });
                 let computed = run(&parsed_input);
-                assert_eq!(parsed_expected, computed);
+                assert!(
+                    parsed_expected == computed,
+                    concat!(
+                        "Expression simplification produced the wrong result\n",
+                        "\n",
+                        "Input (Rust syntax):    {:#?}\n",
+                        "Expected (Rust syntax): {:#?}\n",
+                        "Actual (Rust syntax):   {:#?}\n",
+                        "\n",
+                        "   Input (Quil syntax): {}\n",
+                        "Expected (Quil syntax): {}\n",
+                        "  Actual (Quil syntax): {}",
+                    ),
+                    parsed_input,
+                    parsed_expected,
+                    computed,
+                    parsed_input.to_quil_or_debug(),
+                    parsed_expected.to_quil_or_debug(),
+                    computed.to_quil_or_debug(),
+                );
             }
         };
     }

--- a/quil-rs/src/expression/simplification/mod.rs
+++ b/quil-rs/src/expression/simplification/mod.rs
@@ -1,16 +1,14 @@
-use crate::expression::Expression;
-
 mod by_hand;
 
-/// Simplify an [`Expression`].
-pub(super) fn run(expression: &Expression) -> Expression {
-    by_hand::run(expression)
-}
+pub(super) use by_hand::run;
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
     use std::str::FromStr;
+
+    use crate::expression::Expression;
 
     macro_rules! test_simplify {
         ($name:ident, $input:expr, $expected:expr) => {

--- a/quil-rs/src/instruction/gate.rs
+++ b/quil-rs/src/instruction/gate.rs
@@ -961,6 +961,7 @@ mod test_gate_definition {
     use crate::quil::Quil;
     use crate::{imag, real};
     use insta::assert_snapshot;
+    use internment::ArcIntern;
     use rstest::rstest;
 
     #[rstest]
@@ -982,50 +983,50 @@ mod test_gate_definition {
                 vec![
                     Expression::FunctionCall(FunctionCallExpression {
                         function: crate::expression::ExpressionFunction::Cosine,
-                        expression: Box::new(Expression::Infix(InfixExpression {
-                            left: Box::new(Expression::Variable("theta".to_string())),
+                        expression: ArcIntern::new(Expression::Infix(InfixExpression {
+                            left: ArcIntern::new(Expression::Variable("theta".to_string())),
                             operator: InfixOperator::Slash,
-                            right: Box::new(Expression::Number(real!(2.0))),
+                            right: ArcIntern::new(Expression::Number(real!(2.0))),
                         })),
                     }),
                     Expression::Infix(InfixExpression {
-                        left: Box::new(Expression::Prefix(PrefixExpression {
+                        left: ArcIntern::new(Expression::Prefix(PrefixExpression {
                             operator: PrefixOperator::Minus,
-                            expression: Box::new(Expression::Number(imag!(1f64)))
+                            expression: ArcIntern::new(Expression::Number(imag!(1f64)))
                         })),
                         operator: InfixOperator::Star,
-                        right: Box::new(Expression::FunctionCall(FunctionCallExpression {
+                        right: ArcIntern::new(Expression::FunctionCall(FunctionCallExpression {
                             function: ExpressionFunction::Sine,
-                            expression: Box::new(Expression::Infix(InfixExpression {
-                                left: Box::new(Expression::Variable("theta".to_string())),
+                            expression: ArcIntern::new(Expression::Infix(InfixExpression {
+                                left: ArcIntern::new(Expression::Variable("theta".to_string())),
                                 operator: InfixOperator::Slash,
-                                right: Box::new(Expression::Number(real!(2.0))),
+                                right: ArcIntern::new(Expression::Number(real!(2.0))),
                             })),
                         })),
                     })
                 ],
                 vec![
                     Expression::Infix(InfixExpression {
-                        left: Box::new(Expression::Prefix(PrefixExpression {
+                        left: ArcIntern::new(Expression::Prefix(PrefixExpression {
                             operator: PrefixOperator::Minus,
-                            expression: Box::new(Expression::Number(imag!(1f64)))
+                            expression: ArcIntern::new(Expression::Number(imag!(1f64)))
                         })),
                         operator: InfixOperator::Star,
-                        right: Box::new(Expression::FunctionCall(FunctionCallExpression {
+                        right: ArcIntern::new(Expression::FunctionCall(FunctionCallExpression {
                             function: ExpressionFunction::Sine,
-                            expression: Box::new(Expression::Infix(InfixExpression {
-                                left: Box::new(Expression::Variable("theta".to_string())),
+                            expression: ArcIntern::new(Expression::Infix(InfixExpression {
+                                left: ArcIntern::new(Expression::Variable("theta".to_string())),
                                 operator: InfixOperator::Slash,
-                                right: Box::new(Expression::Number(real!(2.0))),
+                                right: ArcIntern::new(Expression::Number(real!(2.0))),
                             })),
                         })),
                     }),
                     Expression::FunctionCall(FunctionCallExpression {
                         function: crate::expression::ExpressionFunction::Cosine,
-                        expression: Box::new(Expression::Infix(InfixExpression {
-                            left: Box::new(Expression::Variable("theta".to_string())),
+                        expression: ArcIntern::new(Expression::Infix(InfixExpression {
+                            left: ArcIntern::new(Expression::Variable("theta".to_string())),
                             operator: InfixOperator::Slash,
-                            right: Box::new(Expression::Number(real!(2.0))),
+                            right: ArcIntern::new(Expression::Number(real!(2.0))),
                         })),
                     }),
                 ],
@@ -1042,28 +1043,28 @@ mod test_gate_definition {
                 PauliTerm {
                     arguments: vec![(PauliGate::Z, "p".to_string()), (PauliGate::Z, "q".to_string())],
                     expression: Expression::Infix(InfixExpression {
-                        left: Box::new(Expression::Prefix(PrefixExpression {
+                        left: ArcIntern::new(Expression::Prefix(PrefixExpression {
                             operator: PrefixOperator::Minus,
-                            expression: Box::new(Expression::Variable("theta".to_string()))
+                            expression: ArcIntern::new(Expression::Variable("theta".to_string()))
                         })),
                         operator: InfixOperator::Slash,
-                        right: Box::new(Expression::Number(real!(4.0)))
+                        right: ArcIntern::new(Expression::Number(real!(4.0)))
                     }),
                 },
                 PauliTerm {
                     arguments: vec![(PauliGate::Y, "p".to_string())],
                     expression: Expression::Infix(InfixExpression {
-                        left: Box::new(Expression::Variable("theta".to_string())),
+                        left: ArcIntern::new(Expression::Variable("theta".to_string())),
                         operator: InfixOperator::Slash,
-                        right: Box::new(Expression::Number(real!(4.0)))
+                        right: ArcIntern::new(Expression::Number(real!(4.0)))
                     }),
                 },
                 PauliTerm {
                     arguments: vec![(PauliGate::X, "q".to_string())],
                     expression: Expression::Infix(InfixExpression {
-                        left: Box::new(Expression::Variable("theta".to_string())),
+                        left: ArcIntern::new(Expression::Variable("theta".to_string())),
                         operator: InfixOperator::Slash,
-                        right: Box::new(Expression::Number(real!(4.0)))
+                        right: ArcIntern::new(Expression::Number(real!(4.0)))
                     }),
                 },
             ]})

--- a/quil-rs/src/parser/command.rs
+++ b/quil-rs/src/parser/command.rs
@@ -656,6 +656,7 @@ mod tests {
         },
         make_test,
     };
+    use internment::ArcIntern;
     use rstest::*;
 
     use super::{parse_declare, parse_defcircuit, parse_defgate, parse_measurement, parse_pragma};
@@ -907,24 +908,24 @@ mod tests {
         {
             // 1/sqrt(2)
             let expression = Expression::Infix(InfixExpression {
-                left: Box::new(Expression::Number(real!(1.0))),
+                left: ArcIntern::new(Expression::Number(real!(1.0))),
                 operator: InfixOperator::Slash,
-                right: Box::new(Expression::FunctionCall(FunctionCallExpression {
+                right: ArcIntern::new(Expression::FunctionCall(FunctionCallExpression {
                     function: crate::expression::ExpressionFunction::SquareRoot,
-                    expression: Box::new(Expression::Number(real!(2.0))),
+                    expression: ArcIntern::new(Expression::Number(real!(2.0))),
                 })),
             });
 
             // -1/sqrt(2)
             let negative_expression = Expression::Infix(InfixExpression {
-                left: Box::new(Expression::Prefix(PrefixExpression {
+                left: ArcIntern::new(Expression::Prefix(PrefixExpression {
                     operator: PrefixOperator::Minus,
-                    expression: Box::new(Expression::Number(real!(1.0))),
+                    expression: ArcIntern::new(Expression::Number(real!(1.0))),
                 })),
                 operator: InfixOperator::Slash,
-                right: Box::new(Expression::FunctionCall(FunctionCallExpression {
+                right: ArcIntern::new(Expression::FunctionCall(FunctionCallExpression {
                     function: crate::expression::ExpressionFunction::SquareRoot,
-                    expression: Box::new(Expression::Number(real!(2.0))),
+                    expression: ArcIntern::new(Expression::Number(real!(2.0))),
                 })),
             });
 
@@ -952,50 +953,50 @@ mod tests {
                 vec![
                     Expression::FunctionCall(FunctionCallExpression {
                         function: crate::expression::ExpressionFunction::Cosine,
-                        expression: Box::new(Expression::Infix(InfixExpression {
-                            left: Box::new(Expression::Variable("theta".to_string())),
+                        expression: ArcIntern::new(Expression::Infix(InfixExpression {
+                            left: ArcIntern::new(Expression::Variable("theta".to_string())),
                             operator: InfixOperator::Slash,
-                            right: Box::new(Expression::Number(real!(2.0))),
+                            right: ArcIntern::new(Expression::Number(real!(2.0))),
                         })),
                     }),
                     Expression::Infix(InfixExpression {
-                        left: Box::new(Expression::Prefix(PrefixExpression {
+                        left: ArcIntern::new(Expression::Prefix(PrefixExpression {
                             operator: PrefixOperator::Minus,
-                            expression: Box::new(Expression::Number(imag!(1f64)))
+                            expression: ArcIntern::new(Expression::Number(imag!(1f64)))
                         })),
                         operator: InfixOperator::Star,
-                        right: Box::new(Expression::FunctionCall(FunctionCallExpression {
+                        right: ArcIntern::new(Expression::FunctionCall(FunctionCallExpression {
                             function: ExpressionFunction::Sine,
-                            expression: Box::new(Expression::Infix(InfixExpression {
-                                left: Box::new(Expression::Variable("theta".to_string())),
+                            expression: ArcIntern::new(Expression::Infix(InfixExpression {
+                                left: ArcIntern::new(Expression::Variable("theta".to_string())),
                                 operator: InfixOperator::Slash,
-                                right: Box::new(Expression::Number(real!(2.0))),
+                                right: ArcIntern::new(Expression::Number(real!(2.0))),
                             })),
                         })),
                     })
                 ],
                 vec![
                     Expression::Infix(InfixExpression {
-                        left: Box::new(Expression::Prefix(PrefixExpression {
+                        left: ArcIntern::new(Expression::Prefix(PrefixExpression {
                             operator: PrefixOperator::Minus,
-                            expression: Box::new(Expression::Number(imag!(1f64)))
+                            expression: ArcIntern::new(Expression::Number(imag!(1f64)))
                         })),
                         operator: InfixOperator::Star,
-                        right: Box::new(Expression::FunctionCall(FunctionCallExpression {
+                        right: ArcIntern::new(Expression::FunctionCall(FunctionCallExpression {
                             function: ExpressionFunction::Sine,
-                            expression: Box::new(Expression::Infix(InfixExpression {
-                                left: Box::new(Expression::Variable("theta".to_string())),
+                            expression: ArcIntern::new(Expression::Infix(InfixExpression {
+                                left: ArcIntern::new(Expression::Variable("theta".to_string())),
                                 operator: InfixOperator::Slash,
-                                right: Box::new(Expression::Number(real!(2.0))),
+                                right: ArcIntern::new(Expression::Number(real!(2.0))),
                             })),
                         })),
                     }),
                     Expression::FunctionCall(FunctionCallExpression {
                         function: crate::expression::ExpressionFunction::Cosine,
-                        expression: Box::new(Expression::Infix(InfixExpression {
-                            left: Box::new(Expression::Variable("theta".to_string())),
+                        expression: ArcIntern::new(Expression::Infix(InfixExpression {
+                            left: ArcIntern::new(Expression::Variable("theta".to_string())),
                             operator: InfixOperator::Slash,
-                            right: Box::new(Expression::Number(real!(2.0))),
+                            right: ArcIntern::new(Expression::Number(real!(2.0))),
                         })),
                     }),
                 ],
@@ -1034,28 +1035,30 @@ mod tests {
                             (PauliGate::Z, "q".to_string())
                         ],
                         expression: Expression::Infix(InfixExpression {
-                            left: Box::new(Expression::Prefix(PrefixExpression {
+                            left: ArcIntern::new(Expression::Prefix(PrefixExpression {
                                 operator: PrefixOperator::Minus,
-                                expression: Box::new(Expression::Variable("theta".to_string()))
+                                expression: ArcIntern::new(Expression::Variable(
+                                    "theta".to_string()
+                                ))
                             })),
                             operator: InfixOperator::Slash,
-                            right: Box::new(Expression::Number(real!(4.0)))
+                            right: ArcIntern::new(Expression::Number(real!(4.0)))
                         }),
                     },
                     PauliTerm {
                         arguments: vec![(PauliGate::Y, "p".to_string())],
                         expression: Expression::Infix(InfixExpression {
-                            left: Box::new(Expression::Variable("theta".to_string())),
+                            left: ArcIntern::new(Expression::Variable("theta".to_string())),
                             operator: InfixOperator::Slash,
-                            right: Box::new(Expression::Number(real!(4.0)))
+                            right: ArcIntern::new(Expression::Number(real!(4.0)))
                         }),
                     },
                     PauliTerm {
                         arguments: vec![(PauliGate::X, "q".to_string())],
                         expression: Expression::Infix(InfixExpression {
-                            left: Box::new(Expression::Variable("theta".to_string())),
+                            left: ArcIntern::new(Expression::Variable("theta".to_string())),
                             operator: InfixOperator::Slash,
-                            right: Box::new(Expression::Number(real!(4.0)))
+                            right: ArcIntern::new(Expression::Number(real!(4.0)))
                         }),
                     },
                 ]

--- a/quil-rs/src/parser/common.rs
+++ b/quil-rs/src/parser/common.rs
@@ -502,6 +502,7 @@ pub mod tests {
         real,
     };
 
+    use internment::ArcIntern;
     use nom_locate::LocatedSpan;
 
     use super::{parse_matrix, parse_pauli_terms, parse_permutation, parse_waveform_invocation};
@@ -653,28 +654,28 @@ SWAP-PHASES 2 3 \"xy\" 3 4 \"xy\"";
                     (PauliGate::Z, "q".to_string()),
                 ],
                 expression: Expression::Infix(InfixExpression {
-                    left: Box::new(Expression::Prefix(PrefixExpression {
+                    left: ArcIntern::new(Expression::Prefix(PrefixExpression {
                         operator: PrefixOperator::Minus,
-                        expression: Box::new(Expression::Variable("theta".to_string())),
+                        expression: ArcIntern::new(Expression::Variable("theta".to_string())),
                     })),
                     operator: InfixOperator::Slash,
-                    right: Box::new(Expression::Number(real!(4.0))),
+                    right: ArcIntern::new(Expression::Number(real!(4.0))),
                 }),
             },
             PauliTerm {
                 arguments: vec![(PauliGate::Y, "p".to_string())],
                 expression: Expression::Infix(InfixExpression {
-                    left: Box::new(Expression::Variable("theta".to_string())),
+                    left: ArcIntern::new(Expression::Variable("theta".to_string())),
                     operator: InfixOperator::Slash,
-                    right: Box::new(Expression::Number(real!(4.0))),
+                    right: ArcIntern::new(Expression::Number(real!(4.0))),
                 }),
             },
             PauliTerm {
                 arguments: vec![(PauliGate::X, "q".to_string())],
                 expression: Expression::Infix(InfixExpression {
-                    left: Box::new(Expression::Variable("theta".to_string())),
+                    left: ArcIntern::new(Expression::Variable("theta".to_string())),
                     operator: InfixOperator::Slash,
-                    right: Box::new(Expression::Number(real!(4.0))),
+                    right: ArcIntern::new(Expression::Number(real!(4.0))),
                 }),
             },
         ];

--- a/quil-rs/src/parser/instruction.rs
+++ b/quil-rs/src/parser/instruction.rs
@@ -151,6 +151,7 @@ pub(crate) fn parse_block_instruction<'a>(
 mod tests {
     use std::str::FromStr;
 
+    use internment::ArcIntern;
     use nom_locate::LocatedSpan;
     use num_complex::Complex;
 
@@ -711,40 +712,40 @@ mod tests {
             specification: GateSpecification::Matrix(vec![
                 vec![
                     Expression::Infix(InfixExpression {
-                        left: Box::new(Expression::Number(real!(1.0))),
+                        left: ArcIntern::new(Expression::Number(real!(1.0))),
                         operator: InfixOperator::Slash,
-                        right: Box::new(Expression::FunctionCall(FunctionCallExpression {
+                        right: ArcIntern::new(Expression::FunctionCall(FunctionCallExpression {
                             function: crate::expression::ExpressionFunction::SquareRoot,
-                            expression: Box::new(Expression::Number(real!(2.0))),
+                            expression: ArcIntern::new(Expression::Number(real!(2.0))),
                         })),
                     }),
                     Expression::Infix(InfixExpression {
-                        left: Box::new(Expression::Number(real!(1.0))),
+                        left: ArcIntern::new(Expression::Number(real!(1.0))),
                         operator: InfixOperator::Slash,
-                        right: Box::new(Expression::FunctionCall(FunctionCallExpression {
+                        right: ArcIntern::new(Expression::FunctionCall(FunctionCallExpression {
                             function: crate::expression::ExpressionFunction::SquareRoot,
-                            expression: Box::new(Expression::Number(real!(2.0))),
+                            expression: ArcIntern::new(Expression::Number(real!(2.0))),
                         })),
                     }),
                 ],
                 vec![
                     Expression::Infix(InfixExpression {
-                        left: Box::new(Expression::Number(real!(1.0))),
+                        left: ArcIntern::new(Expression::Number(real!(1.0))),
                         operator: InfixOperator::Slash,
-                        right: Box::new(Expression::FunctionCall(FunctionCallExpression {
+                        right: ArcIntern::new(Expression::FunctionCall(FunctionCallExpression {
                             function: crate::expression::ExpressionFunction::SquareRoot,
-                            expression: Box::new(Expression::Number(real!(2.0))),
+                            expression: ArcIntern::new(Expression::Number(real!(2.0))),
                         })),
                     }),
                     Expression::Infix(InfixExpression {
-                        left: Box::new(Expression::Prefix(PrefixExpression {
+                        left: ArcIntern::new(Expression::Prefix(PrefixExpression {
                             operator: PrefixOperator::Minus,
-                            expression: Box::new(Expression::Number(real!(1.0))),
+                            expression: ArcIntern::new(Expression::Number(real!(1.0))),
                         })),
                         operator: InfixOperator::Slash,
-                        right: Box::new(Expression::FunctionCall(FunctionCallExpression {
+                        right: ArcIntern::new(Expression::FunctionCall(FunctionCallExpression {
                             function: crate::expression::ExpressionFunction::SquareRoot,
-                            expression: Box::new(Expression::Number(real!(2.0))),
+                            expression: ArcIntern::new(Expression::Number(real!(2.0))),
                         })),
                     }),
                 ],
@@ -763,50 +764,50 @@ mod tests {
                 vec![
                     Expression::FunctionCall(FunctionCallExpression {
                         function: ExpressionFunction::Cosine,
-                        expression: Box::new(Expression::Infix(InfixExpression {
-                            left: Box::new(Expression::Variable("theta".to_string())),
+                        expression: ArcIntern::new(Expression::Infix(InfixExpression {
+                            left: ArcIntern::new(Expression::Variable("theta".to_string())),
                             operator: InfixOperator::Slash,
-                            right: Box::new(Expression::Number(Complex { re: 2.0, im: 0.0 })),
+                            right: ArcIntern::new(Expression::Number(Complex { re: 2.0, im: 0.0 })),
                         }))
                     }),
                     Expression::Infix(InfixExpression {
-                        left: Box::new(Expression::Prefix(PrefixExpression {
+                        left: ArcIntern::new(Expression::Prefix(PrefixExpression {
                             operator: PrefixOperator::Minus,
-                            expression: Box::new(Expression::Number(Complex { re: 0.0, im: 1.0 })),
+                            expression: ArcIntern::new(Expression::Number(Complex { re: 0.0, im: 1.0 })),
                         })),
                         operator: InfixOperator::Star,
-                        right: Box::new(Expression::FunctionCall(FunctionCallExpression {
+                        right: ArcIntern::new(Expression::FunctionCall(FunctionCallExpression {
                             function: ExpressionFunction::Sine,
-                            expression: Box::new(Expression::Infix(InfixExpression {
-                                left: Box::new(Expression::Variable("theta".to_string())),
+                            expression: ArcIntern::new(Expression::Infix(InfixExpression {
+                                left: ArcIntern::new(Expression::Variable("theta".to_string())),
                                 operator: InfixOperator::Slash,
-                                right: Box::new(Expression::Number(Complex { re: 2.0, im: 0.0 })),
+                                right: ArcIntern::new(Expression::Number(Complex { re: 2.0, im: 0.0 })),
                             }))
                         }))
                     }),
                 ],
                 vec![
                     Expression::Infix(InfixExpression {
-                        left: Box::new(Expression::Prefix(PrefixExpression {
+                        left: ArcIntern::new(Expression::Prefix(PrefixExpression {
                             operator: PrefixOperator::Minus,
-                            expression: Box::new(Expression::Number(Complex { re: 0.0, im: 1.0 }))
+                            expression: ArcIntern::new(Expression::Number(Complex { re: 0.0, im: 1.0 }))
                         })),
                         operator: InfixOperator::Star,
-                        right: Box::new(Expression::FunctionCall(FunctionCallExpression {
+                        right: ArcIntern::new(Expression::FunctionCall(FunctionCallExpression {
                             function: ExpressionFunction::Sine,
-                            expression: Box::new(Expression::Infix(InfixExpression {
-                                left: Box::new(Expression::Variable("theta".to_string())),
+                            expression: ArcIntern::new(Expression::Infix(InfixExpression {
+                                left: ArcIntern::new(Expression::Variable("theta".to_string())),
                                 operator: InfixOperator::Slash,
-                                right: Box::new(Expression::Number(Complex { re: 2.0, im: 0.0 }))
+                                right: ArcIntern::new(Expression::Number(Complex { re: 2.0, im: 0.0 }))
                             }))
                         }))
                     }),
                     Expression::FunctionCall(FunctionCallExpression {
                         function: ExpressionFunction::Cosine,
-                        expression: Box::new(Expression::Infix(InfixExpression {
-                            left: Box::new(Expression::Variable("theta".to_string())),
+                        expression: ArcIntern::new(Expression::Infix(InfixExpression {
+                            left: ArcIntern::new(Expression::Variable("theta".to_string())),
                             operator: InfixOperator::Slash,
-                            right: Box::new(Expression::Number(Complex { re: 2.0, im: 0.0 })),
+                            right: ArcIntern::new(Expression::Number(Complex { re: 2.0, im: 0.0 })),
                         }))
                     }),
                 ],

--- a/quil-rs/src/program/calibration.rs
+++ b/quil-rs/src/program/calibration.rs
@@ -346,8 +346,7 @@ impl Calibrations {
                             }
 
                             instruction.apply_to_expressions(|expr| {
-                                let previous = std::mem::replace(expr, Expression::PiConstant);
-                                *expr = previous.substitute_variables(&variable_expansions);
+                                *expr = expr.substitute_variables(&variable_expansions);
                             })
                         }
 


### PR DESCRIPTION
This PR features changes to the representation of expressions and simplification in order to:

1. Obtain structural sharing/perform common subexpression elimination: recursive expression structures are now wrapped in [`ArcIntern<Expression>`](https://docs.rs/internment/latest/internment/struct.ArcIntern.html), so that there is at most one instance of every expression; expressions with common subterms will have pointers to the same value.

2. Use this structural sharing to make simplification more efficient by caching work, so that simplification is performed at most once per expression per simplification pass.

This produces a ×10+ speedup on some translation workloads.