### PR TITLE
fix!: set Python and dependency versions to match

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -15,6 +15,11 @@ db-path = "~/.cargo/advisory-db"
 # The url(s) of the advisory databases to use
 db-urls = ["https://github.com/rustsec/advisory-db"]
 
+ignore = [
+  { id = "RUSTSEC-2025-0020", reason = "We will resolve this when we update PyO3 in rigetti-pyo3" },
+  { id = "RUSTSEC-2024-0436", reason = "We will resolve this when we update PyO3 in rigetti-pyo3" },
+]
+
 # This section is considered when running `cargo deny check licenses`
 # More documentation for the licenses section can be found here:
 # https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html

--- a/quil-py/pyproject.toml
+++ b/quil-py/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "quil"
 version = "0.16.0"
-requires-python = ">=3.8"
+requires-python = ">=3.9,<3.13"
 description = "A Python package for building and parsing Quil programs."
 documentation = "https://rigetti.github.io/quil-rs/quil.html"
 readme = "README-py.md"
@@ -10,12 +10,13 @@ authors = [{ name = "Rigetti Computing", email = "softapps@rigetti.com" }]
 classifiers = [
   "Development Status :: 3 - Alpha",
   "License :: OSI Approved :: Apache Software License",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
   "Operating System :: OS Independent",
 ]
-dependencies = ["numpy>=1.21"]
+dependencies = ["numpy>=1.26"]
 
 [tool.maturin]
 features = ["pyo3/extension-module"]

--- a/quil-py/src/instruction/declaration.rs
+++ b/quil-py/src/instruction/declaration.rs
@@ -39,6 +39,8 @@ impl_to_quil!(PyScalarType);
 impl_hash!(PyScalarType);
 
 impl rigetti_pyo3::PyTryFrom<pyo3::PyAny> for PyScalarType {
+    // TODO: Address https://github.com/rigetti/quil-rs/issues/451
+    #[allow(clippy::uninlined_format_args)]
     fn py_try_from(_py: Python, item: &pyo3::PyAny) -> PyResult<Self> {
         let item = item.extract::<String>()?;
         match item.as_str() {

--- a/quil-rs/Cargo.toml
+++ b/quil-rs/Cargo.toml
@@ -64,3 +64,8 @@ harness = false
 
 [[example]]
 name = "generate_test_expressions"
+
+[lints.clippy]
+# TODO: Address github.com/rigetti/quil-rs/issues/451
+uninlined_format_args = "allow"
+

--- a/quil-rs/src/instruction/mod.rs
+++ b/quil-rs/src/instruction/mod.rs
@@ -947,6 +947,8 @@ impl InstructionHandler {
     }
 
     /// Like [`Program::into_simplified`], but using custom instruction handling.
+    // TODO: Address https://github.com/rigetti/quil-rs/issues/453
+    #[allow(clippy::result_large_err)]
     pub fn simplify_program(&mut self, program: &Program) -> Result<Program, ProgramError> {
         program.simplify_with_handler(self)
     }

--- a/quil-rs/src/program/analysis/control_flow_graph.rs
+++ b/quil-rs/src/program/analysis/control_flow_graph.rs
@@ -248,6 +248,8 @@ impl<'p> BasicBlock<'p> {
     }
 }
 
+// TODO: Address https://github.com/rigetti/quil-rs/issues/453
+#[allow(clippy::large_enum_variant)]
 #[allow(clippy::enum_variant_names)]
 #[derive(Debug, thiserror::Error)]
 pub enum BasicBlockScheduleError {

--- a/quil-rs/src/program/mod.rs
+++ b/quil-rs/src/program/mod.rs
@@ -12,6 +12,9 @@
 //See the License for the specific language governing permissions and
 // limitations under the License.
 
+// TODO: Address https://github.com/rigetti/quil-rs/issues/453
+#![allow(clippy::result_large_err)]
+
 use std::collections::{HashMap, HashSet};
 use std::ops::{self};
 use std::str::FromStr;
@@ -55,6 +58,8 @@ pub mod scheduling;
 mod source_map;
 pub mod type_check;
 
+// TODO: Address https://github.com/rigetti/quil-rs/issues/453
+#[allow(clippy::large_enum_variant)]
 #[derive(Clone, Debug, PartialEq, thiserror::Error)]
 pub enum ProgramError {
     #[error("{0}")]

--- a/quil-rs/src/program/type_check.rs
+++ b/quil-rs/src/program/type_check.rs
@@ -1,6 +1,10 @@
 //! Type check Quil programs.
 //!
 //! See the [Quil spec](https://quil-lang.github.io/).
+
+// TODO: Address https://github.com/rigetti/quil-rs/issues/452
+#![allow(clippy::result_large_err)]
+
 use std::fmt::Debug;
 
 use indexmap::IndexMap;


### PR DESCRIPTION
This edits `quil-py`'s `pyproject.toml` to target Python versions 3.9 through 3.12 and sets `numpy>=1.26`, since the previous version combination wasn't accurate and could cause build errors during dependency solving.

Closes: #449