### PR TITLE
feat(quil-py): add waveform constructors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1202,7 +1202,7 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quil-cli"
-version = "0.7.2-rc.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1211,7 +1211,7 @@ dependencies = [
 
 [[package]]
 name = "quil-py"
-version = "0.15.4-rc.0"
+version = "0.16.0"
 dependencies = [
  "indexmap",
  "internment",
@@ -1227,7 +1227,7 @@ dependencies = [
 
 [[package]]
 name = "quil-rs"
-version = "0.30.2-rc.0"
+version = "0.31.0"
 dependencies = [
  "approx",
  "clap",

--- a/quil-py/quil/waveforms/__init__.pyi
+++ b/quil-py/quil/waveforms/__init__.pyi
@@ -1,20 +1,19 @@
 from typing import Iterable
 
 __all__ = [
-    'BoxcarKernel',
-    'ErfSquare',
-    'Gaussian',
-    'DragGaussian',
-    'HermiteGaussian',
-    'apply_phase_and_detuning',
+    "BoxcarKernel",
+    "ErfSquare",
+    "Gaussian",
+    "DragGaussian",
+    "HermiteGaussian",
+    "apply_phase_and_detuning",
 ]
 
 def apply_phase_and_detuning(iq_values: Iterable[complex], phase: float, detuning: float, sample_rate: float):
     """Modulate and phase shift waveform IQ data in place."""
 
-
 class BoxcarKernel:
-    def __new__(cls, phase_cycles: float, scale: float, sample_count: int) -> BoxcarKernel:
+    def __new__(cls, phase: float, scale: float, sample_count: int) -> BoxcarKernel:
         """Create a new BoxcarKernel."""
 
     @property
@@ -32,13 +31,21 @@ class BoxcarKernel:
     def into_iq_value(self) -> complex:
         """Convert BoxcarKernel into a Complex64 value."""
 
-
 class ErfSquare:
     """A waveform with a flat top and edges that are error functions (erfs)."""
 
-    def __new__(cls, duration: float, risetime: float, sample_rate: float,
-                 pad_left: float, pad_right: float, positive_polarity: bool,
-                 scale: float, phase: float, detuning: float) -> ErfSquare:
+    def __new__(
+        cls,
+        duration: float,
+        risetime: float,
+        sample_rate: float,
+        pad_left: float,
+        pad_right: float,
+        positive_polarity: bool,
+        scale: float,
+        phase: float,
+        detuning: float,
+    ) -> ErfSquare:
         """Create a new ErfSquare."""
 
     @property
@@ -51,7 +58,7 @@ class ErfSquare:
 
     @property
     def sample_rate(self) -> float:
-        """Generate wavform samples at this rate (Hz)"""
+        """Generate waveform samples at this rate (Hz)"""
 
     @property
     def pad_left(self) -> float:
@@ -80,13 +87,19 @@ class ErfSquare:
     def into_iq_values(self) -> list[complex]:
         """Convert ErfSquare into a list of Complex64 values."""
 
-
 class Gaussian:
     """A waveform with a Gaussian shape."""
 
-    def __new__(cls, duration: float, fwhm: float, t0: float,
-                 sample_rate: float, scale: float, phase: float,
-                 detuning: float) -> Gaussian:
+    def __new__(
+        cls,
+        duration: float,
+        fwhm: float,
+        t0: float,
+        sample_rate: float,
+        scale: float,
+        phase: float,
+        detuning: float,
+    ) -> Gaussian:
         """Create a new Gaussian."""
 
     @property
@@ -120,7 +133,6 @@ class Gaussian:
     def into_iq_values(self) -> list[complex]:
         """Convert Gaussian into a list of Complex64 values."""
 
-
 class DragGaussian:
     """A waveform with a DRAG-corrected Gaussian shape.
 
@@ -130,9 +142,18 @@ class DragGaussian:
     See Motzoi F. et al., Phys. Rev. Lett., 103 (2009) 110501. for details.
     """
 
-    def __new__(cls, duration: float, fwhm: float, t0: float, anh: float,
-                 alpha: float, sample_rate: float, scale: float, phase: float,
-                 detuning: float) -> DragGaussian:
+    def __new__(
+        cls,
+        duration: float,
+        fwhm: float,
+        t0: float,
+        anh: float,
+        alpha: float,
+        sample_rate: float,
+        scale: float,
+        phase: float,
+        detuning: float,
+    ) -> DragGaussian:
         """Create a new DragGaussian."""
 
     @property
@@ -174,7 +195,6 @@ class DragGaussian:
     def into_iq_values(self) -> list[complex]:
         """Convert DragGaussian into a list of Complex64 values."""
 
-
 class HermiteGaussian:
     """A Hermite Gaussian waveform.
 
@@ -187,9 +207,19 @@ class HermiteGaussian:
     for details.
     """
 
-    def __new__(cls, duration: float, fwhm: float, t0: float, anh: float,
-                 alpha: float, sample_rate: float, second_order_hrm_coeff: float,
-                 scale: float, phase: float, detuning: float) -> HermiteGaussian:
+    def __new__(
+        cls,
+        duration: float,
+        fwhm: float,
+        t0: float,
+        anh: float,
+        alpha: float,
+        sample_rate: float,
+        second_order_hrm_coeff: float,
+        scale: float,
+        phase: float,
+        detuning: float,
+    ) -> HermiteGaussian:
         """Create a new HermiteGaussian."""
 
     @property

--- a/quil-py/quil/waveforms/__init__.pyi
+++ b/quil-py/quil/waveforms/__init__.pyi
@@ -11,12 +11,11 @@ __all__ = [
 
 def apply_phase_and_detuning(iq_values: Iterable[complex], phase: float, detuning: float, sample_rate: float):
     """Modulate and phase shift waveform IQ data in place."""
-    ...
+
 
 class BoxcarKernel:
-    def __new__(self, phase_cycles: float, scale: float, sample_count: int) -> BoxcarKernel:
+    def __new__(cls, phase_cycles: float, scale: float, sample_count: int) -> BoxcarKernel:
         """Create a new BoxcarKernel."""
-        ...
 
     @property
     def phase(self) -> float:
@@ -36,10 +35,11 @@ class BoxcarKernel:
 
 class ErfSquare:
     """A waveform with a flat top and edges that are error functions (erfs)."""
-    def __new__(self, duration: float, risetime: float, sample_rate: float,
+
+    def __new__(cls, duration: float, risetime: float, sample_rate: float,
                  pad_left: float, pad_right: float, positive_polarity: bool,
                  scale: float, phase: float, detuning: float) -> ErfSquare:
-        ...
+        """Create a new ErfSquare."""
 
     @property
     def duration(self) -> float:
@@ -83,10 +83,11 @@ class ErfSquare:
 
 class Gaussian:
     """A waveform with a Gaussian shape."""
-    def __new__(self, duration: float, fwhm: float, t0: float,
+
+    def __new__(cls, duration: float, fwhm: float, t0: float,
                  sample_rate: float, scale: float, phase: float,
                  detuning: float) -> Gaussian:
-        ...
+        """Create a new Gaussian."""
 
     @property
     def duration(self) -> float:
@@ -121,16 +122,18 @@ class Gaussian:
 
 
 class DragGaussian:
-    """A waveform with a DRAG-corrected Gaussian shape.                                                             
-                                                                                                                     
-    This is a Gaussian shape with an additional component proportional to the time derivative of the main Gaussian pulse.
-                                                                                                                         
-    See Motzoi F. et al., Phys. Rev. Lett., 103 (2009) 110501. for details.                                              
+    """A waveform with a DRAG-corrected Gaussian shape.
+
+    This is a Gaussian shape with an additional component
+    proportional to the time derivative of the main Gaussian pulse.
+
+    See Motzoi F. et al., Phys. Rev. Lett., 103 (2009) 110501. for details.
     """
-    def __new__(self, duration: float, fwhm: float, t0: float, anh: float,
+
+    def __new__(cls, duration: float, fwhm: float, t0: float, anh: float,
                  alpha: float, sample_rate: float, scale: float, phase: float,
                  detuning: float) -> DragGaussian:
-        ...
+        """Create a new DragGaussian."""
 
     @property
     def duration(self) -> float:
@@ -170,7 +173,6 @@ class DragGaussian:
 
     def into_iq_values(self) -> list[complex]:
         """Convert DragGaussian into a list of Complex64 values."""
-        ...
 
 
 class HermiteGaussian:
@@ -184,10 +186,11 @@ class HermiteGaussian:
     Warren S. Warren. 81, (1984); doi: 10.1063/1.447644
     for details.
     """
-    def __new__(self, duration: float, fwhm: float, t0: float, anh: float,
+
+    def __new__(cls, duration: float, fwhm: float, t0: float, anh: float,
                  alpha: float, sample_rate: float, second_order_hrm_coeff: float,
                  scale: float, phase: float, detuning: float) -> HermiteGaussian:
-        ...
+        """Create a new HermiteGaussian."""
 
     @property
     def duration(self) -> float:
@@ -231,4 +234,3 @@ class HermiteGaussian:
 
     def into_iq_values(self) -> list[complex]:
         """Convert HermiteGaussian into a list of Complex64 values."""
-        ...

--- a/quil-py/src/waveforms.rs
+++ b/quil-py/src/waveforms.rs
@@ -109,6 +109,35 @@ impl_into_iq_values!(PyErfSquare);
 impl_repr!(PyErfSquare);
 impl_eq!(PyErfSquare);
 
+#[pymethods]
+impl PyErfSquare {
+    #[new]
+    #[allow(clippy::too_many_arguments)]
+    fn __new__(
+        duration: f64,
+        risetime: f64,
+        sample_rate: f64,
+        pad_left: f64,
+        pad_right: f64,
+        positive_polarity: bool,
+        scale: f64,
+        phase: f64,
+        detuning: f64,
+    ) -> Self {
+        PyErfSquare(ErfSquare {
+            duration,
+            risetime,
+            sample_rate,
+            pad_left,
+            pad_right,
+            positive_polarity,
+            scale,
+            phase,
+            detuning,
+        })
+    }
+}
+
 py_wrap_data_struct! {
     #[derive(Debug, PartialEq)]
     #[pyo3(subclass)]
@@ -125,6 +154,30 @@ py_wrap_data_struct! {
 impl_into_iq_values!(PyGaussian);
 impl_repr!(PyGaussian);
 impl_eq!(PyGaussian);
+
+#[pymethods]
+impl PyGaussian {
+    #[new]
+    fn __new__(
+        duration: f64,
+        fwhm: f64,
+        t0: f64,
+        sample_rate: f64,
+        scale: f64,
+        phase: f64,
+        detuning: f64,
+    ) -> Self {
+        PyGaussian(Gaussian {
+            duration,
+            fwhm,
+            t0,
+            sample_rate,
+            scale,
+            phase,
+            detuning,
+        })
+    }
+}
 
 py_wrap_data_struct! {
     #[derive(Debug, PartialEq)]
@@ -145,6 +198,35 @@ impl_into_iq_values!(PyDragGaussian);
 impl_repr!(PyDragGaussian);
 impl_eq!(PyDragGaussian);
 
+#[pymethods]
+impl PyDragGaussian {
+    #[new]
+    #[allow(clippy::too_many_arguments)]
+    fn __new__(
+        duration: f64,
+        fwhm: f64,
+        t0: f64,
+        anh: f64,
+        alpha: f64,
+        sample_rate: f64,
+        scale: f64,
+        phase: f64,
+        detuning: f64,
+    ) -> Self {
+        PyDragGaussian(DragGaussian {
+            duration,
+            fwhm,
+            t0,
+            anh,
+            alpha,
+            sample_rate,
+            scale,
+            phase,
+            detuning,
+        })
+    }
+}
+
 py_wrap_data_struct! {
     #[derive(Debug, PartialEq)]
     #[pyo3(subclass)]
@@ -164,3 +246,34 @@ py_wrap_data_struct! {
 impl_into_iq_values!(PyHermiteGaussian);
 impl_repr!(PyHermiteGaussian);
 impl_eq!(PyHermiteGaussian);
+
+#[pymethods]
+impl PyHermiteGaussian {
+    #[allow(clippy::too_many_arguments)]
+    #[new]
+    fn __new__(
+        duration: f64,
+        fwhm: f64,
+        t0: f64,
+        anh: f64,
+        alpha: f64,
+        sample_rate: f64,
+        second_order_hrm_coeff: f64,
+        scale: f64,
+        phase: f64,
+        detuning: f64,
+    ) -> Self {
+        PyHermiteGaussian(HermiteGaussian {
+            duration,
+            fwhm,
+            t0,
+            anh,
+            alpha,
+            sample_rate,
+            second_order_hrm_coeff,
+            scale,
+            phase,
+            detuning,
+        })
+    }
+}

--- a/quil-py/tests_py/conftest.py
+++ b/quil-py/tests_py/conftest.py
@@ -1,0 +1,153 @@
+import math
+import random
+from random import Random
+
+from pytest import fixture
+
+
+@fixture
+def rng(seed: int) -> Random:
+    """Get an RNG for tests where the actual parameters are somewhat arbitrary,
+    and instead you're testing specific behavior.
+
+    By default, a preset seed is used each run.
+    You can set that seed directly as with the following example::
+
+        pytest --seed 62590
+
+    Alternatively, you can run a number of random trials,
+    each getting a different randomized seed.
+    This run 100 tests with different random seeds::
+
+        pytest --trials 100
+
+    You can combine these options to test first with a specific seed,
+    then with a number of random seeds.
+    """
+    return Random(seed)
+
+
+def pytest_addoption(parser):
+    """Add new options for pytest tests."""
+
+    parser.addoption("--trials", help="set a number of random test runs to perform")
+    parser.addoption("--seed", help="set a specific seed to use")
+
+
+def pytest_generate_tests(metafunc):
+    if "seed" in metafunc.fixturenames:
+        given_seed = metafunc.config.getoption("seed")
+        seeds = [int(given_seed or 62590)]
+
+        # Create random seeds if additional trials requested.
+        trials = max(0, int(metafunc.config.getoption("trials") or 0))
+        if trials <= 0 and not given_seed:
+            trials = 1
+        seeds.extend(random.randint(0, (1 << 32) - 1) for _ in range(trials))
+
+        metafunc.parametrize("seed", seeds)
+
+
+@fixture
+def phase(rng: Random) -> float:
+    r"""Return a random phase between :math:`0` and :math:`2\pi`."""
+
+    return rng.uniform(0, math.pi * 2)
+
+
+@fixture
+def sample_count(rng: Random) -> int:
+    r"""Return a random sample count."""
+
+    return rng.randint(0, (1 << 64) - 1)
+
+
+@fixture
+def duration(rng: Random) -> float:
+    r"""Return a random duration."""
+
+    return rng.uniform(0, 1e10)
+
+
+@fixture
+def risetime(rng: Random) -> float:
+    r"""Return a random risetime."""
+
+    return rng.uniform(0, 1e10)
+
+
+@fixture
+def sample_rate(rng: Random) -> float:
+    r"""Return a random sample_rate."""
+
+    return rng.uniform(0, 1e10)
+
+
+@fixture
+def second_order_hrm_coeff(rng: Random) -> float:
+    r"""Return a random second_order_hrm_coeff."""
+
+    return rng.uniform(0, 1e10)
+
+
+@fixture
+def alpha(rng: Random) -> float:
+    r"""Return a random alpha."""
+
+    return rng.uniform(0, 1e10)
+
+
+@fixture
+def anh(rng: Random) -> float:
+    r"""Return a random anharmonicity constant."""
+
+    return rng.uniform(0, 1e10)
+
+
+@fixture
+def fwhm(rng: Random) -> float:
+    r"""Return a random full width at half maximum value."""
+
+    return rng.uniform(0, 1e10)
+
+
+@fixture
+def t0(rng: Random) -> float:
+    r"""Return a random t0."""
+
+    return rng.uniform(0, 1e10)
+
+
+@fixture
+def pad_left(rng: Random) -> float:
+    r"""Return a random pad_left."""
+
+    return rng.uniform(0, 1e10)
+
+
+@fixture
+def pad_right(rng: Random) -> float:
+    r"""Return a random pad_right."""
+
+    return rng.uniform(0, 1e10)
+
+
+@fixture
+def positive_polarity(rng: Random) -> bool:
+    r"""Return a random positive polarity."""
+
+    return bool(rng.randint(0, 1))
+
+
+@fixture
+def scale(rng: Random) -> float:
+    r"""Return a random scale."""
+
+    return rng.uniform(0, 1e10)
+
+
+@fixture
+def detuning(rng: Random) -> float:
+    r"""Return a random detuning."""
+
+    return rng.uniform(0, 1e10)

--- a/quil-py/tests_py/test_waveforms.py
+++ b/quil-py/tests_py/test_waveforms.py
@@ -1,17 +1,148 @@
 from quil import waveforms
 
+
 class TestConstructors:
-    def test_boxcar_kernel(self):
-        waveforms.BoxcarKernel(0.0, 0.0, 0)
+    """Test that class constructors exist,
+    accept the expected argument names,
+    and correctly round-trip their values.
+    """
 
-    def test_drag_gaussian(self):
-        waveforms.DragGaussian(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+    def test_boxcar_kernel(self, phase: float, scale: float, sample_count: int):
+        wf = waveforms.BoxcarKernel(phase=phase, scale=scale, sample_count=sample_count)
+        assert wf is not None
+        assert wf.phase == phase
+        assert wf.scale == scale
+        assert wf.sample_count == sample_count
 
-    def test_erf_square(self):
-        waveforms.ErfSquare(0.0, 0.0, 0.0, 0.0, 0.0, False, 0.0, 0.0, 0.0)
+    def test_erf_square(
+        self,
+        duration: float,
+        risetime: float,
+        sample_rate: float,
+        pad_left: float,
+        pad_right: float,
+        positive_polarity: bool,
+        scale: float,
+        phase: float,
+        detuning: float,
+    ):
+        wf = waveforms.ErfSquare(
+            duration=duration,
+            risetime=risetime,
+            sample_rate=sample_rate,
+            pad_left=pad_left,
+            pad_right=pad_right,
+            positive_polarity=positive_polarity,
+            scale=scale,
+            phase=phase,
+            detuning=detuning,
+        )
+        assert wf is not None
+        assert wf.duration == duration
+        assert wf.risetime == risetime
+        assert wf.sample_rate == sample_rate
+        assert wf.pad_left == pad_left
+        assert wf.pad_right == pad_right
+        assert wf.positive_polarity == positive_polarity
+        assert wf.scale == scale
+        assert wf.phase == phase
+        assert wf.detuning == detuning
 
-    def test_gaussian(self):
-        waveforms.Gaussian(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+    def test_gaussian(
+        self,
+        duration: float,
+        fwhm: float,
+        t0: float,
+        sample_rate: float,
+        scale: float,
+        phase: float,
+        detuning: float,
+    ):
+        wf = waveforms.Gaussian(
+            duration=duration,
+            fwhm=fwhm,
+            t0=t0,
+            sample_rate=sample_rate,
+            scale=scale,
+            phase=phase,
+            detuning=detuning,
+        )
+        assert wf is not None
+        assert wf.duration == duration
+        assert wf.fwhm == fwhm
+        assert wf.t0 == t0
+        assert wf.sample_rate == sample_rate
+        assert wf.scale == scale
+        assert wf.phase == phase
+        assert wf.detuning == detuning
 
-    def test_hermite(self):
-        waveforms.HermiteGaussian(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+    def test_drag_gaussian(
+        self,
+        duration: float,
+        fwhm: float,
+        t0: float,
+        anh: float,
+        alpha: float,
+        sample_rate: float,
+        scale: float,
+        phase: float,
+        detuning: float,
+    ):
+        wf = waveforms.DragGaussian(
+            duration=duration,
+            fwhm=fwhm,
+            t0=t0,
+            anh=anh,
+            alpha=alpha,
+            sample_rate=sample_rate,
+            scale=scale,
+            phase=phase,
+            detuning=detuning,
+        )
+        assert wf is not None
+        assert wf.duration == duration
+        assert wf.fwhm == fwhm
+        assert wf.t0 == t0
+        assert wf.anh == anh
+        assert wf.alpha == alpha
+        assert wf.sample_rate == sample_rate
+        assert wf.scale == scale
+        assert wf.phase == phase
+        assert wf.detuning == detuning
+
+    def test_hermite_gaussian(
+        self,
+        duration: float,
+        fwhm: float,
+        t0: float,
+        anh: float,
+        alpha: float,
+        sample_rate: float,
+        second_order_hrm_coeff: float,
+        scale: float,
+        phase: float,
+        detuning: float,
+    ):
+        wf = waveforms.HermiteGaussian(
+            duration=duration,
+            fwhm=fwhm,
+            t0=t0,
+            anh=anh,
+            alpha=alpha,
+            sample_rate=sample_rate,
+            second_order_hrm_coeff=second_order_hrm_coeff,
+            scale=scale,
+            phase=phase,
+            detuning=detuning,
+        )
+        assert wf is not None
+        assert wf.duration == duration
+        assert wf.fwhm == fwhm
+        assert wf.t0 == t0
+        assert wf.anh == anh
+        assert wf.alpha == alpha
+        assert wf.sample_rate == sample_rate
+        assert wf.second_order_hrm_coeff == second_order_hrm_coeff
+        assert wf.scale == scale
+        assert wf.phase == phase
+        assert wf.detuning == detuning

--- a/quil-py/tests_py/test_waveforms.py
+++ b/quil-py/tests_py/test_waveforms.py
@@ -1,0 +1,17 @@
+from quil import waveforms
+
+class TestConstructors:
+    def test_boxcar_kernel(self):
+        waveforms.BoxcarKernel(0.0, 0.0, 0)
+
+    def test_drag_gaussian(self):
+        waveforms.DragGaussian(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+
+    def test_erf_square(self):
+        waveforms.ErfSquare(0.0, 0.0, 0.0, 0.0, 0.0, False, 0.0, 0.0, 0.0)
+
+    def test_gaussian(self):
+        waveforms.Gaussian(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+
+    def test_hermite(self):
+        waveforms.HermiteGaussian(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)


### PR DESCRIPTION
Adds missing constructors to the waveforms classes. This is essentially the same as the #423 and #424, but against the updated dependencies.

Closes: #422