### PR TITLE
style: inline format arguments

### DIFF
--- a/quil-py/src/instruction/declaration.rs
+++ b/quil-py/src/instruction/declaration.rs
@@ -39,8 +39,6 @@ impl_to_quil!(PyScalarType);
 impl_hash!(PyScalarType);
 
 impl rigetti_pyo3::PyTryFrom<pyo3::PyAny> for PyScalarType {
-    // TODO: Address https://github.com/rigetti/quil-rs/issues/451
-    #[allow(clippy::uninlined_format_args)]
     fn py_try_from(_py: Python, item: &pyo3::PyAny) -> PyResult<Self> {
         let item = item.extract::<String>()?;
         match item.as_str() {
@@ -49,8 +47,7 @@ impl rigetti_pyo3::PyTryFrom<pyo3::PyAny> for PyScalarType {
             "OCTET" => Ok(Self::Octet),
             "REAL" => Ok(Self::Real),
             _ => Err(PyValueError::new_err(format!(
-                "Invalid value for ScalarType: {}",
-                item
+                "Invalid value for ScalarType: {item}"
             ))),
         }
     }

--- a/quil-rs/Cargo.toml
+++ b/quil-rs/Cargo.toml
@@ -65,7 +65,3 @@ harness = false
 [[example]]
 name = "generate_test_expressions"
 
-[lints.clippy]
-# TODO: Address github.com/rigetti/quil-rs/issues/451
-uninlined_format_args = "allow"
-

--- a/quil-rs/src/expression/mod.rs
+++ b/quil-rs/src/expression/mod.rs
@@ -608,7 +608,7 @@ impl Quil for Expression {
                 right,
             }) => {
                 format_inner_expression(f, fall_back_to_debug, left)?;
-                write!(f, "{}", operator)?;
+                write!(f, "{operator}")?;
                 format_inner_expression(f, fall_back_to_debug, right)
             }
             Number(value) => write!(f, "{}", format_complex(value)).map_err(Into::into),
@@ -617,10 +617,10 @@ impl Quil for Expression {
                 operator,
                 expression,
             }) => {
-                write!(f, "{}", operator)?;
+                write!(f, "{operator}")?;
                 format_inner_expression(f, fall_back_to_debug, expression)
             }
-            Variable(identifier) => write!(f, "%{}", identifier).map_err(Into::into),
+            Variable(identifier) => write!(f, "%{identifier}").map_err(Into::into),
         }
     }
 }

--- a/quil-rs/src/instruction/circuit.rs
+++ b/quil-rs/src/instruction/circuit.rs
@@ -38,15 +38,15 @@ impl Quil for CircuitDefinition {
             write!(writer, "(")?;
             let mut iter = self.parameters.iter();
             if let Some(p) = iter.next() {
-                write!(writer, "%{}", p)?;
+                write!(writer, "%{p}")?;
             }
             for p in iter {
-                write!(writer, ", %{}", p)?;
+                write!(writer, ", %{p}")?;
             }
             write!(writer, ")")?;
         }
         for qubit_variable in &self.qubit_variables {
-            write!(writer, " {}", qubit_variable)?;
+            write!(writer, " {qubit_variable}")?;
         }
         writeln!(writer, ":")?;
         for instruction in &self.instructions {

--- a/quil-rs/src/instruction/control_flow.rs
+++ b/quil-rs/src/instruction/control_flow.rs
@@ -51,10 +51,10 @@ impl Quil for Target {
         fall_back_to_debug: bool,
     ) -> crate::quil::ToQuilResult<()> {
         match self {
-            Target::Fixed(label) => write!(writer, "@{}", label).map_err(Into::into),
+            Target::Fixed(label) => write!(writer, "@{label}").map_err(Into::into),
             Target::Placeholder(_) => {
                 if fall_back_to_debug {
-                    write!(writer, "@{:?}", self).map_err(Into::into)
+                    write!(writer, "@{self:?}").map_err(Into::into)
                 } else {
                     Err(ToQuilError::UnresolvedLabelPlaceholder)
                 }

--- a/quil-rs/src/instruction/extern_call.rs
+++ b/quil-rs/src/instruction/extern_call.rs
@@ -1444,10 +1444,10 @@ mod tests {
         match (test_case.expected, found) {
             (Ok(expected), Ok(found)) => assert_eq!(expected, found),
             (Ok(expected), Err(found)) => {
-                panic!("expected resolution {:?}, found err {:?}", expected, found)
+                panic!("expected resolution {expected:?}, found err {found:?}")
             }
             (Err(expected), Ok(found)) => {
-                panic!("expected err {:?}, found resolution {:?}", expected, found)
+                panic!("expected err {expected:?}, found resolution {found:?}")
             }
             (Err(expected), Err(found)) => assert_eq!(expected, found),
         }
@@ -1528,10 +1528,10 @@ mod tests {
         match (test_case.expected, found) {
             (Ok(expected), Ok(found)) => assert_eq!(expected, found),
             (Ok(expected), Err(found)) => {
-                panic!("expected resolution {:?}, found err {:?}", expected, found)
+                panic!("expected resolution {expected:?}, found err {found:?}")
             }
             (Err(expected), Ok(found)) => {
-                panic!("expected err {:?}, found resolution {:?}", expected, found)
+                panic!("expected err {expected:?}, found resolution {found:?}")
             }
             (Err(expected), Err(found)) => assert_eq!(expected, found),
         }
@@ -1829,10 +1829,10 @@ mod tests {
         match (test_case.expected, found) {
             (Ok(_), Ok(_)) => {}
             (Ok(expected), Err(found)) => {
-                panic!("expected resolution {:?}, found err {:?}", expected, found)
+                panic!("expected resolution {expected:?}, found err {found:?}")
             }
             (Err(expected), Ok(found)) => {
-                panic!("expected err {:?}, found resolution {:?}", expected, found)
+                panic!("expected err {expected:?}, found resolution {found:?}")
             }
             (Err(expected), Err(found)) => assert_eq!(expected, found),
         }
@@ -1949,7 +1949,7 @@ mod tests {
                 assert_eq!(expected, found);
             }
             (Ok(expected), Err(found)) => {
-                panic!("expected resolution {:?}, found err {:?}", expected, found)
+                panic!("expected resolution {expected:?}, found err {found:?}")
             }
             (Err(expected), Ok(_)) => {
                 panic!(
@@ -2169,10 +2169,10 @@ mod tests {
                 assert_eq!(expected, found);
             }
             (Ok(_), Err(found)) => {
-                panic!("expected valid, found err {:?}", found)
+                panic!("expected valid, found err {found:?}")
             }
             (Err(expected), Ok(_)) => {
-                panic!("expected err {:?}, found valid", expected)
+                panic!("expected err {expected:?}, found valid")
             }
             (Err(expected), Err((_, found))) => assert_eq!(expected, found),
         }
@@ -2319,20 +2319,15 @@ mod tests {
                 assert_eq!(expected, parsed);
             }
             (Ok(expected), Err(e)) => {
-                panic!("Expected {:?}, got error: {:?}", expected, e);
+                panic!("Expected {expected:?}, got error: {e:?}");
             }
             (Err(expected), Ok(parsed)) => {
-                panic!("Expected error: {:?}, got {:?}", expected, parsed);
+                panic!("Expected error: {expected:?}, got {parsed:?}");
             }
             (Err(expected), Err(found)) => {
                 let expected = format!("{expected:?}");
                 let found = format!("{found:?}");
-                assert!(
-                    found.contains(&expected),
-                    "`{}` not in `{}`",
-                    expected,
-                    found
-                );
+                assert!(found.contains(&expected), "`{expected}` not in `{found}`");
             }
         }
     }

--- a/quil-rs/src/instruction/mod.rs
+++ b/quil-rs/src/instruction/mod.rs
@@ -339,7 +339,7 @@ where
             match c {
                 '"' => write!(f, "\\\"")?,
                 '\\' => write!(f, "\\\\")?,
-                c => write!(f, "{}", c)?,
+                c => write!(f, "{c}")?,
             }
         }
         write!(f, "\"")

--- a/quil-rs/src/instruction/qubit.rs
+++ b/quil-rs/src/instruction/qubit.rs
@@ -33,7 +33,7 @@ impl Quil for Qubit {
             Fixed(value) => write!(writer, "{value}").map_err(Into::into),
             Placeholder(_) => {
                 if fall_back_to_debug {
-                    write!(writer, "{:?}", self).map_err(Into::into)
+                    write!(writer, "{self:?}").map_err(Into::into)
                 } else {
                     Err(ToQuilError::UnresolvedQubitPlaceholder)
                 }

--- a/quil-rs/src/instruction/timing.rs
+++ b/quil-rs/src/instruction/timing.rs
@@ -30,7 +30,7 @@ impl Quil for Delay {
             qubit.write(writer, fall_back_to_debug)?;
         }
         for frame_name in &self.frame_names {
-            write!(writer, " \"{}\"", frame_name)?;
+            write!(writer, " \"{frame_name}\"")?;
         }
         write!(writer, " ",)?;
         self.duration.write(writer, fall_back_to_debug)

--- a/quil-rs/src/parser/command.rs
+++ b/quil-rs/src/parser/command.rs
@@ -1156,19 +1156,14 @@ mod tests {
                 assert_eq!(remainder, test_case.remainder);
             }
             (Ok(expected), Err(e)) => {
-                panic!("Expected {:?}, got error: {:?}", expected, e);
+                panic!("Expected {expected:?}, got error: {e:?}");
             }
             (Err(expected), Ok((_, parsed))) => {
-                panic!("Expected error: {:?}, got {:?}", expected, parsed);
+                panic!("Expected error: {expected:?}, got {parsed:?}");
             }
             (Err(expected), Err(found)) => {
                 let found = format!("{found:?}");
-                assert!(
-                    found.contains(&expected),
-                    "`{}` not in `{}`",
-                    expected,
-                    found
-                );
+                assert!(found.contains(&expected), "`{expected}` not in `{found}`");
             }
         }
     }

--- a/quil-rs/src/parser/lexer/quoted_strings.rs
+++ b/quil-rs/src/parser/lexer/quoted_strings.rs
@@ -121,9 +121,7 @@ mod tests {
         let round_tripped = QuotedString(&parsed).to_string();
         assert!(
             input.starts_with(&round_tripped),
-            "expected `{}` to start with `{}`",
-            input,
-            round_tripped
+            "expected `{input}` to start with `{round_tripped}`"
         );
     }
 }

--- a/quil-rs/src/program/analysis/control_flow_graph.rs
+++ b/quil-rs/src/program/analysis/control_flow_graph.rs
@@ -602,7 +602,7 @@ X 0
         let program: Program = input.parse().unwrap();
         let graph = ControlFlowGraph::from(&program);
         let blocks = graph.into_blocks();
-        println!("blocks: {:#?}", blocks);
+        println!("blocks: {blocks:#?}");
         let actual = blocks
             .iter()
             .map(|block| block.instruction_index_offset())
@@ -637,10 +637,10 @@ PULSE 0 "a" flat(duration: 1.0)
         let program: Program = input.parse().unwrap();
         let graph = ControlFlowGraph::from(&program);
         let blocks = graph.into_blocks();
-        println!("blocks: {:#?}", blocks);
+        println!("blocks: {blocks:#?}");
 
         let schedule = blocks[0].as_schedule_seconds(&program).unwrap();
-        println!("schedule: {:#?}", schedule);
+        println!("schedule: {schedule:#?}");
         assert_eq!(schedule.duration().0, 21.0);
         let schedule_items = schedule.into_items();
 
@@ -762,7 +762,7 @@ CZ 0 2
         let program: Program = input.parse().unwrap();
         let graph = ControlFlowGraph::from(&program);
         let blocks = graph.into_blocks();
-        println!("blocks: {:#?}", blocks);
+        println!("blocks: {blocks:#?}");
 
         let schedule = blocks[0].as_schedule_seconds(&program).unwrap();
         let mut schedule_items = schedule.into_items();

--- a/quil-rs/src/program/scheduling/graphviz_dot.rs
+++ b/quil-rs/src/program/scheduling/graphviz_dot.rs
@@ -117,7 +117,7 @@ impl From<usize> for DotFormatBlockLabel<'_> {
 impl std::fmt::Display for DotFormatBlockLabel<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            DotFormatBlockLabel::Unlabeled { index } => write!(f, "block_{}", index),
+            DotFormatBlockLabel::Unlabeled { index } => write!(f, "block_{index}"),
             DotFormatBlockLabel::Labeled(label) => write!(f, "{}", label.to_quil_or_debug()),
         }
     }
@@ -141,7 +141,7 @@ impl ScheduledProgram<'_> {
             let mut digraph = writer.digraph();
 
             let blocks = self.basic_blocks();
-            println!("blocks: {:?}", blocks);
+            println!("blocks: {blocks:?}");
             let mut iter = blocks.iter().enumerate().peekable();
             if let Some((index, first_block)) = iter.peek() {
                 let block_node_label = first_block

--- a/quil-rs/src/waveform/templates.rs
+++ b/quil-rs/src/waveform/templates.rs
@@ -262,10 +262,7 @@ mod tests {
     fn assert_almost_eq(left: Complex64, right: Complex64, epsilon: f64) {
         assert!(
             (left - right).norm() < epsilon,
-            "Expected {} to be almost equal to {} with epsilon {}",
-            left,
-            right,
-            epsilon
+            "Expected {left} to be almost equal to {right} with epsilon {epsilon}"
         );
     }
 

--- a/quil-rs/tests/calibration_test.rs
+++ b/quil-rs/tests/calibration_test.rs
@@ -13,7 +13,7 @@ use quil_rs::quil::Quil;
 #[rstest]
 fn test_calibration_filtering(#[files("tests/programs/calibration_*.quil")] path: PathBuf) {
     let program_text =
-        read_to_string(&path).unwrap_or_else(|_| panic!("Should be able to load file: {:?}", path));
+        read_to_string(&path).unwrap_or_else(|_| panic!("Should be able to load file: {path:?}"));
     let program = Program::from_str(&program_text).expect("Should be able to parse test program.");
 
     assert_snapshot!(


### PR DESCRIPTION
These changes were applied automatically using `cargo clippy --fix`.

Closes: #451