### PR TITLE
ci: update Cargo.lock when releasing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,9 +28,9 @@ jobs:
         fetch-depth: 0
         token: ${{ secrets.PAT }}
     - name: Install Knope
-      uses: knope-dev/action@v2.0.0
+      uses: knope-dev/action@v2.1.0
       with:
-        version: 0.16.0 # Test before updating, breaking changes likely: https://github.com/knope-dev/action#install-latest-version
+        version: 0.21.3 # Test before updating, breaking changes likely: https://github.com/knope-dev/action#install-latest-version
     - run: |
         git config --global user.name "${{ github.triggering_actor }}"
         git config --global user.email "${{ github.triggering_actor}}@users.noreply.github.com"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1202,7 +1202,7 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quil-cli"
-version = "0.8.0"
+version = "0.9.0-rc.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -1211,7 +1211,7 @@ dependencies = [
 
 [[package]]
 name = "quil-py"
-version = "0.16.0"
+version = "0.17.0-rc.2"
 dependencies = [
  "indexmap",
  "internment",
@@ -1227,7 +1227,7 @@ dependencies = [
 
 [[package]]
 name = "quil-rs"
-version = "0.31.0"
+version = "0.32.0-rc.2"
 dependencies = [
  "approx",
  "clap",

--- a/knope.toml
+++ b/knope.toml
@@ -1,15 +1,15 @@
 [packages.quil-rs]
-versioned_files = ["quil-rs/Cargo.toml"]
+versioned_files = ["quil-rs/Cargo.toml", "Cargo.lock"]
 changelog = "quil-rs/CHANGELOG.md"
 scopes = ["rs", "rust", "quil-rs"]
 
 [packages.quil-py]
-versioned_files = ["quil-py/Cargo.toml", "quil-py/pyproject.toml"]
+versioned_files = ["quil-py/Cargo.toml", "quil-py/pyproject.toml", "Cargo.lock"]
 changelog = "quil-py/CHANGELOG.md"
 scopes = ["py", "python", "quil-py"]
 
 [packages.quil-cli]
-versioned_files = ["quil-cli/Cargo.toml"]
+versioned_files = ["quil-cli/Cargo.toml", "Cargo.lock"]
 changelog = "quil-cli/CHANGELOG.md"
 scopes = ["cli", "quil-cli"]
 

--- a/quil-rs/src/parser/mod.rs
+++ b/quil-rs/src/parser/mod.rs
@@ -41,14 +41,14 @@ type InternalParserResult<'a, R, E = InternalParseError<'a>> = IResult<ParserInp
 ///
 /// This also converts the first item from [`TokenWithLocation`] to [`Token`], which makes match
 /// statements more straightforward.
-pub(crate) fn split_first_token(input: ParserInput) -> Option<(&Token, ParserInput)> {
+pub(crate) fn split_first_token(input: ParserInput<'_>) -> Option<(&Token, ParserInput<'_>)> {
     input
         .split_first()
         .map(|(first, rest)| (first.as_token(), rest))
 }
 
 /// Returns the first token of the input as [`Token`] instead of [`TokenWithLocation`].
-pub(crate) fn first_token(input: ParserInput) -> Option<&Token> {
+pub(crate) fn first_token(input: ParserInput<'_>) -> Option<&Token> {
     input.first().map(TokenWithLocation::as_token)
 }
 

--- a/quil-rs/src/program/scheduling/graph.rs
+++ b/quil-rs/src/program/scheduling/graph.rs
@@ -513,7 +513,7 @@ impl<'a> ScheduledBasicBlock<'a> {
         self.instructions().is_empty()
     }
 
-    pub fn terminator(&self) -> &BasicBlockTerminator {
+    pub fn terminator(&self) -> &BasicBlockTerminator<'_> {
         self.basic_block.terminator()
     }
 

--- a/quil-rs/src/program/scheduling/graph.rs
+++ b/quil-rs/src/program/scheduling/graph.rs
@@ -513,7 +513,7 @@ impl<'a> ScheduledBasicBlock<'a> {
         self.instructions().is_empty()
     }
 
-    pub fn terminator(&self) -> &BasicBlockTerminator<'_> {
+    pub fn terminator(&self) -> &BasicBlockTerminator<'a> {
         self.basic_block.terminator()
     }
 


### PR DESCRIPTION
This commit updates `knope.toml` so that the automatically-generated release commits contain the necessary changes to `Cargo.lock`.