### PR TITLE
fix: `FENCE` "uses" frames instead of "blocking" frames

### DIFF
--- a/quil-rs/src/instruction/mod.rs
+++ b/quil-rs/src/instruction/mod.rs
@@ -614,12 +614,12 @@ impl Instruction {
                 blocked: None,
             }),
             Instruction::Fence(Fence { qubits }) => Some(FrameMatchConditions {
-                used: None,
-                blocked: Some(if qubits.is_empty() {
+                used: Some(if qubits.is_empty() {
                     FrameMatchCondition::All
                 } else {
                     FrameMatchCondition::AnyOfQubits(qubits.iter().collect())
                 }),
+                blocked: None,
             }),
             Instruction::Reset(Reset { qubit }) => {
                 let qubits = match qubit {

--- a/quil-rs/src/program/mod.rs
+++ b/quil-rs/src/program/mod.rs
@@ -1750,13 +1750,13 @@ DEFFRAME 0 1 \"2q\":
                 vec![r#"0 1 "2q""#],
                 vec![],
             ),
-            // A Fence with qubits specified uses and blocks all frames intersecting that qubit
-            (r#"FENCE 1"#, vec![], vec![r#"1 "c""#, r#"0 1 "2q""#]),
-            // Fence-all uses and blocks all frames declared in the program
+            // A Fence with qubits specified uses all frames intersecting that qubit
+            (r#"FENCE 1"#, vec![r#"1 "c""#, r#"0 1 "2q""#], vec![]),
+            // Fence-all uses all frames declared in the program
             (
                 r#"FENCE"#,
-                vec![],
                 vec![r#"0 "a""#, r#"0 "b""#, r#"1 "c""#, r#"0 1 "2q""#],
+                vec![],
             ),
             // Delay uses and blocks frames on exactly the given qubits and with any of the given names
             (r#"DELAY 0 1.0"#, vec![r#"0 "a""#, r#"0 "b""#], vec![]),

--- a/quil-rs/src/program/scheduling/graphviz_dot.rs
+++ b/quil-rs/src/program/scheduling/graphviz_dot.rs
@@ -458,6 +458,20 @@ FENCE 0
         );
 
         build_dot_format_snapshot_test_case!(
+            fence_three_frame_stagger,
+            "
+PULSE 0 \"rf\" test(duration: 1e-6)
+PULSE 1 \"rf\" test(duration: 1e-6)
+PULSE 2 \"rf\" test(duration: 1e-6)
+FENCE
+DELAY 0 100e-6
+FENCE 0 1
+FENCE 0 2
+PULSE 2 \"rf\" test(duration: 1e-6)
+"
+        );
+
+        build_dot_format_snapshot_test_case!(
             jump,
             "DECLARE ro BIT
 LABEL @first-block

--- a/quil-rs/src/program/scheduling/snapshots/quil_rs__program__scheduling__graphviz_dot__tests__graph__blocking_pulses_wrap_nonblocking.snap
+++ b/quil-rs/src/program/scheduling/snapshots/quil_rs__program__scheduling__graphviz_dot__tests__graph__blocking_pulses_wrap_nonblocking.snap
@@ -17,35 +17,23 @@ timing"];
 timing"];
     "block_0_start" -> "block_0_3" [label="ordering
 timing"];
-    "block_0_start" -> "block_0_4" [label="ordering
-timing"];
-    "block_0_start" -> "block_0_end" [label="ordering
-timing"];
     "block_0_0" [shape=rectangle, label="[0] PULSE 0 \"rf\" test(duration: 1000000)"];
     "block_0_0" -> "block_0_1" [label="ordering
 timing"];
     "block_0_0" -> "block_0_2" [label="ordering
 timing"];
-    "block_0_0" -> "block_0_end" [label="ordering
+    "block_0_0" -> "block_0_3" [label="ordering
 timing"];
     "block_0_1" [shape=rectangle, label="[1] NONBLOCKING PULSE 0 \"ro_tx\" test(duration: 1000000)"];
     "block_0_1" -> "block_0_2" [label="ordering
 timing"];
     "block_0_1" -> "block_0_3" [label="ordering
 timing"];
-    "block_0_1" -> "block_0_4" [label="ordering
-timing"];
-    "block_0_1" -> "block_0_end" [label="ordering
-timing"];
     "block_0_2" [shape=rectangle, label="[2] PULSE 0 \"rf\" test(duration: 1000000)"];
     "block_0_2" -> "block_0_3" [label="ordering
 timing"];
-    "block_0_2" -> "block_0_4" [label="ordering
-timing"];
-    "block_0_2" -> "block_0_end" [label="ordering
-timing"];
     "block_0_3" [shape=rectangle, label="[3] FENCE 0"];
-    "block_0_3" -> "block_0_end" [label="ordering
+    "block_0_3" -> "block_0_4" [label="ordering
 timing"];
     "block_0_4" [shape=rectangle, label="[4] FENCE 0"];
     "block_0_4" -> "block_0_end" [label="ordering

--- a/quil-rs/src/program/scheduling/snapshots/quil_rs__program__scheduling__graphviz_dot__tests__graph__fence_all.snap
+++ b/quil-rs/src/program/scheduling/snapshots/quil_rs__program__scheduling__graphviz_dot__tests__graph__fence_all.snap
@@ -11,8 +11,6 @@ digraph {
     "block_0_start" [shape=circle, label="start"];
     "block_0_start" -> "block_0_0" [label="ordering
 timing"];
-    "block_0_start" -> "block_0_end" [label="ordering
-timing"];
     "block_0_0" [shape=rectangle, label="[0] FENCE"];
     "block_0_0" -> "block_0_end" [label="ordering
 timing"];

--- a/quil-rs/src/program/scheduling/snapshots/quil_rs__program__scheduling__graphviz_dot__tests__graph__fence_all_with_nonblocking_pulses.snap
+++ b/quil-rs/src/program/scheduling/snapshots/quil_rs__program__scheduling__graphviz_dot__tests__graph__fence_all_with_nonblocking_pulses.snap
@@ -15,17 +15,11 @@ timing"];
 timing"];
     "block_0_start" -> "block_0_2" [label="ordering
 timing"];
-    "block_0_start" -> "block_0_end" [label="ordering
-timing"];
     "block_0_0" [shape=rectangle, label="[0] NONBLOCKING PULSE 0 \"rf\" test(duration: 1000000)"];
     "block_0_0" -> "block_0_2" [label="ordering
 timing"];
-    "block_0_0" -> "block_0_3" [label="ordering
-timing"];
     "block_0_1" [shape=rectangle, label="[1] NONBLOCKING PULSE 1 \"rf\" test(duration: 1000000)"];
     "block_0_1" -> "block_0_2" [label="ordering
-timing"];
-    "block_0_1" -> "block_0_4" [label="ordering
 timing"];
     "block_0_2" [shape=rectangle, label="[2] FENCE"];
     "block_0_2" -> "block_0_3" [label="ordering

--- a/quil-rs/src/program/scheduling/snapshots/quil_rs__program__scheduling__graphviz_dot__tests__graph__fence_one_wrapper.snap
+++ b/quil-rs/src/program/scheduling/snapshots/quil_rs__program__scheduling__graphviz_dot__tests__graph__fence_one_wrapper.snap
@@ -11,21 +11,13 @@ digraph {
     "block_0_start" [shape=circle, label="start"];
     "block_0_start" -> "block_0_0" [label="ordering
 timing"];
-    "block_0_start" -> "block_0_1" [label="ordering
-timing"];
-    "block_0_start" -> "block_0_2" [label="ordering
-timing"];
-    "block_0_start" -> "block_0_end" [label="ordering
-timing"];
     "block_0_0" [shape=rectangle, label="[0] FENCE 0"];
     "block_0_0" -> "block_0_1" [label="ordering
 timing"];
-    "block_0_0" -> "block_0_end" [label="ordering
+    "block_0_0" -> "block_0_2" [label="ordering
 timing"];
     "block_0_1" [shape=rectangle, label="[1] NONBLOCKING PULSE 0 \"rf\" flat(duration: 4e-7, iq: 1)"];
     "block_0_1" -> "block_0_2" [label="ordering
-timing"];
-    "block_0_1" -> "block_0_end" [label="ordering
 timing"];
     "block_0_2" [shape=rectangle, label="[2] FENCE 0"];
     "block_0_2" -> "block_0_end" [label="ordering

--- a/quil-rs/src/program/scheduling/snapshots/quil_rs__program__scheduling__graphviz_dot__tests__graph__fence_three_frame_stagger.snap
+++ b/quil-rs/src/program/scheduling/snapshots/quil_rs__program__scheduling__graphviz_dot__tests__graph__fence_three_frame_stagger.snap
@@ -1,0 +1,54 @@
+---
+source: quil-rs/src/program/scheduling/graphviz_dot.rs
+expression: dot_format
+---
+digraph {
+  entry -> "block_0_start";
+  entry [label="Entry Point"];
+  subgraph cluster_0 {
+    label="block_0";
+    node [style="filled"];
+    "block_0_start" [shape=circle, label="start"];
+    "block_0_start" -> "block_0_0" [label="ordering
+timing"];
+    "block_0_start" -> "block_0_1" [label="ordering
+timing"];
+    "block_0_start" -> "block_0_2" [label="ordering
+timing"];
+    "block_0_start" -> "block_0_3" [label="ordering
+timing"];
+    "block_0_0" [shape=rectangle, label="[0] PULSE 0 \"rf\" test(duration: 1e-6)"];
+    "block_0_0" -> "block_0_3" [label="ordering
+timing"];
+    "block_0_1" [shape=rectangle, label="[1] PULSE 1 \"rf\" test(duration: 1e-6)"];
+    "block_0_1" -> "block_0_3" [label="ordering
+timing"];
+    "block_0_2" [shape=rectangle, label="[2] PULSE 2 \"rf\" test(duration: 1e-6)"];
+    "block_0_2" -> "block_0_3" [label="ordering
+timing"];
+    "block_0_3" [shape=rectangle, label="[3] FENCE"];
+    "block_0_3" -> "block_0_4" [label="ordering
+timing"];
+    "block_0_3" -> "block_0_5" [label="ordering
+timing"];
+    "block_0_3" -> "block_0_6" [label="ordering
+timing"];
+    "block_0_4" [shape=rectangle, label="[4] DELAY 0 0.0001"];
+    "block_0_4" -> "block_0_5" [label="ordering
+timing"];
+    "block_0_5" [shape=rectangle, label="[5] FENCE 0 1"];
+    "block_0_5" -> "block_0_6" [label="ordering
+timing"];
+    "block_0_5" -> "block_0_end" [label="ordering
+timing"];
+    "block_0_6" [shape=rectangle, label="[6] FENCE 0 2"];
+    "block_0_6" -> "block_0_7" [label="ordering
+timing"];
+    "block_0_6" -> "block_0_end" [label="ordering
+timing"];
+    "block_0_7" [shape=rectangle, label="[7] PULSE 2 \"rf\" test(duration: 1e-6)"];
+    "block_0_7" -> "block_0_end" [label="ordering
+timing"];
+    "block_0_end" [shape=circle, label="end"];
+  }
+}

--- a/quil-rs/src/program/scheduling/snapshots/quil_rs__program__scheduling__graphviz_dot__tests__graph__fence_wrapper.snap
+++ b/quil-rs/src/program/scheduling/snapshots/quil_rs__program__scheduling__graphviz_dot__tests__graph__fence_wrapper.snap
@@ -11,12 +11,6 @@ digraph {
     "block_0_start" [shape=circle, label="start"];
     "block_0_start" -> "block_0_0" [label="ordering
 timing"];
-    "block_0_start" -> "block_0_1" [label="ordering
-timing"];
-    "block_0_start" -> "block_0_2" [label="ordering
-timing"];
-    "block_0_start" -> "block_0_end" [label="ordering
-timing"];
     "block_0_0" [shape=rectangle, label="[0] FENCE"];
     "block_0_0" -> "block_0_1" [label="ordering
 timing"];
@@ -27,12 +21,8 @@ timing"];
     "block_0_1" [shape=rectangle, label="[1] NONBLOCKING PULSE 0 1 \"cz\" test(duration: 1e-6)"];
     "block_0_1" -> "block_0_3" [label="ordering
 timing"];
-    "block_0_1" -> "block_0_end" [label="ordering
-timing"];
     "block_0_2" [shape=rectangle, label="[2] NONBLOCKING PULSE 1 \"rf\" test(duration: 1e-6)"];
     "block_0_2" -> "block_0_3" [label="ordering
-timing"];
-    "block_0_2" -> "block_0_end" [label="ordering
 timing"];
     "block_0_3" [shape=rectangle, label="[3] FENCE 1"];
     "block_0_3" -> "block_0_end" [label="ordering


### PR DESCRIPTION
Changes scheduling behavior of `FENCE`s to be non-concurrent, i.e., serial.

Closes #510