### PR TITLE
`py.typed` file and pyproject authors fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,9 +36,9 @@ jobs:
         git config --global user.email "${{ github.triggering_actor}}@users.noreply.github.com"
 
     - name: Install Knope
-      uses: knope-dev/action@v2.1.0
+      uses: knope-dev/action@v2.1.2
       with:
-        version: 0.21.3 # Test before updating, breaking changes likely: https://github.com/knope-dev/action#install-latest-version
+        version: 0.23.0 # Test before updating, breaking changes likely: https://github.com/knope-dev/action#install-latest-version
 
     - name: Dry-run Release
       run: knope release --verbose --dry-run

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1405,7 +1405,7 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quil-cli"
-version = "0.14.1-rc.1"
+version = "0.14.1-rc.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -1414,7 +1414,7 @@ dependencies = [
 
 [[package]]
 name = "quil-rs"
-version = "0.37.1-rc.1"
+version = "0.37.1-rc.2"
 dependencies = [
  "anyhow",
  "approx",

--- a/quil-cli/CHANGELOG.md
+++ b/quil-cli/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 0.14.1-rc.2 (2026-08-14)
+
+### Features
+
+- add `RaisedCosine` builtin waveform (#517)
+
+### Fixes
+
+- parse raised cosine waveform (#519)
+- add py.typed so downstream packages can use it
+
 ## 0.14.1-rc.1 (2026-08-07)
 
 ### Features

--- a/quil-cli/Cargo.toml
+++ b/quil-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quil-cli"
-version = "0.14.1-rc.1"
+version = "0.14.1-rc.2"
 edition = "2021"
 license = "Apache-2.0"
 
@@ -10,4 +10,4 @@ license = "Apache-2.0"
 anyhow = "1.0.81"
 clap = { workspace = true, features = ["derive"]}
 # This is managed by knope to keep the dependency on quil-rs up-to-date.
-quil-rs = { path = "../quil-rs", version = "0.37.1-rc.1" }
+quil-rs = { path = "../quil-rs", version = "0.37.1-rc.2" }

--- a/quil-rs/CHANGELOG.md
+++ b/quil-rs/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 0.37.1-rc.2 (2026-08-14)
+
+### Features
+
+- add `RaisedCosine` builtin waveform (#517)
+
+### Fixes
+
+- parse raised cosine waveform (#519)
+- add py.typed so downstream packages can use it
+
 ## 0.37.1-rc.1 (2026-08-07)
 
 ### Features

--- a/quil-rs/Cargo.toml
+++ b/quil-rs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "quil-rs"
 description = "Rust tooling for Quil (Quantum Instruction Language)"
-version = "0.37.1-rc.1"
+version = "0.37.1-rc.2"
 edition = "2021"
 rust-version = "1.93"
 license = "Apache-2.0"

--- a/quil-rs/pyproject.toml
+++ b/quil-rs/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "quil"
-version = "0.37.1-rc.1"
+version = "0.37.1-rc.2"
 requires-python = ">=3.10,<4"
 description = "A Python package for building and parsing Quil programs."
 documentation = "https://rigetti.github.io/quil-rs/quil.html"

--- a/quil-rs/pyproject.toml
+++ b/quil-rs/pyproject.toml
@@ -6,7 +6,7 @@ description = "A Python package for building and parsing Quil programs."
 documentation = "https://rigetti.github.io/quil-rs/quil.html"
 readme = "README-py.md"
 license = { text = "Apache-2.0" }
-authors = [{ name = "Rigetti Computing", email = "softapps@rigetti.com" }]
+authors = [{ name = "Rigetti QPU Software", email = "qpu-software@rigetti.com" }]
 classifiers = [
   "Development Status :: 3 - Alpha",
   "License :: OSI Approved :: Apache Software License",


### PR DESCRIPTION
* adds `py.typed` file so that downstream projects don't get an `[import-untyped]` error
* fixes the `authors` list so that it mentions the QCS team specifically and uses our email address (consistent with other projects)